### PR TITLE
feat(tools): add inkbox_place_call for outbound calls

### DIFF
--- a/inkbox_claude/config.py
+++ b/inkbox_claude/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
@@ -17,6 +18,22 @@ INKBOX_WS_PATH = "/phone/media/ws"
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8767
 DEFAULT_WEBHOOK_PATH = "/webhook"
+
+
+def call_contexts_dir() -> Path:
+    """Directory where ``inkbox_place_call`` stashes per-call context (purpose,
+    opening line) for the gateway to load when the outbound call connects.
+
+    Shared across the tool process and the gateway daemon (same host + user);
+    honours ``INKBOX_CLAUDE_HOME`` like the daemon's state dir.
+
+    Returns:
+        Path: The created ``<home>/call_contexts`` directory.
+    """
+    root = Path(os.getenv("INKBOX_CLAUDE_HOME") or (Path.home() / ".inkbox-claude"))
+    path = root / "call_contexts"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
 
 # Tools Claude Code may run without texting the human first. Everything
 # else (Bash, Write, Edit, ...) escalates over the active channel.

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -53,7 +53,7 @@ except ImportError:  # pragma: no cover
     INKBOX_TUNNEL_AVAILABLE = False
 
 try:
-    from .config import DEFAULT_WEBHOOK_PATH, INKBOX_WS_PATH, BridgeConfig
+    from .config import DEFAULT_WEBHOOK_PATH, INKBOX_WS_PATH, BridgeConfig, call_contexts_dir
     from .media import download_media, inbound_media_note
     from .prompts import strip_markdown
     from .realtime import (
@@ -64,7 +64,7 @@ try:
     from .sessions import SessionManager
     from .tools import build_inkbox_mcp_server
 except ImportError:  # pragma: no cover - direct local import/test fallback
-    from config import DEFAULT_WEBHOOK_PATH, INKBOX_WS_PATH, BridgeConfig
+    from config import DEFAULT_WEBHOOK_PATH, INKBOX_WS_PATH, BridgeConfig, call_contexts_dir
     from media import download_media, inbound_media_note
     from prompts import strip_markdown
     from realtime import (
@@ -676,7 +676,9 @@ class InkboxGateway:
     # Inbound: live calls (Inkbox STT/TTS text-frame bridge)
     # ------------------------------------------------------------------
 
-    async def _open_realtime_bridge(self, remote: str, call_id: str) -> Any:
+    async def _open_realtime_bridge(
+        self, remote: str, call_id: str, outbound: Optional[Dict[str, Any]] = None
+    ) -> Any:
         """Preflight an OpenAI Realtime session for an incoming call.
 
         Args:
@@ -688,11 +690,15 @@ class InkboxGateway:
             failed (the caller then falls back to Inkbox STT/TTS).
         """
         phone = getattr(self._identity, "phone_number", None)
+        oc = outbound or {}
         meta = RealtimeCallMeta(
             call_id=call_id or "unknown",
             remote_phone_number=remote or None,
             agent_identity_phone=getattr(phone, "number", None),
             project_dir=self.cfg.project_dir,
+            outbound_purpose=(oc.get("purpose") or None),
+            outbound_opening=(oc.get("opening_message") or None),
+            outbound_context=(oc.get("context") or None),
         )
         try:
             return await open_inkbox_realtime_bridge(config=self.cfg.realtime, meta=meta)
@@ -702,6 +708,32 @@ class InkboxGateway:
                 "falling back to Inkbox STT/TTS unless disabled",
                 call_id, exc.cause,
             )
+            return None
+
+    @staticmethod
+    def _load_outbound_context(token: Optional[str]) -> Optional[Dict[str, Any]]:
+        """Load the purpose/opening an outbound call was placed with.
+
+        ``inkbox_place_call`` writes ``<call_contexts>/<token>.json`` and gives
+        Inkbox a call WS URL carrying ``?context_token=<token>``. Returns the
+        parsed dict, or None for inbound calls / missing or unreadable files.
+
+        Args:
+            token (Optional[str]): The ``context_token`` query value, if any.
+
+        Returns:
+            Optional[Dict[str, Any]]: Parsed context, or None.
+        """
+        token = (token or "").strip()
+        # Token rides in off the URL; never let it escape the contexts dir.
+        if not token or "/" in token or "\\" in token or token in {".", ".."}:
+            return None
+        path = call_contexts_dir() / f"{token}.json"
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
             return None
 
     async def _handle_call_ws(self, request: "web.Request") -> Any:
@@ -725,6 +757,12 @@ class InkboxGateway:
         call_id = str(call_context.get("id") or call_context.get("call_id") or "")
         chat_id = remote or f"call:{call_id}"
 
+        # Outbound-call context: `inkbox_place_call` wrote the purpose/opening to
+        # a token file and put `?context_token=<token>` on the call WS URL. Load
+        # it so the live session opens knowing why it's calling (Hermes parity).
+        # None for inbound calls.
+        outbound = self._load_outbound_context(request.query.get("context_token"))
+
         ws = web.WebSocketResponse()
 
         # Realtime branch: when configured, pre-open OpenAI Realtime BEFORE we
@@ -733,7 +771,7 @@ class InkboxGateway:
         # Code via run_consult. If the preflight fails, fall through to Inkbox
         # STT/TTS below (unless fallback is disabled, then refuse the call).
         if self.cfg.realtime.enabled:
-            bridge = await self._open_realtime_bridge(remote, call_id)
+            bridge = await self._open_realtime_bridge(remote, call_id, outbound)
             if bridge is None and not self.cfg.realtime.fallback_to_inkbox_stt_tts:
                 return web.Response(status=503, text="realtime bridge unavailable")
             if bridge is not None:
@@ -799,7 +837,14 @@ class InkboxGateway:
                     continue
                 event = payload.get("event")
                 if event == "start":
-                    await self._speak(ws, "Hey, you've reached Claude. What do you need?", "greeting")
+                    # Outbound calls open with the supplied line; inbound get the
+                    # default prompt. (The Realtime path handles its own opener.)
+                    opener = (outbound or {}).get("opening_message") or ""
+                    await self._speak(
+                        ws,
+                        opener or "Hey, you've reached Claude. What do you need?",
+                        "greeting",
+                    )
                 elif event == "transcript" and payload.get("is_final"):
                     text = str(payload.get("text") or "").strip()
                     if not text:

--- a/inkbox_claude/realtime.py
+++ b/inkbox_claude/realtime.py
@@ -633,6 +633,19 @@ async def _openai_to_inkbox_pump(
         state.consult_tasks.add(task)
         task.add_done_callback(state.consult_tasks.discard)
 
+    async def _relay_transcript(party: str, text: str) -> None:
+        # Realtime runs the WS in raw-media mode (OpenAI does STT/TTS, Inkbox
+        # does neither), so the platform never records any transcript on its
+        # own. Mirror each finalized turn back as a client `transcript` event
+        # so it lands in the Inkbox call record. party: local=agent, remote=caller.
+        with suppress(Exception):
+            await inkbox_ws.send_str(json.dumps({
+                "event": "transcript",
+                "party": party,
+                "text": text,
+                "is_final": True,
+            }))
+
     async for msg in openai_ws:
         if state.closed:
             return
@@ -689,10 +702,12 @@ async def _openai_to_inkbox_pump(
             text = (frame.get("transcript") or "").strip()
             if text:
                 state.transcript.append(("agent", text))
+                await _relay_transcript("local", text)
         elif ftype == "conversation.item.input_audio_transcription.completed":
             text = (frame.get("transcript") or "").strip()
             if text:
                 state.transcript.append(("caller", text))
+                await _relay_transcript("remote", text)
 
         # Function-call lifecycle.
         elif ftype == "response.output_item.added":

--- a/inkbox_claude/realtime.py
+++ b/inkbox_claude/realtime.py
@@ -105,6 +105,11 @@ class RealtimeCallMeta:
     remote_phone_number: Optional[str]
     agent_identity_phone: Optional[str] = None
     project_dir: Optional[str] = None
+    # Outbound calls only: why this agent placed the call, threaded from
+    # ``inkbox_place_call`` so the live session opens with context, not cold.
+    outbound_purpose: Optional[str] = None
+    outbound_opening: Optional[str] = None
+    outbound_context: Optional[str] = None
 
 
 @dataclass
@@ -166,6 +171,18 @@ def build_realtime_instructions(meta: RealtimeCallMeta, additional: str = "") ->
         "can answer directly. Use it whenever the caller wants something done in the code.",
         "While a tool runs you may say a brief 'one moment' so the caller isn't left in silence.",
     ]
+    if meta.outbound_purpose:
+        lines += [
+            "",
+            "This is an OUTBOUND call you placed — the callee did not call you. "
+            f"You are calling because: {meta.outbound_purpose}",
+        ]
+        if meta.outbound_context:
+            lines.append(f"Background: {meta.outbound_context}")
+        lines.append(
+            "Open by greeting them, saying who you are, and stating why you're "
+            "calling in one short sentence, then let them respond."
+        )
     if additional.strip():
         lines += ["", additional.strip()]
     return "\n".join(lines)
@@ -173,6 +190,17 @@ def build_realtime_instructions(meta: RealtimeCallMeta, additional: str = "") ->
 
 def build_realtime_greeting(meta: RealtimeCallMeta) -> str:
     """Instructions for the proactive opening line spoken at pickup."""
+    if meta.outbound_opening:
+        return (
+            "Open the call by saying, naturally and in one short sentence: "
+            f"\"{meta.outbound_opening}\" Then stop and let them respond."
+        )
+    if meta.outbound_purpose:
+        return (
+            "You placed this call. Open by greeting them, saying you're their "
+            f"Claude Code agent, and stating why you're calling: {meta.outbound_purpose}. "
+            "Keep it to one short sentence, then stop."
+        )
     return (
         "Greet the caller briefly and naturally, e.g. \"Hey, it's your Claude Code "
         "agent — what do you need?\" Keep it to one short sentence and then stop."

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -12,8 +12,11 @@ import dataclasses
 import json
 import logging
 import mimetypes
+import secrets
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 try:
     from .media import file_to_email_attachment
@@ -21,9 +24,9 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
     from media import file_to_email_attachment
 
 try:
-    from .config import INKBOX_WS_PATH
+    from .config import INKBOX_WS_PATH, call_contexts_dir
 except ImportError:  # pragma: no cover - direct local import/test fallback
-    from config import INKBOX_WS_PATH
+    from config import INKBOX_WS_PATH, call_contexts_dir
 
 try:
     from claude_agent_sdk import create_sdk_mcp_server, tool
@@ -80,6 +83,46 @@ def _upload_media_url(identity: Any, path: str) -> str:
         content_type=mimetypes.guess_type(resolved.name)[0],
     )
     return upload.media_url
+
+
+def _append_query_param(raw_url: str, key: str, value: str) -> str:
+    """Append/replace one query param on a URL, preserving the rest. Used to
+    tag the call WS URL with the context token the gateway reads on connect.
+    """
+    parts = urlparse(raw_url)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query[key] = value
+    return urlunparse(parts._replace(query=urlencode(query)))
+
+
+def _write_call_context(
+    *, purpose: str, opening_message: str, context: str, to_number: str
+) -> str:
+    """Persist an outbound call's purpose/opening for the gateway to load when
+    the call connects, keyed by a fresh opaque token. Mirrors the Hermes
+    plugin's ``inkbox_call_contexts`` handoff.
+
+    Args:
+        purpose (str): Why the agent is placing the call.
+        opening_message (str): Optional exact first line to say on pickup.
+        context (str): Optional extra background for the live session.
+        to_number (str): The E.164 destination (recorded for debugging).
+
+    Returns:
+        str: The token to put on the call WS URL as ``context_token``.
+    """
+    token = secrets.token_urlsafe(18)
+    payload = {
+        "created_at": time.time(),
+        "purpose": purpose,
+        "opening_message": opening_message,
+        "context": context,
+        "to_number": to_number,
+    }
+    (call_contexts_dir() / f"{token}.json").write_text(
+        json.dumps(payload, indent=2) + "\n"
+    )
+    return token
 
 
 def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, List[str]]:
@@ -402,14 +445,23 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         "audio bridges to this agent over the running bridge gateway's call-media "
         "WebSocket, so the agent talks the call live (Inkbox STT/TTS, or the "
         "OpenAI Realtime path when enabled). Requires the bridge gateway to be "
-        "running. Pass to_number in E.164, e.g. +15551234567.",
-        {"to_number": str},
+        "running. ALWAYS pass purpose so the live call opens knowing why it's "
+        "calling — without it the voice runtime (especially Realtime) starts with "
+        "no context. Optionally pass opening_message (the exact first line to say) "
+        "and context (extra background). to_number is E.164, e.g. +15551234567.",
+        {"to_number": str, "purpose": str, "opening_message": str, "context": str},
     )
     async def inkbox_place_call(args: Dict[str, Any]) -> Dict[str, Any]:
         def _run():
             to_number = str(args.get("to_number") or "").strip()
             if not to_number:
                 raise ValueError("to_number is required (E.164, e.g. +15551234567)")
+            purpose = str(args.get("purpose") or "").strip()
+            if not purpose:
+                raise ValueError(
+                    "purpose is required so the live call opens with context — "
+                    "the voice runtime has no other way to know why it's calling"
+                )
             identity = _identity()
             # Reuse the same call-media WebSocket the gateway already serves and
             # registered on this number for inbound calls; otherwise derive it
@@ -426,11 +478,22 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
                     "no call-media WebSocket URL available — start the Inkbox "
                     "bridge gateway (it provisions the tunnel + call WS) first"
                 )
+            # Stash purpose/opening to a token file and tag the WS URL with
+            # ?context_token=<token>; the gateway loads it when the call connects
+            # so the live session opens with context (mirrors the Hermes plugin).
+            token = _write_call_context(
+                purpose=purpose,
+                opening_message=str(args.get("opening_message") or "").strip(),
+                context=str(args.get("context") or "").strip(),
+                to_number=to_number,
+            )
+            ws_url = _append_query_param(ws_url, "context_token", token)
             call = identity.place_call(to_number=to_number, client_websocket_url=ws_url)
             return {
                 "placed": True,
                 "id": str(getattr(call, "id", "")),
                 "to": to_number,
+                "context_token": token,
                 "status": _json_safe(getattr(call, "status", None)),
             }
 

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -502,12 +502,55 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         except Exception as exc:
             return _error(str(exc))
 
+    @tool(
+        "inkbox_list_calls",
+        "List recent phone calls on this agent's Inkbox number, newest first "
+        "(inbound + outbound). Each row has the call id, direction, status, the "
+        "remote number, and start/end times. Use this to find a call id to pass "
+        "to inkbox_get_call_transcript — e.g. to recap the last call, list calls "
+        "then read the newest one's transcript.",
+        {"limit": int, "offset": int},
+    )
+    async def inkbox_list_calls(args: Dict[str, Any]) -> Dict[str, Any]:
+        def _run():
+            return _identity().list_calls(
+                limit=int(args.get("limit") or 25),
+                offset=int(args.get("offset") or 0),
+            )
+
+        try:
+            return _result(await asyncio.to_thread(_run))
+        except Exception as exc:
+            return _error(str(exc))
+
+    @tool(
+        "inkbox_get_call_transcript",
+        "Fetch the transcript segments for one phone call by call_id, ordered "
+        "oldest-first. Each segment has party (remote=the other party, "
+        "local=this agent), text, and a timestamp. Returns an empty list if the "
+        "call recorded no speech. Get a call_id from inkbox_list_calls.",
+        {"call_id": str},
+    )
+    async def inkbox_get_call_transcript(args: Dict[str, Any]) -> Dict[str, Any]:
+        def _run():
+            call_id = str(args.get("call_id") or "").strip()
+            if not call_id:
+                raise ValueError("call_id is required (get one from inkbox_list_calls)")
+            return _identity().list_transcripts(call_id)
+
+        try:
+            return _result(await asyncio.to_thread(_run))
+        except Exception as exc:
+            return _error(str(exc))
+
     tools = [
         inkbox_whoami,
         inkbox_send_email,
         inkbox_send_sms,
         inkbox_send_imessage,
         inkbox_place_call,
+        inkbox_list_calls,
+        inkbox_get_call_transcript,
         inkbox_list_text_conversations,
         inkbox_get_text_conversation,
         inkbox_list_imessage_conversations,
@@ -525,6 +568,8 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         "mcp__inkbox__inkbox_send_sms",
         "mcp__inkbox__inkbox_send_imessage",
         "mcp__inkbox__inkbox_place_call",
+        "mcp__inkbox__inkbox_list_calls",
+        "mcp__inkbox__inkbox_get_call_transcript",
         "mcp__inkbox__inkbox_list_text_conversations",
         "mcp__inkbox__inkbox_get_text_conversation",
         "mcp__inkbox__inkbox_list_imessage_conversations",

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -21,6 +21,11 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
     from media import file_to_email_attachment
 
 try:
+    from .config import INKBOX_WS_PATH
+except ImportError:  # pragma: no cover - direct local import/test fallback
+    from config import INKBOX_WS_PATH
+
+try:
     from claude_agent_sdk import create_sdk_mcp_server, tool
 
     CLAUDE_SDK_AVAILABLE = True
@@ -391,11 +396,55 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         except Exception as exc:
             return _error(str(exc))
 
+    @tool(
+        "inkbox_place_call",
+        "Place an outbound phone call from this agent's Inkbox number. The call's "
+        "audio bridges to this agent over the running bridge gateway's call-media "
+        "WebSocket, so the agent talks the call live (Inkbox STT/TTS, or the "
+        "OpenAI Realtime path when enabled). Requires the bridge gateway to be "
+        "running. Pass to_number in E.164, e.g. +15551234567.",
+        {"to_number": str},
+    )
+    async def inkbox_place_call(args: Dict[str, Any]) -> Dict[str, Any]:
+        def _run():
+            to_number = str(args.get("to_number") or "").strip()
+            if not to_number:
+                raise ValueError("to_number is required (E.164, e.g. +15551234567)")
+            identity = _identity()
+            # Reuse the same call-media WebSocket the gateway already serves and
+            # registered on this number for inbound calls; otherwise derive it
+            # from the identity's tunnel host.
+            phone = identity.phone_number
+            ws_url = str(getattr(phone, "client_websocket_url", "") or "").strip()
+            if not ws_url:
+                tunnel = getattr(identity, "tunnel", None)
+                host = str(getattr(tunnel, "public_host", "") or "").strip()
+                if host:
+                    ws_url = f"wss://{host}{INKBOX_WS_PATH}"
+            if not ws_url:
+                raise RuntimeError(
+                    "no call-media WebSocket URL available — start the Inkbox "
+                    "bridge gateway (it provisions the tunnel + call WS) first"
+                )
+            call = identity.place_call(to_number=to_number, client_websocket_url=ws_url)
+            return {
+                "placed": True,
+                "id": str(getattr(call, "id", "")),
+                "to": to_number,
+                "status": _json_safe(getattr(call, "status", None)),
+            }
+
+        try:
+            return _result(await asyncio.to_thread(_run))
+        except Exception as exc:
+            return _error(str(exc))
+
     tools = [
         inkbox_whoami,
         inkbox_send_email,
         inkbox_send_sms,
         inkbox_send_imessage,
+        inkbox_place_call,
         inkbox_list_text_conversations,
         inkbox_get_text_conversation,
         inkbox_list_imessage_conversations,
@@ -412,6 +461,7 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         "mcp__inkbox__inkbox_send_email",
         "mcp__inkbox__inkbox_send_sms",
         "mcp__inkbox__inkbox_send_imessage",
+        "mcp__inkbox__inkbox_place_call",
         "mcp__inkbox__inkbox_list_text_conversations",
         "mcp__inkbox__inkbox_get_text_conversation",
         "mcp__inkbox__inkbox_list_imessage_conversations",

--- a/tests/test_gateway_call_ws.py
+++ b/tests/test_gateway_call_ws.py
@@ -30,6 +30,7 @@ class _FakeWS:
 class _FakeRequest:
     def __init__(self):
         self.headers = {}  # no X-Call-Context; signature check is off
+        self.query = {}  # no context_token; inbound (no outbound place-call ctx)
 
 
 def test_call_ws_declares_inkbox_stt_tts_headers(monkeypatch):

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 
+import aiohttp
+
 from inkbox_claude import realtime
 from inkbox_claude.realtime import (
     CONSULT_TOOL_NAME,
@@ -14,6 +16,7 @@ from inkbox_claude.realtime import (
     _BridgeState,
     _dispatch_post_call,
     _dispatch_tool_call,
+    _openai_to_inkbox_pump,
     _send_session_update,
     build_realtime_instructions,
 )
@@ -267,3 +270,53 @@ def test_post_call_dispatch_reflects_when_no_actions():
 
     asyncio.run(_dispatch_post_call(state, on_actions, on_ended))
     assert seen["transcript"] == [("agent", "bye")]
+
+
+class _FakeOpenAIWS:
+    """Async-iterates a fixed list of OpenAI frames as WS TEXT messages."""
+
+    def __init__(self, frames):
+        self._msgs = [
+            type("Msg", (), {"type": aiohttp.WSMsgType.TEXT, "data": json.dumps(f)})()
+            for f in frames
+        ]
+
+    def __aiter__(self):
+        async def gen():
+            for m in self._msgs:
+                yield m
+        return gen()
+
+
+def test_realtime_transcripts_are_mirrored_into_inkbox():
+    # Raw-media realtime means Inkbox does no STT; the pump must relay each
+    # finalized turn back as a `transcript` event so the call record fills in.
+    openai = _FakeOpenAIWS([
+        {"type": "conversation.item.input_audio_transcription.completed",
+         "transcript": "hey can you check the build"},
+        {"type": "response.output_audio_transcript.done",
+         "transcript": "sure, the build is green"},
+    ])
+    ink = _FakeInkboxWS()
+    state = _BridgeState()
+    state.stream_id = "s1"
+
+    asyncio.run(_openai_to_inkbox_pump(
+        openai_ws=openai,
+        inkbox_ws=ink,
+        state=state,
+        config=RealtimeConfig(api_key="sk-x"),
+        meta=_meta(),
+        on_agent_consult=lambda q, t: (_ for _ in ()).throw(AssertionError("no consult")),
+    ))
+
+    transcripts = [f for f in ink.sent if f.get("event") == "transcript"]
+    assert transcripts == [
+        {"event": "transcript", "party": "remote", "text": "hey can you check the build", "is_final": True},
+        {"event": "transcript", "party": "local", "text": "sure, the build is green", "is_final": True},
+    ]
+    # And still collected in-memory for the post-call reflection.
+    assert state.transcript == [
+        ("caller", "hey can you check the build"),
+        ("agent", "sure, the build is green"),
+    ]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,107 @@
+import asyncio
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+
+import mcp.types as mt
+import pytest
+
+from inkbox_claude import tools as tools_mod
+
+if not tools_mod.CLAUDE_SDK_AVAILABLE:  # pragma: no cover - sdk is a hard dep here
+    pytest.skip("claude-agent-sdk not installed", allow_module_level=True)
+
+
+# Mirror the SDK shapes as dataclasses so _json_safe serializes them to dicts.
+@dataclass
+class _FakeCall:
+    direction: str
+    id: uuid.UUID = field(default_factory=uuid.uuid4)
+    local_phone_number: str = "+16614031457"
+    remote_phone_number: str = "+15551112222"
+    status: str = "completed"
+    started_at: datetime = datetime(2026, 6, 18, 4, 0, 0)
+    ended_at: datetime = datetime(2026, 6, 18, 4, 1, 0)
+
+
+@dataclass
+class _FakeTranscript:
+    party: str
+    text: str
+    seq: int
+    id: uuid.UUID = field(default_factory=uuid.uuid4)
+    ts_ms: int = 0
+
+
+class _FakeIdentity:
+    def __init__(self):
+        self.list_calls_kwargs = None
+        self.transcript_call_id = None
+
+    def list_calls(self, **kwargs):
+        self.list_calls_kwargs = kwargs
+        return [_FakeCall("inbound"), _FakeCall("outbound")]
+
+    def list_transcripts(self, call_id):
+        self.transcript_call_id = call_id
+        return [
+            _FakeTranscript("remote", "hey can you check the build", 1),
+            _FakeTranscript("local", "sure, it's green", 2),
+        ]
+
+
+class _FakeClient:
+    def __init__(self):
+        self.identity = _FakeIdentity()
+
+    def get_identity(self, handle):
+        return self.identity
+
+
+def _call(server, name, arguments):
+    """Invoke a tool by name through the MCP server and return parsed JSON."""
+    handler = server["instance"].request_handlers[mt.CallToolRequest]
+    req = mt.CallToolRequest(
+        method="tools/call",
+        params=mt.CallToolRequestParams(name=name, arguments=arguments),
+    )
+    result = asyncio.run(handler(req)).root
+    return json.loads(result.content[0].text)
+
+
+def test_call_read_tools_are_registered():
+    server, names = tools_mod.build_inkbox_mcp_server(_FakeClient(), "claude-code-dima")
+    assert "mcp__inkbox__inkbox_list_calls" in names
+    assert "mcp__inkbox__inkbox_get_call_transcript" in names
+
+
+def test_list_calls_passes_pagination_and_returns_rows():
+    client = _FakeClient()
+    server, _ = tools_mod.build_inkbox_mcp_server(client, "claude-code-dima")
+
+    data = _call(server, "inkbox_list_calls", {"limit": 5, "offset": 10})
+
+    assert client.identity.list_calls_kwargs == {"limit": 5, "offset": 10}
+    assert [row["direction"] for row in data] == ["inbound", "outbound"]
+
+
+def test_get_call_transcript_returns_segments():
+    client = _FakeClient()
+    server, _ = tools_mod.build_inkbox_mcp_server(client, "claude-code-dima")
+
+    data = _call(server, "inkbox_get_call_transcript", {"call_id": "call-123"})
+
+    assert client.identity.transcript_call_id == "call-123"
+    assert [(seg["party"], seg["text"]) for seg in data] == [
+        ("remote", "hey can you check the build"),
+        ("local", "sure, it's green"),
+    ]
+
+
+def test_get_call_transcript_requires_call_id():
+    server, _ = tools_mod.build_inkbox_mcp_server(_FakeClient(), "claude-code-dima")
+
+    data = _call(server, "inkbox_get_call_transcript", {"call_id": "  "})
+
+    assert "call_id is required" in data["error"]


### PR DESCRIPTION
Adds outbound calling to the bridge, with full call context (the Hermes way).

**`inkbox_place_call`** — dials an E.164 number and bridges its audio to the gateway's existing `/phone/media/ws` (the same socket used for inbound calls), so the agent talks the call live (Inkbox STT/TTS, or the Realtime path when enabled).

**Call context (purpose/opening).** `place_call` takes `purpose` (required), `opening_message`, and `context`. It stashes them to a token file and appends `?context_token=<token>` to the call WS URL; the gateway loads the token when the call connects and threads the purpose into:
- the Realtime **instructions** + opening line (so the model knows *why* it is calling instead of opening cold), and
- the Inkbox STT/TTS **opener**.

Mirrors the Hermes plugin's `inkbox_call_contexts` handoff. Without it, an outbound Realtime call had no idea why it was placed.

- Reuses the number's registered `client_websocket_url`; falls back to deriving `wss://<tunnel public_host>/phone/media/ws`.
- Errors clearly when the bridge gateway is not running.
- Registered as `mcp__inkbox__inkbox_place_call`.