### PR TITLE
Add /resume, /status, and /usage texted commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Sessions are keyed by Inkbox contact, so one person = one conversation across ch
 
 - `/clear` (or `/new`) — start a fresh conversation: forgets the resumed session, tears down the client, and clears session-scoped permission grants.
 - `/stop` — interrupt the current turn and drop anything queued, keeping your conversation context intact.
+- `/resume` — texts you back a numbered list of recent conversations for the project (each with a short summary and timestamp); reply with a number to reopen that one. Like `/resume` in the Claude Code CLI.
 
 These match only when the whole message is exactly the command, so "please /clear the cache" is still a normal turn.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Sessions are keyed by Inkbox contact, so one person = one conversation across ch
 - `/stop` — interrupt the current turn and drop anything queued, keeping your conversation context intact.
 - `/resume` — texts you back a numbered list of recent conversations for the project (each with a short summary and timestamp); reply with a number to reopen that one. Like `/resume` in the Claude Code CLI.
 - `/status` — reports what the bridge is doing for you right now (working, waiting on a reply, or idle) and whether you're in a fresh or ongoing conversation. Read-only; doesn't disturb a running turn.
-- `/usage` — reports this conversation's cumulative Claude usage (turns, input/output tokens, and approximate cost).
+- `/usage` — reports your Claude subscription usage, mirroring the Claude Code `/usage` command: the rolling 5-hour session window and the weekly windows, each with percent used and when it resets.
 
 These match only when the whole message is exactly the command, so "please /clear the cache" is still a normal turn.
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Sessions are keyed by Inkbox contact, so one person = one conversation across ch
 - `/clear` (or `/new`) — start a fresh conversation: forgets the resumed session, tears down the client, and clears session-scoped permission grants.
 - `/stop` — interrupt the current turn and drop anything queued, keeping your conversation context intact.
 - `/resume` — texts you back a numbered list of recent conversations for the project (each with a short summary and timestamp); reply with a number to reopen that one. Like `/resume` in the Claude Code CLI.
+- `/status` — reports what the bridge is doing for you right now (working, waiting on a reply, or idle) and whether you're in a fresh or ongoing conversation. Read-only; doesn't disturb a running turn.
+- `/usage` — reports this conversation's cumulative Claude usage (turns, input/output tokens, and approximate cost).
 
 These match only when the whole message is exactly the command, so "please /clear the cache" is still a normal turn.
 

--- a/inkbox_claude/claude_usage.py
+++ b/inkbox_claude/claude_usage.py
@@ -8,7 +8,7 @@ then format the blocks for a text reply.
 
 The response shape (matching the CLI) is::
 
-    {"five_hour":  {"utilization": 0.0-1.0, "resets_at": <iso|epoch>},
+    {"five_hour":  {"utilization": 0-100, "resets_at": <iso|epoch>},
      "seven_day":  {...},
      "seven_day_opus": {...}}
 """
@@ -129,7 +129,8 @@ def format_usage(data: dict, *, now: Optional[datetime] = None) -> str:
         block = data.get(key)
         if not isinstance(block, dict) or block.get("utilization") is None:
             continue
-        pct = round(float(block["utilization"]) * 100)
+        # utilization is already a percentage (0-100), not a 0-1 fraction.
+        pct = round(float(block["utilization"]))
         reset = _fmt_reset(block.get("resets_at"), now=now)
         lines.append(f"{label}: {pct}% used" + (f", resets {reset}" if reset else ""))
     return "\n".join(lines) if lines else "No usage windows reported."

--- a/inkbox_claude/claude_usage.py
+++ b/inkbox_claude/claude_usage.py
@@ -1,0 +1,160 @@
+"""Fetch Claude subscription usage — mirrors the Claude Code ``/usage`` command.
+
+Claude Code's ``/usage`` reports rate-limit utilization against the rolling
+5-hour session window and the weekly windows. It gets this from the OAuth
+endpoint ``/api/oauth/usage`` using the subscription login. We do the same:
+read the token from Claude Code's own credential store and call that endpoint,
+then format the blocks for a text reply.
+
+The response shape (matching the CLI) is::
+
+    {"five_hour":  {"utilization": 0.0-1.0, "resets_at": <iso|epoch>},
+     "seven_day":  {...},
+     "seven_day_opus": {...}}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+# Claude Code calls GET /api/oauth/usage; try the API host first, then claude.ai.
+USAGE_URLS = (
+    "https://api.anthropic.com/api/oauth/usage",
+    "https://claude.ai/api/oauth/usage",
+)
+_OAUTH_BETA = "oauth-2025-04-20"
+# Friendly labels for each window the endpoint reports.
+_BLOCKS = (
+    ("five_hour", "5-hour session"),
+    ("seven_day", "This week (all models)"),
+    ("seven_day_opus", "This week (Opus)"),
+)
+
+
+def _read_oauth_token() -> Optional[str]:
+    """Read the subscription OAuth access token from Claude Code's creds.
+
+    Returns:
+        Optional[str]: The access token, or None if not logged in via subscription.
+    """
+    path = Path(os.getenv("CLAUDE_CONFIG_DIR") or (Path.home() / ".claude")) / ".credentials.json"
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return ((data.get("claudeAiOauth") or {}).get("accessToken")) or None
+
+
+def fetch_usage() -> dict:
+    """Call the usage endpoint and return the raw JSON payload.
+
+    Returns:
+        dict: The parsed usage response.
+
+    Raises:
+        RuntimeError: "no-auth" when there's no subscription token.
+        urllib.error.HTTPError / URLError: on a failed request.
+    """
+    token = _read_oauth_token()
+    if not token:
+        raise RuntimeError("no-auth")
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "anthropic-beta": _OAUTH_BETA,
+        "User-Agent": "inkbox-claude",
+    }
+    last: Exception = RuntimeError("no endpoint")
+    for url in USAGE_URLS:
+        try:
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req, timeout=8) as resp:
+                return json.loads(resp.read().decode())
+        except urllib.error.HTTPError as exc:
+            # Auth failures are terminal (same answer on either host); surface them.
+            if exc.code in (401, 403):
+                raise
+            last = exc
+        except Exception as exc:  # connection error → try the next host
+            last = exc
+    raise last
+
+
+def _parse_dt(value: Any) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _fmt_reset(value: Any, *, now: Optional[datetime] = None) -> str:
+    """Render a reset timestamp as a short 'in 2h 15m' string."""
+    dt = _parse_dt(value)
+    if dt is None:
+        return ""
+    now = now or datetime.now(timezone.utc)
+    seconds = (dt - now).total_seconds()
+    if seconds <= 0:
+        return "now"
+    hours, minutes = int(seconds // 3600), int((seconds % 3600) // 60)
+    if hours >= 24:
+        return f"in {hours // 24}d {hours % 24}h"
+    if hours >= 1:
+        return f"in {hours}h {minutes}m"
+    return f"in {minutes}m"
+
+
+def format_usage(data: dict, *, now: Optional[datetime] = None) -> str:
+    """Format the usage payload like Claude Code's /usage (5h + weekly blocks).
+
+    Args:
+        data (dict): The /api/oauth/usage response.
+        now (Optional[datetime]): Reference time (for testing reset deltas).
+
+    Returns:
+        str: One line per reported window, or a fallback if none are present.
+    """
+    lines = []
+    for key, label in _BLOCKS:
+        block = data.get(key)
+        if not isinstance(block, dict) or block.get("utilization") is None:
+            continue
+        pct = round(float(block["utilization"]) * 100)
+        reset = _fmt_reset(block.get("resets_at"), now=now)
+        lines.append(f"{label}: {pct}% used" + (f", resets {reset}" if reset else ""))
+    return "\n".join(lines) if lines else "No usage windows reported."
+
+
+def usage_report() -> str:
+    """Fetch and format Claude usage, returning a text-ready summary.
+
+    Returns:
+        str: The usage report, or a friendly error message.
+    """
+    try:
+        data = fetch_usage()
+    except RuntimeError as exc:
+        if str(exc) == "no-auth":
+            return (
+                "Can't read your Claude usage — no subscription login found on this "
+                "machine. (If you're on an API key instead of a Claude plan, there's "
+                "no /usage to show.)"
+            )
+        return f"Couldn't fetch Claude usage: {exc}"
+    except urllib.error.HTTPError as exc:
+        if exc.code in (401, 403):
+            return "Couldn't fetch Claude usage — the login looks expired. Run claude once to refresh it, then try again."
+        return f"Couldn't fetch Claude usage (HTTP {exc.code})."
+    except Exception as exc:
+        return f"Couldn't fetch Claude usage: {exc}"
+    return "Claude usage:\n" + format_usage(data)

--- a/inkbox_claude/sessions.py
+++ b/inkbox_claude/sessions.py
@@ -14,6 +14,8 @@ import asyncio
 import json
 import logging
 import os
+import re
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, Optional
 
@@ -70,6 +72,10 @@ TYPING_REFRESH_SECONDS = 4.0
 # The bridge acts on these locally — they never reach Claude as a turn.
 RESET_COMMANDS = frozenset({"/clear", "/new"})  # start a fresh conversation
 STOP_COMMANDS = frozenset({"/stop"})            # abort whatever's in flight
+RESUME_COMMANDS = frozenset({"/resume"})        # pick a past session to reopen
+
+# How many recent sessions to offer when the human texts /resume.
+RESUME_LIST_LIMIT = 5
 
 
 def _control_command(text: str) -> Optional[str]:
@@ -79,15 +85,136 @@ def _control_command(text: str) -> Optional[str]:
         text (str): The raw inbound message text.
 
     Returns:
-        Optional[str]: "reset" or "stop" when the whole message is exactly
-            that command, otherwise None (so it's forwarded to Claude).
+        Optional[str]: "reset", "stop", or "resume" when the whole message is
+            exactly that command, otherwise None (so it's forwarded to Claude).
     """
     token = text.strip().lower()
     if token in RESET_COMMANDS:
         return "reset"
     if token in STOP_COMMANDS:
         return "stop"
+    if token in RESUME_COMMANDS:
+        return "resume"
     return None
+
+
+def _transcript_dir(project_dir: Optional[str]) -> Optional[Path]:
+    """Locate Claude Code's transcript folder for a project.
+
+    Claude Code stores one JSONL transcript per session under
+    ``<config>/projects/<slugified project path>``.
+
+    Args:
+        project_dir (Optional[str]): Project working directory.
+
+    Returns:
+        Optional[Path]: The transcript directory, or None without a project.
+    """
+    if not project_dir:
+        return None
+    base = Path(os.getenv("CLAUDE_CONFIG_DIR") or (Path.home() / ".claude"))
+    # The slug is the absolute path with every separator turned into a dash.
+    slug = str(Path(project_dir).resolve()).replace("/", "-")
+    return base / "projects" / slug
+
+
+def _clean_summary(text: str) -> str:
+    # Drop the leading channel tag the bridge prepends ("[iMessage from ...]").
+    text = text.strip()
+    if text.startswith("["):
+        end = text.find("]")
+        if end != -1:
+            text = text[end + 1:].strip()
+    # Collapse whitespace and keep it short enough for a text message.
+    return " ".join(text.split())[:80]
+
+
+def _session_digest(path: Path) -> Optional[Dict[str, Any]]:
+    """Summarize one transcript file into {id, summary, mtime}.
+
+    Args:
+        path (Path): Path to a ``<session id>.jsonl`` transcript.
+
+    Returns:
+        Optional[Dict[str, Any]]: Digest, or None if the file can't be read.
+    """
+    summary = ""
+    try:
+        with path.open() as fh:
+            for raw in fh:
+                try:
+                    entry = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                # Prefer an explicit compaction summary when one exists.
+                if entry.get("type") == "summary" and entry.get("summary"):
+                    summary = str(entry["summary"])
+                    break
+                # Otherwise fall back to the first real user message.
+                if entry.get("type") == "user":
+                    content = (entry.get("message") or {}).get("content")
+                    if isinstance(content, list):
+                        content = " ".join(
+                            b.get("text", "") for b in content
+                            if isinstance(b, dict) and b.get("type") == "text"
+                        )
+                    text = _clean_summary(str(content or ""))
+                    # Skip injected system reminders and other tool noise.
+                    if text and not text.startswith("<"):
+                        summary = text
+                        break
+    except OSError:
+        return None
+    return {"id": path.stem, "summary": summary or "(no summary)", "mtime": path.stat().st_mtime}
+
+
+def list_recent_sessions(
+    project_dir: Optional[str],
+    limit: int = RESUME_LIST_LIMIT,
+    exclude_id: Optional[str] = None,
+) -> list[Dict[str, Any]]:
+    """List a project's most recent Claude Code sessions, newest first.
+
+    Args:
+        project_dir (Optional[str]): Project working directory.
+        limit (int): Max sessions to return.
+        exclude_id (Optional[str]): Session id to omit (e.g. the live one).
+
+    Returns:
+        list[Dict[str, Any]]: Digests {id, summary, mtime}, newest first.
+    """
+    tdir = _transcript_dir(project_dir)
+    if tdir is None or not tdir.is_dir():
+        return []
+    files = sorted(tdir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True)
+    out: list[Dict[str, Any]] = []
+    for path in files:
+        if path.stem == exclude_id:
+            continue
+        digest = _session_digest(path)
+        if digest is not None:
+            out.append(digest)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _format_resume_list(sessions: list[Dict[str, Any]]) -> str:
+    # A numbered, one-line-each menu sized for a text message.
+    lines = ["Recent conversations — reply with a number to resume:"]
+    for i, s in enumerate(sessions, 1):
+        when = datetime.fromtimestamp(s["mtime"]).strftime("%b %d %H:%M")
+        lines.append(f"{i}. ({when}) {s['summary']}")
+    return "\n".join(lines)
+
+
+def _parse_index(reply: str, count: int) -> Optional[int]:
+    # Pull the first integer out of the reply ("2", "#2", "option 2").
+    match = re.search(r"\d+", reply or "")
+    if not match:
+        return None
+    choice = int(match.group())
+    return choice - 1 if 1 <= choice <= count else None
 
 
 def _state_path() -> Path:
@@ -131,6 +258,7 @@ class ContactSession:
         self._client: Optional[ClaudeSDKClient] = None
         self._queue: asyncio.Queue[str] = asyncio.Queue()
         self._worker: Optional[asyncio.Task] = None
+        self._resume_task: Optional[asyncio.Task] = None  # /resume pick in flight
         self._turn_active = False     # a Claude turn is mid-flight
         self._interrupting = False    # a new message asked us to abort it
 
@@ -160,6 +288,9 @@ class ContactSession:
             return
         if command == "stop":
             await self._stop_turn()
+            return
+        if command == "resume":
+            await self._begin_resume()
             return
 
         # A reply while an escalation is outstanding answers the escalation —
@@ -266,6 +397,48 @@ class ContactSession:
                 self._queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
+
+    async def _begin_resume(self) -> None:
+        """List recent sessions and let the human pick one to reopen.
+
+        Returns:
+            None
+        """
+        sessions = list_recent_sessions(
+            self.cfg.project_dir, exclude_id=self.resume_session_id
+        )
+        if not sessions:
+            await self._reply("No other recent conversations to resume.")
+            return
+        # Run the numbered pick in the background so the inbound webhook can
+        # return promptly while we wait (up to the escalation timeout) for the
+        # human's choice. Keep a reference so the task isn't GC'd.
+        self._resume_task = asyncio.create_task(self._run_resume_pick(sessions))
+
+    async def _run_resume_pick(self, sessions: list[Dict[str, Any]]) -> None:
+        try:
+            reply = await self._escalate("resume", _format_resume_list(sessions))
+            if reply is None:
+                await self._reply("No pick — staying in the current conversation.")
+                return
+            index = _parse_index(reply, len(sessions))
+            if index is None:
+                await self._reply(
+                    f"Didn't catch a number from 1-{len(sessions)} — staying put. "
+                    "Send /resume to try again."
+                )
+                return
+            chosen = sessions[index]
+            # Swap in the chosen session and tear down the client so the next
+            # turn continues it; persist it so it survives bridge restarts.
+            await self.close()
+            self.resume_session_id = chosen["id"]
+            if self.on_session_id is not None:
+                self.on_session_id(self.chat_id, chosen["id"])
+            self.always_allowed.clear()
+            await self._reply(f"Resumed: {chosen['summary']}")
+        except Exception:
+            logger.exception("[session %s] resume pick failed", self.chat_id)
 
     # ------------------------------------------------------------------
     # Claude Code turn

--- a/inkbox_claude/sessions.py
+++ b/inkbox_claude/sessions.py
@@ -267,11 +267,6 @@ class ContactSession:
         self._resume_task: Optional[asyncio.Task] = None  # /resume pick in flight
         self._turn_active = False     # a Claude turn is mid-flight
         self._interrupting = False    # a new message asked us to abort it
-        # Running usage totals for this conversation, surfaced by /usage.
-        self._usage_turns = 0
-        self._usage_input = 0
-        self._usage_output = 0
-        self._usage_cost = 0.0
 
     # ------------------------------------------------------------------
     # Inbound routing
@@ -479,38 +474,18 @@ class ContactSession:
         convo = "an ongoing conversation" if self.resume_session_id else "a fresh conversation"
         await self._reply(f"{state} We're in {convo}.")
 
-    def _accumulate_usage(self, message: "ResultMessage") -> None:
-        """Fold one finished turn's token/cost usage into the running totals.
-
-        Args:
-            message (ResultMessage): The turn's terminal result message.
-
-        Returns:
-            None
-        """
-        self._usage_turns += 1
-        if message.total_cost_usd:
-            self._usage_cost += float(message.total_cost_usd)
-        usage = message.usage or {}
-        self._usage_input += int(usage.get("input_tokens") or 0)
-        self._usage_output += int(usage.get("output_tokens") or 0)
-
     async def _report_usage(self) -> None:
-        """Text back this conversation's cumulative Claude usage.
+        """Text back Claude subscription usage, mirroring Claude Code's /usage.
 
         Returns:
             None
         """
-        if self._usage_turns == 0:
-            await self._reply("No usage yet this conversation — I haven't run anything.")
-            return
-        parts = [
-            f"{self._usage_turns} turn{'s' if self._usage_turns != 1 else ''}",
-            f"{self._usage_input:,} in / {self._usage_output:,} out tokens",
-        ]
-        if self._usage_cost:
-            parts.append(f"about ${self._usage_cost:.2f}")
-        await self._reply("This conversation so far: " + ", ".join(parts) + ".")
+        try:
+            from .claude_usage import usage_report
+        except ImportError:  # pragma: no cover - direct local import/test fallback
+            from claude_usage import usage_report
+        # The fetch is a blocking HTTP call — keep it off the event loop.
+        await self._reply(await asyncio.to_thread(usage_report))
 
     # ------------------------------------------------------------------
     # Claude Code turn
@@ -536,7 +511,6 @@ class ContactSession:
                             chunks.append(block.text)
                 elif isinstance(message, ResultMessage):
                     final = message.result
-                    self._accumulate_usage(message)
                     if message.session_id and self.on_session_id:
                         self.resume_session_id = message.session_id
                         self.on_session_id(self.chat_id, message.session_id)

--- a/inkbox_claude/sessions.py
+++ b/inkbox_claude/sessions.py
@@ -73,6 +73,8 @@ TYPING_REFRESH_SECONDS = 4.0
 RESET_COMMANDS = frozenset({"/clear", "/new"})  # start a fresh conversation
 STOP_COMMANDS = frozenset({"/stop"})            # abort whatever's in flight
 RESUME_COMMANDS = frozenset({"/resume"})        # pick a past session to reopen
+STATUS_COMMANDS = frozenset({"/status"})        # report what the bridge is doing
+USAGE_COMMANDS = frozenset({"/usage"})          # report Claude usage this convo
 
 # How many recent sessions to offer when the human texts /resume.
 RESUME_LIST_LIMIT = 5
@@ -85,8 +87,8 @@ def _control_command(text: str) -> Optional[str]:
         text (str): The raw inbound message text.
 
     Returns:
-        Optional[str]: "reset", "stop", or "resume" when the whole message is
-            exactly that command, otherwise None (so it's forwarded to Claude).
+        Optional[str]: "reset", "stop", "resume", "status", or "usage" when the
+            whole message is exactly that command, else None (forwarded to Claude).
     """
     token = text.strip().lower()
     if token in RESET_COMMANDS:
@@ -95,6 +97,10 @@ def _control_command(text: str) -> Optional[str]:
         return "stop"
     if token in RESUME_COMMANDS:
         return "resume"
+    if token in STATUS_COMMANDS:
+        return "status"
+    if token in USAGE_COMMANDS:
+        return "usage"
     return None
 
 
@@ -261,6 +267,11 @@ class ContactSession:
         self._resume_task: Optional[asyncio.Task] = None  # /resume pick in flight
         self._turn_active = False     # a Claude turn is mid-flight
         self._interrupting = False    # a new message asked us to abort it
+        # Running usage totals for this conversation, surfaced by /usage.
+        self._usage_turns = 0
+        self._usage_input = 0
+        self._usage_output = 0
+        self._usage_cost = 0.0
 
     # ------------------------------------------------------------------
     # Inbound routing
@@ -291,6 +302,13 @@ class ContactSession:
             return
         if command == "resume":
             await self._begin_resume()
+            return
+        # /status and /usage just report back — they don't disturb a running turn.
+        if command == "status":
+            await self._report_status()
+            return
+        if command == "usage":
+            await self._report_usage()
             return
 
         # A reply while an escalation is outstanding answers the escalation —
@@ -441,6 +459,60 @@ class ContactSession:
             logger.exception("[session %s] resume pick failed", self.chat_id)
 
     # ------------------------------------------------------------------
+    # Status / usage reports (/status, /usage)
+    # ------------------------------------------------------------------
+
+    async def _report_status(self) -> None:
+        """Text back what the bridge is doing for this contact right now.
+
+        Returns:
+            None
+        """
+        if self._turn_active:
+            state = "I'm working on your last message right now."
+        elif self.pending is not None and not self.pending.future.done():
+            state = f"I'm waiting on your reply to a {self.pending.kind}."
+        elif not self._queue.empty():
+            state = "I'm about to start on your message."
+        else:
+            state = "I'm idle and ready for your next message."
+        convo = "an ongoing conversation" if self.resume_session_id else "a fresh conversation"
+        await self._reply(f"{state} We're in {convo}.")
+
+    def _accumulate_usage(self, message: "ResultMessage") -> None:
+        """Fold one finished turn's token/cost usage into the running totals.
+
+        Args:
+            message (ResultMessage): The turn's terminal result message.
+
+        Returns:
+            None
+        """
+        self._usage_turns += 1
+        if message.total_cost_usd:
+            self._usage_cost += float(message.total_cost_usd)
+        usage = message.usage or {}
+        self._usage_input += int(usage.get("input_tokens") or 0)
+        self._usage_output += int(usage.get("output_tokens") or 0)
+
+    async def _report_usage(self) -> None:
+        """Text back this conversation's cumulative Claude usage.
+
+        Returns:
+            None
+        """
+        if self._usage_turns == 0:
+            await self._reply("No usage yet this conversation — I haven't run anything.")
+            return
+        parts = [
+            f"{self._usage_turns} turn{'s' if self._usage_turns != 1 else ''}",
+            f"{self._usage_input:,} in / {self._usage_output:,} out tokens",
+        ]
+        if self._usage_cost:
+            parts.append(f"about ${self._usage_cost:.2f}")
+        await self._reply("This conversation so far: " + ", ".join(parts) + ".")
+
+    # ------------------------------------------------------------------
     # Claude Code turn
     # ------------------------------------------------------------------
 
@@ -464,6 +536,7 @@ class ContactSession:
                             chunks.append(block.text)
                 elif isinstance(message, ResultMessage):
                     final = message.result
+                    self._accumulate_usage(message)
                     if message.session_id and self.on_session_id:
                         self.resume_session_id = message.session_id
                         self.on_session_id(self.chat_id, message.session_id)

--- a/tests/test_claude_usage.py
+++ b/tests/test_claude_usage.py
@@ -5,10 +5,11 @@ from inkbox_claude import claude_usage
 
 def test_format_usage_matches_claude_code_shape():
     now = datetime(2026, 6, 16, 12, 0, tzinfo=timezone.utc)
+    # utilization is a 0-100 percentage, as the live endpoint returns it.
     data = {
-        "five_hour": {"utilization": 0.42, "resets_at": "2026-06-16T14:30:00Z"},
-        "seven_day": {"utilization": 0.10, "resets_at": "2026-06-19T12:00:00Z"},
-        "seven_day_opus": {"utilization": 0.0, "resets_at": "2026-06-19T12:00:00Z"},
+        "five_hour": {"utilization": 42, "resets_at": "2026-06-16T14:30:00Z"},
+        "seven_day": {"utilization": 10, "resets_at": "2026-06-19T12:00:00Z"},
+        "seven_day_opus": {"utilization": 0, "resets_at": "2026-06-19T12:00:00Z"},
     }
     out = claude_usage.format_usage(data, now=now)
     assert "5-hour session: 42% used, resets in 2h 30m" in out
@@ -17,7 +18,7 @@ def test_format_usage_matches_claude_code_shape():
 
 
 def test_format_usage_skips_missing_windows():
-    out = claude_usage.format_usage({"five_hour": {"utilization": 0.5, "resets_at": None}})
+    out = claude_usage.format_usage({"five_hour": {"utilization": 50, "resets_at": None}})
     assert out == "5-hour session: 50% used"  # no reset suffix when unknown
 
 

--- a/tests/test_claude_usage.py
+++ b/tests/test_claude_usage.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timezone
+
+from inkbox_claude import claude_usage
+
+
+def test_format_usage_matches_claude_code_shape():
+    now = datetime(2026, 6, 16, 12, 0, tzinfo=timezone.utc)
+    data = {
+        "five_hour": {"utilization": 0.42, "resets_at": "2026-06-16T14:30:00Z"},
+        "seven_day": {"utilization": 0.10, "resets_at": "2026-06-19T12:00:00Z"},
+        "seven_day_opus": {"utilization": 0.0, "resets_at": "2026-06-19T12:00:00Z"},
+    }
+    out = claude_usage.format_usage(data, now=now)
+    assert "5-hour session: 42% used, resets in 2h 30m" in out
+    assert "This week (all models): 10% used, resets in 3d 0h" in out
+    assert "This week (Opus): 0% used" in out
+
+
+def test_format_usage_skips_missing_windows():
+    out = claude_usage.format_usage({"five_hour": {"utilization": 0.5, "resets_at": None}})
+    assert out == "5-hour session: 50% used"  # no reset suffix when unknown
+
+
+def test_format_usage_empty_payload():
+    assert claude_usage.format_usage({}) == "No usage windows reported."
+
+
+def test_usage_report_handles_no_subscription(monkeypatch):
+    # No token → friendly message, no crash.
+    monkeypatch.setattr(claude_usage, "_read_oauth_token", lambda: None)
+    msg = claude_usage.usage_report()
+    assert "no subscription login" in msg.lower()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -235,29 +235,17 @@ def test_status_command_does_not_interrupt_a_running_turn():
     asyncio.run(scenario())
 
 
-def test_usage_command_reports_nothing_then_accumulated():
-    import types
+def test_usage_command_reports_claude_usage(monkeypatch):
+    # /usage delegates to claude_usage.usage_report (the real subscription fetch).
+    import inkbox_claude.claude_usage as cu
 
     async def scenario():
         sent = []
         session = make_session(sent)
-
+        monkeypatch.setattr(cu, "usage_report", lambda: "Claude usage:\n5-hour session: 12% used")
         await session.handle_inbound("/usage", "imessage", {"conversation_id": "c1"})
-        assert "no usage yet" in sent[-1][1].lower()
-
-        # Fold in two finished turns and report the running totals.
-        session._accumulate_usage(
-            types.SimpleNamespace(total_cost_usd=0.01, usage={"input_tokens": 100, "output_tokens": 40})
-        )
-        session._accumulate_usage(
-            types.SimpleNamespace(total_cost_usd=0.02, usage={"input_tokens": 200, "output_tokens": 60})
-        )
-        await session.handle_inbound("/usage", "imessage", {"conversation_id": "c1"})
-
-        line = sent[-1][1]
-        assert "2 turns" in line
-        assert "300 in / 100 out" in line
-        assert "$0.03" in line
+        assert "5-hour session: 12% used" in sent[-1][1]
+        assert session._queue.empty()  # report only, no Claude turn
 
     asyncio.run(scenario())
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -194,6 +194,74 @@ def test_non_command_is_forwarded_as_a_turn():
     asyncio.run(scenario())
 
 
+def test_status_command_reports_idle_without_queueing():
+    async def scenario():
+        sent = []
+        session = make_session(sent)
+        await session.handle_inbound("/status", "imessage", {"conversation_id": "c1"})
+        # Reports state, starts no turn.
+        assert "idle" in sent[-1][1].lower()
+        assert session._queue.empty()
+
+    asyncio.run(scenario())
+
+
+def test_status_command_does_not_interrupt_a_running_turn():
+    async def scenario():
+        sent = []
+        session = make_session(sent)
+
+        class FakeClient:
+            def __init__(self):
+                self.interrupts = 0
+
+            async def interrupt(self):
+                self.interrupts += 1
+
+        fake = FakeClient()
+        session._client = fake
+        session._turn_active = True
+        session._worker = asyncio.create_task(asyncio.sleep(10))
+
+        await session.handle_inbound("/status", "imessage", {"conversation_id": "c1"})
+
+        # Read-only: it reports "working" and leaves the turn running.
+        assert fake.interrupts == 0
+        assert session._interrupting is False
+        assert "working" in sent[-1][1].lower()
+
+        session._worker.cancel()
+
+    asyncio.run(scenario())
+
+
+def test_usage_command_reports_nothing_then_accumulated():
+    import types
+
+    async def scenario():
+        sent = []
+        session = make_session(sent)
+
+        await session.handle_inbound("/usage", "imessage", {"conversation_id": "c1"})
+        assert "no usage yet" in sent[-1][1].lower()
+
+        # Fold in two finished turns and report the running totals.
+        session._accumulate_usage(
+            types.SimpleNamespace(total_cost_usd=0.01, usage={"input_tokens": 100, "output_tokens": 40})
+        )
+        session._accumulate_usage(
+            types.SimpleNamespace(total_cost_usd=0.02, usage={"input_tokens": 200, "output_tokens": 60})
+        )
+        await session.handle_inbound("/usage", "imessage", {"conversation_id": "c1"})
+
+        line = sent[-1][1]
+        assert "2 turns" in line
+        assert "300 in / 100 out" in line
+        assert "$0.03" in line
+
+    asyncio.run(scenario())
+
+
 def _make_transcripts(base, project, specs):
     """Write fake Claude Code transcripts.
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,7 +1,14 @@
 import asyncio
+import json
+import os
+from pathlib import Path
 
 from inkbox_claude.config import BridgeConfig
-from inkbox_claude.sessions import ContactSession
+from inkbox_claude.sessions import (
+    ContactSession,
+    _parse_index,
+    list_recent_sessions,
+)
 
 
 def make_session(sent, typing=None):
@@ -183,6 +190,116 @@ def test_non_command_is_forwarded_as_a_turn():
         assert not session._queue.empty()
         assert session._queue.get_nowait().endswith("please /clear the cache")
         session._worker.cancel()
+
+    asyncio.run(scenario())
+
+
+def _make_transcripts(base, project, specs):
+    """Write fake Claude Code transcripts.
+
+    Each spec is (name, [user message contents], mtime) — one JSONL user line
+    is written per content string.
+    """
+    slug = str(Path(project).resolve()).replace("/", "-")
+    tdir = Path(base) / "projects" / slug
+    tdir.mkdir(parents=True, exist_ok=True)
+    for name, contents, mtime in specs:
+        path = tdir / name
+        body = "".join(
+            json.dumps({"type": "user", "message": {"content": c}}) + "\n"
+            for c in contents
+        )
+        path.write_text(body)
+        os.utime(path, (mtime, mtime))
+    return tdir
+
+
+def test_list_recent_sessions_orders_excludes_and_summarizes(tmp_path, monkeypatch):
+    project = str(tmp_path / "proj")
+    base = tmp_path / "cfg"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(base))
+
+    _make_transcripts(
+        base,
+        project,
+        [
+            ("aaa.jsonl", ["[iMessage from +1] fix the auth bug"], 100),
+            ("bbb.jsonl", ["exclude me"], 200),
+            ("ccc.jsonl", ["older one"], 50),
+            # First user line is an injected reminder — the digest should skip
+            # it and use the next real message.
+            ("ddd.jsonl", ["<system-reminder>x</system-reminder>", "the real message"], 300),
+        ],
+    )
+
+    out = list_recent_sessions(project, exclude_id="bbb")
+    # Newest first, excluded id dropped.
+    assert [s["id"] for s in out] == ["ddd", "aaa", "ccc"]
+    # Channel tag stripped, and the reminder line skipped.
+    assert out[1]["summary"] == "fix the auth bug"
+    assert out[0]["summary"] == "the real message"
+
+
+def test_parse_index():
+    assert _parse_index("2", 3) == 1
+    assert _parse_index("#3 please", 3) == 2
+    assert _parse_index("0", 3) is None
+    assert _parse_index("9", 3) is None
+    assert _parse_index("nope", 3) is None
+
+
+def test_resume_command_with_no_sessions(tmp_path, monkeypatch):
+    async def scenario():
+        sent = []
+        session = make_session(sent)
+        session.cfg.project_dir = str(tmp_path / "empty-proj")
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "cfg"))
+        await session.handle_inbound("/resume", "imessage", {"conversation_id": "c1"})
+        assert sent[-1][1] == "No other recent conversations to resume."
+        assert session._queue.empty()
+
+    asyncio.run(scenario())
+
+
+def test_resume_command_lists_then_swaps_on_pick(tmp_path, monkeypatch):
+    async def scenario():
+        project = str(tmp_path / "proj")
+        base = tmp_path / "cfg"
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(base))
+        _make_transcripts(
+            base,
+            project,
+            [
+                ("newer.jsonl", ["the newer conversation"], 200),
+                ("older.jsonl", ["the older conversation"], 100),
+            ],
+        )
+
+        sent = []
+        persisted = []
+        session = make_session(sent)
+        session.cfg.project_dir = project
+        session.on_session_id = lambda chat_id, sid: persisted.append((chat_id, sid))
+
+        class FakeClient:
+            async def disconnect(self):
+                pass
+
+        session._client = FakeClient()
+
+        # /resume sends the numbered menu and parks waiting for a pick.
+        await session.handle_inbound("/resume", "imessage", {"conversation_id": "c1"})
+        await asyncio.sleep(0.05)
+        assert "Recent conversations" in sent[-1][1]
+        assert session.pending is not None
+
+        # Picking #2 swaps in the older session and persists it.
+        await session.handle_inbound("2", "imessage", {"conversation_id": "c1"})
+        await asyncio.sleep(0.05)
+        assert session.resume_session_id == "older"
+        assert persisted == [("contact-1", "older")]
+        assert session._client is None
+        assert sent[-1][1] == "Resumed: the older conversation"
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
Brings the Claude Code CLI's `/resume` experience to the bridge: text `/resume` and the agent texts back a numbered list of the project's recent conversations — each with a one-line summary and a timestamp — and you reply with a number to reopen that exact session.

How it works:
- Reads Claude Code's per-session JSONL transcripts under the config dir (honoring `CLAUDE_CONFIG_DIR`), newest first, excluding the currently-live session.
- Each summary prefers an explicit compaction summary, otherwise the first real user message (channel tag stripped, system reminders skipped), trimmed to one line.
- The numbered pick reuses the existing escalation/numbered-reply flow and runs in a background task so the inbound webhook returns promptly while it waits.
- The chosen session id is persisted, so the resumed conversation survives bridge restarts.

Adds unit tests for the listing/ordering/summarizing, index parsing, the empty case, and the full list-then-pick swap, plus a README note.