### PR TITLE
Handle inbound and outbound media across SMS, iMessage, and email

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ Calls have two modes, chosen per call:
 
 **Inbound.** When someone sends an MMS image, an iMessage attachment, or an email with files, the gateway downloads them to `~/.inkbox-claude/media/` (override with `INKBOX_CLAUDE_MEDIA_DIR`) and appends the local paths to the message, so Claude can open them with its Read tool — including viewing images. Media-only messages (no text) still wake the agent.
 
-**Outbound.** Claude can send you media on any channel via its Inkbox tools:
-- **Email** — `inkbox_send_email(..., attachment_paths=[...])` attaches local files (base64 inline, ~25 MB total).
-- **iMessage** — `inkbox_send_imessage(..., media_path=...)` uploads a local file (≤10 MB) and sends it.
-- **SMS/MMS** — `inkbox_send_sms(..., media_urls=[...])` takes public URLs; to send a local file over MMS, `inkbox_upload_media(file_path)` first to get a hosted URL.
+**Outbound.** Claude sends media with a single tool call per channel — it just passes local file paths, and the tool handles any upload-then-send round trip internally:
+- **Email** — `inkbox_send_email(..., attachment_paths=[...])` (base64 inline, ~25 MB total).
+- **iMessage** — `inkbox_send_imessage(..., media_path=...)` (uploaded + sent, ≤10 MB).
+- **SMS/MMS** — `inkbox_send_sms(..., media_paths=[...])` (uploaded + sent; `media_urls` also accepts already-hosted URLs).
 
 ## Config reference
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ Calls have two modes, chosen per call:
   When the call ends, queued actions run in your session (and any plain "reflect on the call" follow-up if none were queued) — so "after we hang up, open a PR and text me" actually happens. Enable it in `inkbox-claude setup` (it validates your OpenAI key live) or via the `INKBOX_REALTIME_*` env vars below.
 - **Inkbox STT/TTS** (default / fallback): Inkbox auto-accepts the call and opens a WebSocket to the bridge; finalized transcripts become turns in your same session and Claude's replies are spoken back. The bridge falls back to this automatically if Realtime is off or OpenAI can't be reached (unless `INKBOX_REALTIME_FALLBACK_TO_INKBOX_STT_TTS=false`).
 
+## Media
+
+**Inbound.** When someone sends an MMS image, an iMessage attachment, or an email with files, the gateway downloads them to `~/.inkbox-claude/media/` (override with `INKBOX_CLAUDE_MEDIA_DIR`) and appends the local paths to the message, so Claude can open them with its Read tool — including viewing images. Media-only messages (no text) still wake the agent.
+
+**Outbound.** Claude can send you media on any channel via its Inkbox tools:
+- **Email** — `inkbox_send_email(..., attachment_paths=[...])` attaches local files (base64 inline, ~25 MB total).
+- **iMessage** — `inkbox_send_imessage(..., media_path=...)` uploads a local file (≤10 MB) and sends it.
+- **SMS/MMS** — `inkbox_send_sms(..., media_urls=[...])` takes public URLs; to send a local file over MMS, `inkbox_upload_media(file_path)` first to get a hosted URL.
+
 ## Config reference
 
 | Env var | Required | Default | Description |

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -54,6 +54,7 @@ except ImportError:  # pragma: no cover
 
 try:
     from .config import DEFAULT_WEBHOOK_PATH, INKBOX_WS_PATH, BridgeConfig
+    from .media import download_media, inbound_media_note
     from .prompts import strip_markdown
     from .realtime import (
         RealtimeBridgeConnectError,
@@ -64,6 +65,7 @@ try:
     from .tools import build_inkbox_mcp_server
 except ImportError:  # pragma: no cover - direct local import/test fallback
     from config import DEFAULT_WEBHOOK_PATH, INKBOX_WS_PATH, BridgeConfig
+    from media import download_media, inbound_media_note
     from prompts import strip_markdown
     from realtime import (
         RealtimeBridgeConnectError,
@@ -436,6 +438,9 @@ class InkboxGateway:
 
         subject = str(message.get("subject") or "")
         body_text = await asyncio.to_thread(self._fetch_mail_body, message)
+        if message.get("has_attachments"):
+            saved = await self._fetch_mail_attachments(message)
+            body_text = (body_text + inbound_media_note(saved)).strip()
         chat_id = self._chat_key(data, sender)
         meta = {
             "to": sender,
@@ -446,6 +451,49 @@ class InkboxGateway:
         # The channel tag (Subject included) is added by frame_inbound.
         await self.sessions.get(chat_id).handle_inbound(body_text, "email", meta)
         return web.json_response({"ok": True})
+
+    async def _fetch_mail_attachments(self, message: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Fetch + download an inbound email's attachments, best-effort.
+
+        Email webhooks only carry ``has_attachments``; the file list and signed
+        URLs come from the message detail + per-attachment endpoint.
+
+        Args:
+            message (dict): The inbound message object from the webhook.
+
+        Returns:
+            list[dict]: Saved attachments ({path, content_type, size}); empty on
+            any failure.
+        """
+        msg_id = str(message.get("id") or "")
+        email = getattr(self._identity, "email_address", None)
+        if not msg_id or not email:
+            return []
+        try:
+            detail = await asyncio.to_thread(self._identity.get_message, msg_id)
+            metadata = list(getattr(detail, "attachment_metadata", None) or [])
+        except Exception:
+            logger.debug("[bridge] attachment metadata fetch failed", exc_info=True)
+            return []
+
+        items: List[Dict[str, Any]] = []
+        for att in metadata:
+            filename = att.get("filename") if isinstance(att, dict) else getattr(att, "filename", None)
+            if not filename:
+                continue
+            try:
+                # Mint a signed URL per attachment (mirrors identity.get_message).
+                signed = await asyncio.to_thread(
+                    self._inkbox._messages.get_attachment, email, msg_id, filename
+                )
+            except Exception:
+                logger.debug("[bridge] attachment URL fetch failed for %s", filename, exc_info=True)
+                continue
+            url = signed.get("url") if isinstance(signed, dict) else None
+            if url:
+                ctype = att.get("content_type") if isinstance(att, dict) else None
+                items.append({"url": url, "content_type": ctype, "size": None})
+        return await download_media(items, prefix=f"mail-{msg_id}")
 
     def _fetch_mail_body(self, message: Dict[str, Any]) -> str:
         # The webhook only carries a snippet; pull the full body when we can.
@@ -468,7 +516,9 @@ class InkboxGateway:
             message.get("sender_phone_number") or message.get("remote_phone_number") or ""
         ).strip()
         text = str(message.get("text") or "").strip()
-        if not sender or not text:
+        media = message.get("media") or []
+        # An MMS can be media-only (no text) — still wake the agent for it.
+        if not sender or (not text and not media):
             return web.json_response({"ok": True, "ignored": "empty"})
         if text.lower() in SMS_CONTROL_WORDS:
             # Carrier keywords (STOP/START/HELP/...) are acked by Inkbox.
@@ -476,13 +526,14 @@ class InkboxGateway:
         if not self._sender_allowed(sender):
             return web.json_response({"ok": True, "ignored": "sender-not-allowed"})
 
+        body = await self._with_media(text, media, prefix=f"sms-{message.get('id', '')}")
         chat_id = self._chat_key(data, sender)
         meta = {
             "conversation_id": message.get("conversation_id"),
             "to": sender,
             "sender": sender,
         }
-        await self.sessions.get(chat_id).handle_inbound(text, "sms", meta)
+        await self.sessions.get(chat_id).handle_inbound(body, "sms", meta)
         return web.json_response({"ok": True})
 
     async def _on_imessage_received(self, envelope: Dict[str, Any]) -> "web.Response":
@@ -492,15 +543,34 @@ class InkboxGateway:
             return web.json_response({"ok": True, "ignored": "outbound-or-reaction"})
         sender = str(message.get("remote_number") or "").strip()
         text = str(message.get("content") or "").strip()
-        if not sender or not text:
+        media = message.get("media") or []
+        if not sender or (not text and not media):
             return web.json_response({"ok": True, "ignored": "empty"})
         if not self._sender_allowed(sender):
             return web.json_response({"ok": True, "ignored": "sender-not-allowed"})
 
+        body = await self._with_media(text, media, prefix=f"imsg-{message.get('id', '')}")
         chat_id = self._chat_key(data, sender)
         meta = {"conversation_id": message.get("conversation_id"), "sender": sender}
-        await self.sessions.get(chat_id).handle_inbound(text, "imessage", meta)
+        await self.sessions.get(chat_id).handle_inbound(body, "imessage", meta)
         return web.json_response({"ok": True})
+
+    async def _with_media(self, text: str, media: List[Dict[str, Any]], *, prefix: str) -> str:
+        """Download inbound media and append a note pointing Claude at the files.
+
+        Args:
+            text (str): The message text (may be empty for media-only messages).
+            media (list): The webhook's media items ({url, content_type, size}).
+            prefix (str): Filename prefix for the saved files.
+
+        Returns:
+            str: The text with a saved-attachments note appended (or just the
+            note when the message had no text).
+        """
+        if not media:
+            return text
+        saved = await download_media(media, prefix=prefix)
+        return (text + inbound_media_note(saved)).strip()
 
     # ------------------------------------------------------------------
     # Outbound delivery failures

--- a/inkbox_claude/media.py
+++ b/inkbox_claude/media.py
@@ -1,0 +1,125 @@
+"""Media helpers for the bridge.
+
+Inbound: download attachments that arrive on webhooks (MMS/iMessage media,
+email attachments) to local files so Claude can open them with the Read tool.
+Outbound: turn local files into the shapes each channel's send API wants
+(base64 for email, an uploaded URL for SMS/iMessage).
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import mimetypes
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:
+    import aiohttp
+except ImportError:  # pragma: no cover - aiohttp is a runtime dep
+    aiohttp = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+_UNSAFE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def media_dir() -> Path:
+    """Directory inbound attachments are saved to (created if missing)."""
+    base = os.getenv("INKBOX_CLAUDE_MEDIA_DIR") or str(Path.home() / ".inkbox-claude" / "media")
+    path = Path(base)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _extension_for(content_type: Optional[str], url: str) -> str:
+    """Pick a file extension from the URL, falling back to the MIME type."""
+    name = url.split("?", 1)[0]
+    _, dot, ext = name.rpartition(".")
+    if dot and 1 <= len(ext) <= 5 and ext.isalnum():
+        return f".{ext.lower()}"
+    if content_type:
+        guessed = mimetypes.guess_extension(content_type.split(";", 1)[0].strip())
+        if guessed:
+            return guessed
+    return ".bin"
+
+
+def _item_field(item: Any, name: str) -> Any:
+    # Webhook payloads are dicts; SDK objects expose the same attrs.
+    if isinstance(item, dict):
+        return item.get(name)
+    return getattr(item, name, None)
+
+
+async def download_media(items: List[Any], *, prefix: str) -> List[Dict[str, Any]]:
+    """Download inbound media items to local files, best-effort.
+
+    Args:
+        items (list): Media items (each carrying a ``url`` + ``content_type``),
+            from a webhook's ``media`` list or fetched email attachments.
+        prefix (str): Filename prefix (e.g. ``sms-<msgid>``) for the saved files.
+
+    Returns:
+        list[dict]: The files that downloaded, as
+        ``{"path", "content_type", "size"}``. Items that fail are skipped.
+    """
+    if aiohttp is None or not items:
+        return []
+    dest = media_dir()
+    safe_prefix = _UNSAFE.sub("-", prefix) or "media"
+    saved: List[Dict[str, Any]] = []
+    timeout = aiohttp.ClientTimeout(total=30)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        for idx, item in enumerate(items):
+            url = str(_item_field(item, "url") or "")
+            if not url:
+                continue
+            content_type = _item_field(item, "content_type")
+            target = dest / f"{safe_prefix}-{idx}{_extension_for(content_type, url)}"
+            try:
+                async with session.get(url) as resp:
+                    if resp.status != 200:
+                        logger.warning("[media] download %s… -> HTTP %s", url[:60], resp.status)
+                        continue
+                    target.write_bytes(await resp.read())
+            except Exception as exc:
+                logger.warning("[media] download failed: %s", exc)
+                continue
+            saved.append({
+                "path": str(target),
+                "content_type": content_type or "application/octet-stream",
+                "size": _item_field(item, "size"),
+            })
+    return saved
+
+
+def inbound_media_note(saved: List[Dict[str, Any]]) -> str:
+    """Render a note about saved attachments to append to an inbound message."""
+    if not saved:
+        return ""
+    lines = ["", "[Attachments received — saved locally. Use the Read tool to view images/files:]"]
+    for item in saved:
+        lines.append(f"- {item['path']} ({item['content_type']})")
+    return "\n".join(lines)
+
+
+def file_to_email_attachment(path: str) -> Dict[str, str]:
+    """Read a local file into the email attachment shape (base64 inline).
+
+    Args:
+        path (str): Local file path to attach.
+
+    Returns:
+        dict: ``{"filename", "content_type", "content_base64"}`` for send_email.
+    """
+    resolved = Path(path).expanduser()
+    data = resolved.read_bytes()
+    content_type = mimetypes.guess_type(resolved.name)[0] or "application/octet-stream"
+    return {
+        "filename": resolved.name,
+        "content_type": content_type,
+        "content_base64": base64.b64encode(data).decode("ascii"),
+    }

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -55,6 +55,28 @@ def _error(message: str) -> Dict[str, Any]:
     return {"content": [{"type": "text", "text": json.dumps({"error": message})}], "is_error": True}
 
 
+def _upload_media_url(identity: Any, path: str) -> str:
+    """Upload a local file via the SDK and return its hosted media URL.
+
+    The send tools call this so attaching a local file is one tool call for the
+    agent, even though it's an upload-then-send round trip under the hood.
+
+    Args:
+        identity (Any): The agent identity (has ``upload_imessage_media``).
+        path (str): Local file path to upload.
+
+    Returns:
+        str: The hosted ``media_url`` to pass as a ``media_urls`` entry.
+    """
+    resolved = Path(path).expanduser()
+    upload = identity.upload_imessage_media(
+        content=resolved.read_bytes(),
+        filename=resolved.name,
+        content_type=mimetypes.guess_type(resolved.name)[0],
+    )
+    return upload.media_url
+
+
 def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, List[str]]:
     """Build the in-process MCP server carrying the Inkbox tools.
 
@@ -119,25 +141,30 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
 
     @tool(
         "inkbox_send_sms",
-        "Send an SMS/MMS from this agent's Inkbox phone number. Use conversation_id "
-        "to reply in an existing thread, or to (E.164) for a new one. For MMS, pass "
-        "media_urls as a list of PUBLIC image/file URLs (SMS media must be a hosted "
-        "URL — to send a local file, call inkbox_upload_media first to get a URL).",
-        {"to": str, "text": str, "media_urls": list},
+        "Send an SMS/MMS from this agent's Inkbox phone number. Reply in a thread "
+        "with conversation_id, or start one with to (E.164). To send images/files "
+        "(MMS), pass media_paths as a list of LOCAL file paths — they're uploaded "
+        "and attached for you (each up to 10 MB). Already-hosted URLs may instead "
+        "be passed as media_urls.",
+        {"to": str, "text": str, "media_paths": list, "media_urls": list},
     )
     async def inkbox_send_sms(args: Dict[str, Any]) -> Dict[str, Any]:
         def _run():
+            identity = _identity()
             kwargs: Dict[str, Any] = {"text": str(args.get("text") or "")}
             target = str(args.get("to") or "").strip()
             if target.startswith("+"):
                 kwargs["to"] = target
             else:
                 kwargs["conversation_id"] = target
-            media_urls = [str(u) for u in (args.get("media_urls") or [])]
-            if media_urls:
-                kwargs["media_urls"] = media_urls
-            msg = _identity().send_text(**kwargs)
-            return {"sent": True, "id": str(getattr(msg, "id", ""))}
+            # One tool call for the agent; the upload→send two-step is internal.
+            urls = [str(u) for u in (args.get("media_urls") or [])]
+            for path in (args.get("media_paths") or []):
+                urls.append(_upload_media_url(identity, str(path)))
+            if urls:
+                kwargs["media_urls"] = urls
+            msg = identity.send_text(**kwargs)
+            return {"sent": True, "id": str(getattr(msg, "id", "")), "media": len(urls)}
 
         try:
             return _result(await asyncio.to_thread(_run))
@@ -162,42 +189,10 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
             }
             media_path = str(args.get("media_path") or "").strip()
             if media_path:
-                # iMessage media is upload-then-send: push the bytes, send the URL.
-                path = Path(media_path).expanduser()
-                upload = identity.upload_imessage_media(
-                    content=path.read_bytes(),
-                    filename=path.name,
-                    content_type=mimetypes.guess_type(path.name)[0],
-                )
-                kwargs["media_urls"] = [upload.media_url]
+                # One tool call for the agent; the upload→send two-step is internal.
+                kwargs["media_urls"] = [_upload_media_url(identity, media_path)]
             msg = identity.send_imessage(**kwargs)
             return {"sent": True, "id": str(getattr(msg, "id", ""))}
-
-        try:
-            return _result(await asyncio.to_thread(_run))
-        except Exception as exc:
-            return _error(str(exc))
-
-    @tool(
-        "inkbox_upload_media",
-        "Upload a local file and get back a hosted media_url. Use it as a "
-        "media_urls entry for inkbox_send_sms (MMS) when you need to send a local "
-        "file over SMS. Max 10 MB.",
-        {"file_path": str},
-    )
-    async def inkbox_upload_media(args: Dict[str, Any]) -> Dict[str, Any]:
-        def _run():
-            path = Path(str(args["file_path"])).expanduser()
-            upload = _identity().upload_imessage_media(
-                content=path.read_bytes(),
-                filename=path.name,
-                content_type=mimetypes.guess_type(path.name)[0],
-            )
-            return {
-                "media_url": upload.media_url,
-                "content_type": getattr(upload, "content_type", None),
-                "size": getattr(upload, "size", None),
-            }
 
         try:
             return _result(await asyncio.to_thread(_run))
@@ -275,7 +270,6 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         inkbox_get_text_conversation,
         inkbox_list_imessage_conversations,
         inkbox_get_imessage_conversation,
-        inkbox_upload_media,
     ]
     server = create_sdk_mcp_server(name="inkbox", version="0.1.0", tools=tools)
     tool_names = [
@@ -287,6 +281,5 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         "mcp__inkbox__inkbox_get_text_conversation",
         "mcp__inkbox__inkbox_list_imessage_conversations",
         "mcp__inkbox__inkbox_get_imessage_conversation",
-        "mcp__inkbox__inkbox_upload_media",
     ]
     return server, tool_names

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -11,7 +11,14 @@ import asyncio
 import dataclasses
 import json
 import logging
+import mimetypes
+from pathlib import Path
 from typing import Any, Dict, List, Tuple
+
+try:
+    from .media import file_to_email_attachment
+except ImportError:  # pragma: no cover - direct local import/test fallback
+    from media import file_to_email_attachment
 
 try:
     from claude_agent_sdk import create_sdk_mcp_server, tool
@@ -89,17 +96,21 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
 
     @tool(
         "inkbox_send_email",
-        "Send an email from this agent's Inkbox mailbox.",
-        {"to": str, "subject": str, "body": str},
+        "Send an email from this agent's Inkbox mailbox. To attach files, pass "
+        "attachment_paths as a list of local file paths (max ~25 MB total).",
+        {"to": str, "subject": str, "body": str, "attachment_paths": list},
     )
     async def inkbox_send_email(args: Dict[str, Any]) -> Dict[str, Any]:
         def _run():
+            paths = args.get("attachment_paths") or []
+            attachments = [file_to_email_attachment(str(p)) for p in paths] or None
             msg = _identity().send_email(
                 to=[str(args["to"])],
                 subject=str(args.get("subject") or ""),
                 body_text=str(args.get("body") or ""),
+                attachments=attachments,
             )
-            return {"sent": True, "id": str(getattr(msg, "id", ""))}
+            return {"sent": True, "id": str(getattr(msg, "id", "")), "attachments": len(paths)}
 
         try:
             return _result(await asyncio.to_thread(_run))
@@ -108,9 +119,11 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
 
     @tool(
         "inkbox_send_sms",
-        "Send an SMS from this agent's Inkbox phone number. Use conversation_id "
-        "to reply in an existing thread, or to (E.164) for a new one.",
-        {"to": str, "text": str},
+        "Send an SMS/MMS from this agent's Inkbox phone number. Use conversation_id "
+        "to reply in an existing thread, or to (E.164) for a new one. For MMS, pass "
+        "media_urls as a list of PUBLIC image/file URLs (SMS media must be a hosted "
+        "URL — to send a local file, call inkbox_upload_media first to get a URL).",
+        {"to": str, "text": str, "media_urls": list},
     )
     async def inkbox_send_sms(args: Dict[str, Any]) -> Dict[str, Any]:
         def _run():
@@ -120,6 +133,9 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
                 kwargs["to"] = target
             else:
                 kwargs["conversation_id"] = target
+            media_urls = [str(u) for u in (args.get("media_urls") or [])]
+            if media_urls:
+                kwargs["media_urls"] = media_urls
             msg = _identity().send_text(**kwargs)
             return {"sent": True, "id": str(getattr(msg, "id", ""))}
 
@@ -132,16 +148,56 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         "inkbox_send_imessage",
         "Send an iMessage. Pass an existing conversation_id — get it from "
         "inkbox_list_imessage_conversations (iMessage is recipient-first: a "
-        "conversation exists only after the person has messaged this agent).",
-        {"conversation_id": str, "text": str},
+        "conversation exists only after the person has messaged this agent). To "
+        "attach an image/file, pass media_path as a local file path (uploaded "
+        "automatically, max 10 MB).",
+        {"conversation_id": str, "text": str, "media_path": str},
     )
     async def inkbox_send_imessage(args: Dict[str, Any]) -> Dict[str, Any]:
         def _run():
-            msg = _identity().send_imessage(
-                conversation_id=str(args["conversation_id"]),
-                text=str(args.get("text") or ""),
-            )
+            identity = _identity()
+            kwargs: Dict[str, Any] = {
+                "conversation_id": str(args["conversation_id"]),
+                "text": str(args.get("text") or ""),
+            }
+            media_path = str(args.get("media_path") or "").strip()
+            if media_path:
+                # iMessage media is upload-then-send: push the bytes, send the URL.
+                path = Path(media_path).expanduser()
+                upload = identity.upload_imessage_media(
+                    content=path.read_bytes(),
+                    filename=path.name,
+                    content_type=mimetypes.guess_type(path.name)[0],
+                )
+                kwargs["media_urls"] = [upload.media_url]
+            msg = identity.send_imessage(**kwargs)
             return {"sent": True, "id": str(getattr(msg, "id", ""))}
+
+        try:
+            return _result(await asyncio.to_thread(_run))
+        except Exception as exc:
+            return _error(str(exc))
+
+    @tool(
+        "inkbox_upload_media",
+        "Upload a local file and get back a hosted media_url. Use it as a "
+        "media_urls entry for inkbox_send_sms (MMS) when you need to send a local "
+        "file over SMS. Max 10 MB.",
+        {"file_path": str},
+    )
+    async def inkbox_upload_media(args: Dict[str, Any]) -> Dict[str, Any]:
+        def _run():
+            path = Path(str(args["file_path"])).expanduser()
+            upload = _identity().upload_imessage_media(
+                content=path.read_bytes(),
+                filename=path.name,
+                content_type=mimetypes.guess_type(path.name)[0],
+            )
+            return {
+                "media_url": upload.media_url,
+                "content_type": getattr(upload, "content_type", None),
+                "size": getattr(upload, "size", None),
+            }
 
         try:
             return _result(await asyncio.to_thread(_run))
@@ -219,6 +275,7 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         inkbox_get_text_conversation,
         inkbox_list_imessage_conversations,
         inkbox_get_imessage_conversation,
+        inkbox_upload_media,
     ]
     server = create_sdk_mcp_server(name="inkbox", version="0.1.0", tools=tools)
     tool_names = [
@@ -230,5 +287,6 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         "mcp__inkbox__inkbox_get_text_conversation",
         "mcp__inkbox__inkbox_list_imessage_conversations",
         "mcp__inkbox__inkbox_get_imessage_conversation",
+        "mcp__inkbox__inkbox_upload_media",
     ]
     return server, tool_names

--- a/tests/test_gateway_inbound_media.py
+++ b/tests/test_gateway_inbound_media.py
@@ -1,0 +1,92 @@
+import asyncio
+import json
+import types
+
+import pytest
+
+from inkbox_claude import gateway
+from inkbox_claude.config import BridgeConfig
+
+
+@pytest.fixture(autouse=True)
+def fake_web(monkeypatch):
+    def json_response(payload):
+        return types.SimpleNamespace(text=json.dumps(payload), payload=payload)
+    monkeypatch.setattr(gateway, "web", types.SimpleNamespace(json_response=json_response))
+
+
+class _FakeSession:
+    def __init__(self):
+        self.inbound = []
+
+    async def handle_inbound(self, text, mode, meta):
+        self.inbound.append((text, mode, meta))
+
+
+class _FakeSessions:
+    def __init__(self):
+        self.by_id = {}
+
+    def get(self, chat_id):
+        return self.by_id.setdefault(chat_id, _FakeSession())
+
+
+def _gw(monkeypatch, saved):
+    async def fake_download(items, *, prefix):
+        # Pretend each item downloaded; echo count so the prefix/threading works.
+        return saved
+    monkeypatch.setattr(gateway, "download_media", fake_download)
+    gw = gateway.InkboxGateway(BridgeConfig(require_signature=False, allow_all_users=True))
+    gw.sessions = _FakeSessions()
+    return gw
+
+
+def test_inbound_mms_media_only_wakes_agent_with_note(monkeypatch):
+    gw = _gw(monkeypatch, [{"path": "/m/sms-0.jpg", "content_type": "image/jpeg"}])
+    envelope = {"data": {"text_message": {
+        "id": "t1", "direction": "inbound", "remote_phone_number": "+15551234567",
+        "text": "", "media": [{"url": "https://s3/x.jpg", "content_type": "image/jpeg"}],
+    }}}
+    asyncio.run(gw._on_text_received(envelope))
+
+    session = gw.sessions.by_id["+15551234567"]
+    assert len(session.inbound) == 1
+    body, mode, _ = session.inbound[0]
+    assert mode == "sms"
+    assert "/m/sms-0.jpg (image/jpeg)" in body  # media note present
+    assert "Read tool" in body
+
+
+def test_inbound_imessage_with_text_and_media_appends_note(monkeypatch):
+    gw = _gw(monkeypatch, [{"path": "/m/imsg-0.png", "content_type": "image/png"}])
+    envelope = {"data": {"message": {
+        "id": "i1", "direction": "inbound", "remote_number": "+15551112222",
+        "content": "check this out", "media": [{"url": "https://s3/y.png", "content_type": "image/png"}],
+    }}}
+    asyncio.run(gw._on_imessage_received(envelope))
+
+    body, mode, _ = gw.sessions.by_id["+15551112222"].inbound[0]
+    assert mode == "imessage"
+    assert body.startswith("check this out")
+    assert "/m/imsg-0.png (image/png)" in body
+
+
+def test_inbound_text_without_media_is_unchanged(monkeypatch):
+    gw = _gw(monkeypatch, [])
+    envelope = {"data": {"text_message": {
+        "id": "t2", "direction": "inbound", "remote_phone_number": "+15550000000",
+        "text": "just text",
+    }}}
+    asyncio.run(gw._on_text_received(envelope))
+    body, _, _ = gw.sessions.by_id["+15550000000"].inbound[0]
+    assert body == "just text"
+
+
+def test_empty_message_no_text_no_media_is_ignored(monkeypatch):
+    gw = _gw(monkeypatch, [])
+    envelope = {"data": {"text_message": {
+        "id": "t3", "direction": "inbound", "remote_phone_number": "+15550000001", "text": "",
+    }}}
+    resp = asyncio.run(gw._on_text_received(envelope))
+    assert json.loads(resp.text)["ignored"] == "empty"
+    assert "+15550000001" not in gw.sessions.by_id

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,39 @@
+import base64
+
+from inkbox_claude import media
+
+
+def test_extension_prefers_url_then_content_type():
+    assert media._extension_for("image/jpeg", "https://x/a/photo.PNG?sig=1") == ".png"
+    assert media._extension_for("image/jpeg", "https://x/a/blob?sig=1") == ".jpg"
+    assert media._extension_for(None, "https://x/a/blob") == ".bin"
+
+
+def test_inbound_media_note_lists_paths():
+    note = media.inbound_media_note([
+        {"path": "/m/sms-0.jpg", "content_type": "image/jpeg"},
+        {"path": "/m/sms-1.pdf", "content_type": "application/pdf"},
+    ])
+    assert "Read tool" in note
+    assert "/m/sms-0.jpg (image/jpeg)" in note
+    assert "/m/sms-1.pdf (application/pdf)" in note
+
+
+def test_inbound_media_note_empty_when_nothing_saved():
+    assert media.inbound_media_note([]) == ""
+
+
+def test_file_to_email_attachment_base64s_local_file(tmp_path):
+    f = tmp_path / "report.txt"
+    f.write_bytes(b"hello world")
+    att = media.file_to_email_attachment(str(f))
+    assert att["filename"] == "report.txt"
+    assert att["content_type"] == "text/plain"
+    assert base64.b64decode(att["content_base64"]) == b"hello world"
+
+
+def test_file_to_email_attachment_unknown_type_falls_back(tmp_path):
+    f = tmp_path / "blob.weirdext"
+    f.write_bytes(b"\x00\x01")
+    att = media.file_to_email_attachment(str(f))
+    assert att["content_type"] == "application/octet-stream"


### PR DESCRIPTION
Adds full media support to the bridge — receiving attachments and letting Claude send them.

Closes #3.

## Inbound (was: attachments silently dropped)
Webhooks carry media, but the gateway only read text. Now `text.received` / `imessage.received` / `message.received` handlers download attachments and hand them to Claude:
- **SMS/MMS + iMessage** — media comes straight off the webhook (`data.*.media[]` = signed S3 URLs); downloaded directly.
- **Email** — fetched via message detail (`attachment_metadata`) + a per-attachment signed URL.
- Files are saved to `~/.inkbox-claude/media/` (override `INKBOX_CLAUDE_MEDIA_DIR`), and their local paths are appended to the message so Claude can open them with its **Read tool** (so it can actually *see* images).
- **Media-only messages** (an MMS/iMessage with no text) now wake the agent instead of being dropped as "empty".
- Download is best-effort — a failed fetch is skipped, never blocks the message.

## Outbound (Claude can send you media)
Each channel maps to its natural mechanism:
- **Email** — `inkbox_send_email(..., attachment_paths=[...])`: local files, base64 inline (~25 MB total).
- **iMessage** — `inkbox_send_imessage(..., media_path=...)`: uploads the local file (≤10 MB), then sends it.
- **SMS/MMS** — `inkbox_send_sms(..., media_urls=[...])`: public URLs (carrier MMS needs a hosted URL).
- **`inkbox_upload_media(file_path)`** — turns a local file into a hosted `media_url` for the SMS/MMS path.

Shared logic (download, attachment note, base64 encode, extension inference) lives in a new `media.py`. Covered by unit tests for the helpers and the gateway inbound wiring (media-only wakes the agent, note appended, text-only unchanged, empty ignored).