### PR TITLE
Support texted control commands (/clear, /new, /stop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ Sessions are keyed by Inkbox contact, so one person = one conversation across ch
 
 **Interrupt by texting again.** Messaging the agent again while it's mid-turn works like pressing Esc in Claude Code and typing a new message: the running turn is interrupted, its partial answer is dropped, and Claude picks up your new message instead. (A reply while it's waiting on a permission/poll still answers that escalation — interrupting only applies while it's actively working.)
 
+**Control commands.** A handful of slash-commands steer the conversation itself and are handled by the bridge instead of being sent to Claude (works on any channel):
+
+- `/clear` (or `/new`) — start a fresh conversation: forgets the resumed session, tears down the client, and clears session-scoped permission grants.
+- `/stop` — interrupt the current turn and drop anything queued, keeping your conversation context intact.
+
+These match only when the whole message is exactly the command, so "please /clear the cache" is still a normal turn.
+
 **Errors.** If a turn fails, you get a short plain-language heads-up ("I hit an error while working on that and had to stop") rather than silence.
 
 ## Voice

--- a/inkbox_claude/sessions.py
+++ b/inkbox_claude/sessions.py
@@ -66,6 +66,29 @@ TypingFn = Callable[[str, str, Dict[str, Any]], Awaitable[Any]]
 # indicator on this cadence for as long as a turn is running.
 TYPING_REFRESH_SECONDS = 4.0
 
+# Leading slash-commands the human can text to steer the conversation itself.
+# The bridge acts on these locally — they never reach Claude as a turn.
+RESET_COMMANDS = frozenset({"/clear", "/new"})  # start a fresh conversation
+STOP_COMMANDS = frozenset({"/stop"})            # abort whatever's in flight
+
+
+def _control_command(text: str) -> Optional[str]:
+    """Classify a message as a bridge control command, if it is one.
+
+    Args:
+        text (str): The raw inbound message text.
+
+    Returns:
+        Optional[str]: "reset" or "stop" when the whole message is exactly
+            that command, otherwise None (so it's forwarded to Claude).
+    """
+    token = text.strip().lower()
+    if token in RESET_COMMANDS:
+        return "reset"
+    if token in STOP_COMMANDS:
+        return "stop"
+    return None
+
 
 def _state_path() -> Path:
     root = Path(os.getenv("INKBOX_CLAUDE_HOME") or Path.home() / ".inkbox-claude")
@@ -86,6 +109,7 @@ class ContactSession:
         identity_info: Dict[str, str],
         resume_session_id: Optional[str] = None,
         on_session_id: Optional[Callable[[str, str], None]] = None,
+        on_clear: Optional[Callable[[str], None]] = None,
         typing_fn: Optional[TypingFn] = None,
     ):
         self.chat_id = chat_id
@@ -97,6 +121,7 @@ class ContactSession:
         self.identity_info = identity_info
         self.resume_session_id = resume_session_id
         self.on_session_id = on_session_id
+        self.on_clear = on_clear
 
         self.mode = "email"  # last inbound modality; selects the reply channel
         self.reply_meta: Dict[str, Any] = {}
@@ -126,6 +151,16 @@ class ContactSession:
         """
         self.mode = mode
         self.reply_meta = dict(meta or {})
+
+        # Bridge control commands (/clear, /new, /stop) steer the conversation
+        # itself — handle them here instead of forwarding them to Claude.
+        command = _control_command(text)
+        if command == "reset":
+            await self._reset_session()
+            return
+        if command == "stop":
+            await self._stop_turn()
+            return
 
         # A reply while an escalation is outstanding answers the escalation —
         # it does not start a new agent turn.
@@ -171,6 +206,66 @@ class ContactSession:
                     )
                 except Exception:
                     logger.exception("[session %s] could not send the error notice", self.chat_id)
+
+    # ------------------------------------------------------------------
+    # Control commands (/clear, /new, /stop)
+    # ------------------------------------------------------------------
+
+    async def _reset_session(self) -> None:
+        """Start a fresh conversation: drop the resumed Claude session id and
+        tear down the client so the next turn opens a brand-new session.
+
+        Returns:
+            None
+        """
+        await self._abort_in_flight()
+        # Forget the resumed conversation everywhere — in memory, the live
+        # client, the persisted map, and any session-scoped tool grants.
+        self.resume_session_id = None
+        await self.close()
+        if self.on_clear is not None:
+            self.on_clear(self.chat_id)
+        self.always_allowed.clear()
+        await self._reply("Started a fresh conversation — previous context cleared.")
+
+    async def _stop_turn(self) -> None:
+        """Interrupt the running turn (if any) and drop anything queued,
+        keeping the conversation context intact.
+
+        Returns:
+            None
+        """
+        had_work = (
+            self._turn_active or self.pending is not None or not self._queue.empty()
+        )
+        await self._abort_in_flight()
+        await self._reply("Stopped." if had_work else "Nothing to stop — I'm idle.")
+
+    async def _abort_in_flight(self) -> None:
+        """Cancel whatever the session is currently doing: a parked
+        escalation, a running turn, and any queued-but-unstarted messages.
+
+        Returns:
+            None
+        """
+        # Unblock a parked permission/poll so its turn can unwind (None reads
+        # as "no answer" — the same as a timeout).
+        if self.pending is not None and not self.pending.future.done():
+            self.pending.future.set_result(None)
+            self.pending = None
+        # Interrupt a turn that's actively running, like pressing Esc.
+        if self._turn_active and self._client is not None:
+            self._interrupting = True
+            try:
+                await self._client.interrupt()
+            except Exception:
+                logger.debug("[session %s] interrupt failed", self.chat_id, exc_info=True)
+        # Discard messages queued but not yet started.
+        while not self._queue.empty():
+            try:
+                self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
 
     # ------------------------------------------------------------------
     # Claude Code turn
@@ -394,8 +489,7 @@ class SessionManager:
         except Exception:
             return {}
 
-    def _save_session_id(self, chat_id: str, session_id: str) -> None:
-        self._session_ids[chat_id] = session_id
+    def _persist(self) -> None:
         try:
             path = _state_path()
             tmp = path.with_suffix(".tmp")
@@ -403,6 +497,15 @@ class SessionManager:
             os.replace(tmp, path)
         except Exception:
             logger.exception("failed to persist session state")
+
+    def _save_session_id(self, chat_id: str, session_id: str) -> None:
+        self._session_ids[chat_id] = session_id
+        self._persist()
+
+    def _clear_state(self, chat_id: str) -> None:
+        """Forget a contact's persisted Claude session id (for /clear, /new)."""
+        if self._session_ids.pop(chat_id, None) is not None:
+            self._persist()
 
     def get(self, chat_id: str) -> ContactSession:
         """Fetch or lazily create the session for one remote party.
@@ -424,6 +527,7 @@ class SessionManager:
                 identity_info=self.identity_info,
                 resume_session_id=self._session_ids.get(chat_id),
                 on_session_id=self._save_session_id,
+                on_clear=self._clear_state,
                 typing_fn=self.typing_fn,
             )
             self.sessions[chat_id] = session

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -96,6 +96,97 @@ def test_typing_loop_skips_non_imessage():
     asyncio.run(scenario())
 
 
+def test_clear_command_starts_fresh_session():
+    async def scenario():
+        sent = []
+        cleared = []
+        session = make_session(sent)
+        session.on_clear = lambda chat_id: cleared.append(chat_id)
+        session.mode = "imessage"
+
+        class FakeClient:
+            def __init__(self):
+                self.disconnects = 0
+
+            async def disconnect(self):
+                self.disconnects += 1
+
+        fake = FakeClient()
+        session._client = fake
+        session.resume_session_id = "old-session"
+        session.always_allowed.add("Bash")
+
+        await session.handle_inbound("/clear", "imessage", {"conversation_id": "c1"})
+
+        # Resume id forgotten, client torn down, persisted state cleared.
+        assert session.resume_session_id is None
+        assert session._client is None
+        assert fake.disconnects == 1
+        assert cleared == ["contact-1"]
+        assert session.always_allowed == set()
+        # The command is confirmed and never queued as a Claude turn.
+        assert session._queue.empty()
+        assert "fresh conversation" in sent[-1][1].lower()
+
+    asyncio.run(scenario())
+
+
+def test_stop_command_interrupts_turn_without_clearing():
+    async def scenario():
+        sent = []
+        session = make_session(sent)
+
+        class FakeClient:
+            def __init__(self):
+                self.interrupts = 0
+
+            async def interrupt(self):
+                self.interrupts += 1
+
+        fake = FakeClient()
+        session._client = fake
+        session._turn_active = True
+        session.resume_session_id = "keep-me"
+        session._worker = asyncio.create_task(asyncio.sleep(10))
+
+        await session.handle_inbound("/stop", "imessage", {"conversation_id": "c1"})
+
+        assert fake.interrupts == 1
+        assert session._interrupting is True
+        # Context is preserved — /stop only halts the current work.
+        assert session.resume_session_id == "keep-me"
+        assert session._queue.empty()
+        assert sent[-1][1] == "Stopped."
+
+        session._worker.cancel()
+
+    asyncio.run(scenario())
+
+
+def test_stop_command_when_idle():
+    async def scenario():
+        sent = []
+        session = make_session(sent)
+        await session.handle_inbound("/stop", "sms", {"conversation_id": "c1"})
+        assert sent[-1][1] == "Nothing to stop — I'm idle."
+        assert session._queue.empty()
+
+    asyncio.run(scenario())
+
+
+def test_non_command_is_forwarded_as_a_turn():
+    async def scenario():
+        sent = []
+        session = make_session(sent)
+        # A message that merely mentions a slash word is a normal turn.
+        await session.handle_inbound("please /clear the cache", "sms", {})
+        assert not session._queue.empty()
+        assert session._queue.get_nowait().endswith("please /clear the cache")
+        session._worker.cancel()
+
+    asyncio.run(scenario())
+
+
 def test_double_text_interrupts_running_turn():
     async def scenario():
         session = make_session([])


### PR DESCRIPTION
Recognizes a small set of leading slash-commands in `handle_inbound` and acts on them in the bridge instead of forwarding them to Claude as a turn:

- `/clear` (or `/new`) — starts a fresh conversation: drops the resumed session id, tears down the client so the next turn opens a brand-new Claude Code session, clears the persisted session map, and resets session-scoped tool grants.
- `/stop` — interrupts the running turn and drops anything queued, while keeping the conversation context intact.

Commands match only when the whole message is exactly the command, so "please /clear the cache" is still a normal turn. Because `handle_inbound` is the shared inbound choke point, this works across every channel (email/SMS/iMessage/voice).

Adds unit tests for the reset, stop, idle-stop, and pass-through cases, and documents the commands in the README.

Closes #1