### PR TITLE
fix(realtime): end calls with stop event, not hangup

### DIFF
--- a/inkbox_claude/realtime.py
+++ b/inkbox_claude/realtime.py
@@ -870,11 +870,12 @@ async def _handle_hang_up(
 
     # Second attempt within the window → perform the real hangup.
     reason = (args.get("reason") or "").strip()
-    hangup_frame: Dict[str, Any] = {"event": "hangup"}
+    # Inkbox ends the call on a `stop` event; `hangup` is ignored server-side.
+    stop_frame: Dict[str, Any] = {"event": "stop"}
     if reason:
-        hangup_frame["reason"] = reason
+        stop_frame["reason"] = reason
     if state.stream_id:
-        hangup_frame["stream_id"] = state.stream_id
+        stop_frame["stream_id"] = state.stream_id
     # Don't ask the model to speak again — we're ending the call.
     await _submit_tool_result(
         openai_ws, call_id,
@@ -884,7 +885,7 @@ async def _handle_hang_up(
     try:
         # Let the spoken goodbye land before we drop the carrier leg.
         await asyncio.sleep(HANGUP_CLOSE_DELAY_S)
-        await inkbox_ws.send_str(json.dumps(hangup_frame))
+        await inkbox_ws.send_str(json.dumps(stop_frame))
     except Exception as exc:
         logger.debug("[realtime] hangup frame send failed: %s", exc)
     state.closed = True

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -224,16 +224,16 @@ def test_hangup_is_two_step(monkeypatch):
     ws, ink, state = _FakeWS(), _FakeInkboxWS(), _BridgeState()
     state.stream_id = "s1"
 
-    # First call: arm + ask for goodbye, no hangup frame yet.
+    # First call: arm + ask for goodbye, no stop frame yet.
     _dispatch(ws, HANG_UP_CALL_TOOL_NAME, {}, state, inkbox_ws=ink)
     assert _last_output(ws)["status"] == "confirm_goodbye"
     assert state.hangup_armed_at is not None
-    assert not any(f.get("event") == "hangup" for f in ink.sent)
+    assert not any(f.get("event") == "stop" for f in ink.sent)
 
-    # Second call: real hangup frame to Inkbox + sockets closed.
+    # Second call: real stop frame to Inkbox + sockets closed.
     _dispatch(ws, HANG_UP_CALL_TOOL_NAME, {"reason": "done"}, state, inkbox_ws=ink)
-    hangup = next(f for f in ink.sent if f.get("event") == "hangup")
-    assert hangup["reason"] == "done" and hangup["stream_id"] == "s1"
+    stop = next(f for f in ink.sent if f.get("event") == "stop")
+    assert stop["reason"] == "done" and stop["stream_id"] == "s1"
     assert ink.closed is True and state.closed is True
 
 


### PR DESCRIPTION
The realtime voice bridge sent `{"event":"hangup"}` to end a call, but Inkbox only releases the carrier leg on a `stop` event (it sets `hangup_reason=local` and fires `CLIENT_HANGUP`). A `hangup` event is ignored server-side, so the agent went silent while the call stayed connected.

Switches the hangup path to send `{"event":"stop"}` (still carrying `reason`/`stream_id`) and updates the bridge tests to match.

Part of a 4-repo sweep fixing the same bug across the Inkbox realtime harnesses (claude-code-plugin, codex-plugin, hermes-agent-plugin, openclaw-plugin).