### PR TITLE
feat(realtime): standardize consult tool as `consult_agent`, 300s timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ These match only when the whole message is exactly the command, so "please /clea
 Calls have two modes, chosen per call:
 
 - **OpenAI Realtime** (when configured): the bridge pre-opens an OpenAI Realtime session and accepts the call in raw-media mode, so a natural, low-latency voice handles the conversation. It runs the call itself and has these tools:
-  - `consult_claude_code` — do real work *now* in the project; runs in the *same* contact-keyed session as your SMS/iMessage and its answer is spoken back.
+  - `consult_agent` — do real work *now* in the project; runs in the *same* contact-keyed session as your SMS/iMessage and its answer is spoken back.
   - `register_post_call_action` / `edit_post_call_action` / `delete_post_call_action` — queue, change, or cancel work to run *after* you hang up.
   - `hang_up_call` — two-step (say goodbye, then end the call).
 
@@ -219,7 +219,7 @@ The agent reaches you (or third parties) through an in-process MCP server:
 - `inkbox_lookup_contact` · `inkbox_list_contacts` — resolve and find address-book contacts (reverse-lookup by email/phone, or free-text search by name/company).
 - `inkbox_create_contact` · `inkbox_update_contact` · `inkbox_delete_contact` — save, edit, and remove contacts. Reads and writes are filtered server-side to what this identity may see.
 
-On a live call, the OpenAI Realtime voice agent additionally gets `consult_claude_code`, `register_post_call_action` / `edit_post_call_action` / `delete_post_call_action`, and `hang_up_call` — see [Voice](#voice).
+On a live call, the OpenAI Realtime voice agent additionally gets `consult_agent`, `register_post_call_action` / `edit_post_call_action` / `delete_post_call_action`, and `hang_up_call` — see [Voice](#voice).
 
 ## Smoke test
 

--- a/inkbox_claude/realtime.py
+++ b/inkbox_claude/realtime.py
@@ -12,7 +12,7 @@ two pumps for the call's duration:
   model's own voice is what the caller hears.
 
 The Realtime model runs the spoken conversation itself. It only reaches
-back to Claude Code through the single ``consult_claude_code`` tool — and
+back to Claude Code through the single ``consult_agent`` tool — and
 only when the caller asks for real work. The consult runs in the caller's
 shared :class:`~inkbox_claude.sessions.ContactSession` and its text answer
 is handed back to the model, which speaks it. If OpenAI can't be reached
@@ -50,13 +50,13 @@ DEFAULT_VOICE = "cedar"
 AUDIO_FORMAT_TELEPHONY = {"type": "audio/pcmu"}
 INPUT_TRANSCRIPTION_MODEL = "gpt-4o-mini-transcribe"
 
-CONSULT_TOOL_NAME = "consult_claude_code"
+CONSULT_TOOL_NAME = "consult_agent"
 POST_CALL_ACTION_TOOL_NAME = "register_post_call_action"
 EDIT_POST_CALL_ACTION_TOOL_NAME = "edit_post_call_action"
 DELETE_POST_CALL_ACTION_TOOL_NAME = "delete_post_call_action"
 HANG_UP_CALL_TOOL_NAME = "hang_up_call"
 
-DEFAULT_CONSULT_TIMEOUT_S = 120.0
+DEFAULT_CONSULT_TIMEOUT_S = 300.0
 DEFAULT_CONNECT_TIMEOUT_S = 8.0
 # hang_up_call is two-step: a second call within this window actually hangs up.
 HANGUP_CONFIRM_WINDOW_S = 60.0
@@ -575,7 +575,7 @@ async def _openai_to_inkbox_pump(
     meta: RealtimeCallMeta,
     on_agent_consult: AgentConsultCallback,
 ) -> None:
-    """Forward model audio to Inkbox and handle ``consult_claude_code`` calls."""
+    """Forward model audio to Inkbox and handle ``consult_agent`` calls."""
     # Function-call accumulation keyed by item_id. The name arrives on
     # output_item.added; args stream via ...arguments.delta and finalize on
     # ...arguments.done. Dedupe by call_id so a call dispatches at most once.


### PR DESCRIPTION
Renames the in-call consult tool from the host-specific `consult_claude_code` to the standardized `consult_agent`, and raises the consult timeout from 120s to 300s.

Part of a 4-repo sweep standardizing the realtime consult tool across the Inkbox voice harnesses (claude-code-plugin, codex-plugin, hermes-agent-plugin, zeroclaw): one tool name (`consult_agent`) and a uniform 300s timeout. (OpenClaw is excluded — its consult tool name and timeout are owned by the OpenClaw host SDK, not the plugin.)