### PR TITLE
Fix flat-layout package discovery in editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
 [project.scripts]
 inkbox-claude = "inkbox_claude.cli:main"
 
+[tool.setuptools.packages.find]
+include = ["inkbox_claude*"]
+
 [tool.setuptools.package-data]
 # Ship the bundled Claude Code avatar attached to agents during setup.
 inkbox_claude = ["assets/*.png"]


### PR DESCRIPTION
## Summary

`curl | bash` install fails at the `pip install -e .` step with:

```
error: Multiple top-level packages discovered in a flat-layout: ['assets', 'inkbox_claude'].
```

The repo uses a flat layout — both `inkbox_claude/` and `assets/` sit at the top level. setuptools auto-discovery finds two top-level package candidates, can't choose, and aborts the build.

This pins package discovery to `inkbox_claude*` so the editable install builds cleanly. Verified locally: install succeeds and `inkbox-claude --help` works.