### PR TITLE
Stop oversized messages from permanently wedging a session

### DIFF
--- a/inkbox_claude/sessions.py
+++ b/inkbox_claude/sessions.py
@@ -71,6 +71,12 @@ HealthFn = Callable[[], Awaitable[str]]
 # indicator on this cadence for as long as a turn is running.
 TYPING_REFRESH_SECONDS = 4.0
 
+# Cap on a single stream-json message from the `claude` subprocess. The SDK
+# defaults to 1 MB and kills its message reader if one line exceeds it — a big
+# file read, wide grep, or base64 media payload can blow past that and wedge the
+# session. Give it generous headroom; the buffer is only allocated if actually hit.
+MAX_BUFFER_SIZE = 64 * 1024 * 1024  # 64 MB
+
 
 @dataclass
 class _Turn:
@@ -612,6 +618,14 @@ class ContactSession:
                         self.on_session_id(self.chat_id, message.session_id)
             reply = (final or "\n\n".join(chunks)).strip()
         except Exception as exc:
+            # A failed turn can leave the SDK client wedged — its message reader
+            # dies on errors like an oversized stream-json line, so every later
+            # turn would fail against the same dead client. Drop it (keeping the
+            # resumed session id) so the next turn rebuilds a fresh subprocess
+            # with context intact. An intentional interrupt leaves a healthy
+            # client, so skip the reset there.
+            if not self._interrupting:
+                await self._reset_client()
             # A capture turn must always settle its waiter — surface the error
             # there. A normal turn re-raises so _drain shows the human a notice.
             if turn.future is not None and not turn.future.done():
@@ -742,6 +756,9 @@ class ContactSession:
             mcp_servers={"inkbox": self.mcp_server},
             can_use_tool=self._can_use_tool,
             resume=self.resume_session_id or None,
+            # Raise the SDK's stream-json line cap so an oversized tool result
+            # doesn't kill the reader and wedge the session (see MAX_BUFFER_SIZE).
+            max_buffer_size=MAX_BUFFER_SIZE,
         )
         self._client = ClaudeSDKClient(options=options)
         await self._client.connect()
@@ -835,6 +852,22 @@ class ContactSession:
 
     async def _reply(self, text: str) -> None:
         await self.send_fn(self.chat_id, text, self.mode, self.reply_meta)
+
+    async def _reset_client(self) -> None:
+        """Tear down the live Claude client so the next turn rebuilds it.
+
+        Called after a turn fails: the SDK's message reader dies on errors like
+        an oversized stream-json line, leaving the client wedged so every later
+        turn fails against it. The resumed session id is kept, so the rebuilt
+        client picks the conversation back up with context intact.
+
+        Returns:
+            None
+        """
+        if self._client is None:
+            return
+        logger.info("[session %s] resetting Claude client after a failed turn", self.chat_id)
+        await self.close()
 
     async def close(self) -> None:
         if self._client is not None:

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -507,3 +507,91 @@ def test_double_text_interrupts_running_turn():
         session._worker.cancel()
 
     asyncio.run(scenario())
+
+
+def test_failed_turn_resets_wedged_client_keeping_resume_id():
+    # Regression for the silent-wedge bug: an oversized stream-json line kills
+    # the SDK's message reader, so receive_response() raises and the client is
+    # left dead-but-present. The failed turn must drop the client (so the next
+    # turn rebuilds a fresh subprocess) while keeping the resume id, so the
+    # conversation continues with context intact instead of going silent.
+    async def scenario():
+        session = make_session([])
+
+        class WedgedClient:
+            def __init__(self):
+                self.disconnected = False
+
+            async def query(self, text):
+                pass
+
+            def receive_response(self):
+                async def gen():
+                    raise RuntimeError(
+                        "JSON message exceeded maximum buffer size of 1048576 bytes"
+                    )
+                    yield  # pragma: no cover - makes this an async generator
+                return gen()
+
+            async def disconnect(self):
+                self.disconnected = True
+
+        fake = WedgedClient()
+        session._client = fake
+        session.resume_session_id = "sess-keep"
+
+        # A normal turn (no future) re-raises after self-healing; _drain shows
+        # the human a notice, but the next turn recovers.
+        raised = False
+        try:
+            await session._run_turn(_Turn(text="read a huge file"))
+        except RuntimeError:
+            raised = True
+
+        assert raised is True
+        assert fake.disconnected is True              # wedged client torn down
+        assert session._client is None               # next turn rebuilds fresh
+        assert session.resume_session_id == "sess-keep"  # context preserved
+
+    asyncio.run(scenario())
+
+
+def test_interrupted_turn_does_not_reset_client():
+    # When a turn fails *because* a new message interrupted it, the client is
+    # still healthy — the reset must be skipped so we don't needlessly respawn
+    # the subprocess.
+    async def scenario():
+        session = make_session([])
+
+        class InterruptedClient:
+            def __init__(self, sess):
+                self.sess = sess
+                self.disconnected = False
+
+            async def query(self, text):
+                pass
+
+            def receive_response(self):
+                sess = self.sess
+
+                async def gen():
+                    sess._interrupting = True  # a concurrent /stop flipped this
+                    raise RuntimeError("aborted mid-turn")
+                    yield  # pragma: no cover
+                return gen()
+
+            async def disconnect(self):
+                self.disconnected = True
+
+        fake = InterruptedClient(session)
+        session._client = fake
+
+        try:
+            await session._run_turn(_Turn(text="never mind"))
+        except RuntimeError:
+            pass
+
+        assert session._client is fake      # NOT reset
+        assert fake.disconnected is False
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Problem

A session could go silent until a full systemd restart. Root cause from a live incident: at one point a single stream-json line from the `claude` subprocess exceeded the agent-SDK's default **1 MB buffer**:

```
ERROR claude_agent_sdk._internal.query: Fatal error in message reader:
  Failed to decode JSON: JSON message exceeded maximum buffer size of 1048576 bytes
```

That kills the SDK's message-reader task, but the session's client object stays in place — **dead**. Afterward, inbound messages still arrived (webhook returned 200, the typing indicator even fired), but `client.receive_response()` raised on every turn, so no reply was ever produced. From the user's phone it looked dead; really it was reading messages and silently choking on a wedged client.

## Fix

Two complementary changes in `sessions.py`:

1. **Raise the buffer ceiling.** Pass `max_buffer_size=64 MB` on `ClaudeAgentOptions` so an oversized tool result — a big file read, a wide grep, or a base64 media payload — no longer trips the 1 MB cap. The SDK exposes this field; default was 1 MB.

2. **Self-heal a wedged client.** When a turn fails (and isn't an intentional interrupt), drop the client via a new `_reset_client()` so the next turn rebuilds a fresh subprocess. The resumed session id is kept, so the conversation continues with context intact. This recovers regardless of *which* SDK internal died — the buffer bump alone just raises the ceiling; this removes the permanent-wedge failure mode entirely.

## Notes

- 112 unit tests pass.
- The live gateway was already restarted to recover the current session; this prevents recurrence.