### PR TITLE
feat(setup): require a webhook signing key (no more unsigned fallback)

### DIFF
--- a/inkbox_claude/setup_wizard.py
+++ b/inkbox_claude/setup_wizard.py
@@ -431,6 +431,9 @@ def _enum_value(value: Any) -> str:
 def _setup_signing_key(api_key: str, base_url: str, Inkbox: Any) -> None:
     """Configure (or mint) the HMAC key used to verify inbound webhooks.
 
+    A signing key is mandatory: setup aborts with ``SystemExit`` if one is
+    neither pasted nor minted, so the bridge never runs unsigned.
+
     Args:
         api_key (str): Agent-scoped Inkbox API key.
         base_url (str): Inkbox API base URL.
@@ -444,39 +447,38 @@ def _setup_signing_key(api_key: str, base_url: str, Inkbox: Any) -> None:
     print_info("  Inkbox signs outbound webhooks with an HMAC over the body.")
     print_info("  Without the matching key, the bridge cannot verify inbound Inkbox traffic.")
 
+    print_info("  A signing key is required to continue.")
+
     has_key = prompt_yes_no("  Do you already have an Inkbox signing key?", False)
     if has_key:
         key = prompt("  Paste your Inkbox signing key", password=True).strip()
-        if not key:
-            print_warning("  No key entered; leaving signature verification off.")
-            _save("INKBOX_REQUIRE_SIGNATURE", "false")
+        if key:
+            _save("INKBOX_SIGNING_KEY", key)
+            _save("INKBOX_REQUIRE_SIGNATURE", "true")
+            print_success("  Saved signing key. Signature verification enabled.")
             return
-        _save("INKBOX_SIGNING_KEY", key)
-        _save("INKBOX_REQUIRE_SIGNATURE", "true")
-        print_success("  Saved signing key. Signature verification enabled.")
-        return
+        # An empty paste can't satisfy the requirement — fall through to mint one.
+        print_warning("  No key entered; a signing key is required, so we'll mint one now.")
 
     print_info("  Minting a new key here rotates any existing key for your org.")
     print_info("  Any other gateway using the old key will fail verification until updated.")
     if not prompt_yes_no("  Generate a new signing key now?", True):
-        print_info("  Skipping; bridge will accept unsigned webhooks.")
-        print_info("  Generate later in the Inkbox console.")
-        _save("INKBOX_REQUIRE_SIGNATURE", "false")
-        return
+        print_error("  A signing key is required; cannot complete setup without one.")
+        print_info("  Re-run setup and paste an existing key, or allow key generation.")
+        raise SystemExit(1)
 
     try:
         new_key = Inkbox(api_key=api_key, base_url=base_url).create_signing_key()
     except Exception as exc:
         print_error(f"  Failed to create signing key: {exc}")
-        print_info("  Leaving signature verification off; retry later in the Inkbox console.")
-        _save("INKBOX_REQUIRE_SIGNATURE", "false")
-        return
+        print_error("  A signing key is required; aborting setup. Retry, or paste an existing key.")
+        raise SystemExit(1)
 
     signing_key = str(getattr(new_key, "signing_key", "") or "")
     if not signing_key:
         print_error("  Signing-key response did not include signing_key.")
-        _save("INKBOX_REQUIRE_SIGNATURE", "false")
-        return
+        print_error("  A signing key is required; aborting setup.")
+        raise SystemExit(1)
     _save("INKBOX_SIGNING_KEY", signing_key)
     _save("INKBOX_REQUIRE_SIGNATURE", "true")
     created_at = getattr(new_key, "created_at", None)

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,5 +1,7 @@
 import types
 
+import pytest
+
 from inkbox_claude import setup_wizard
 
 
@@ -158,16 +160,16 @@ def test_setup_signing_key_mints_new(tmp_path, monkeypatch):
     assert "INKBOX_REQUIRE_SIGNATURE=true" in text
 
 
-def test_setup_signing_key_decline_disables_signature(tmp_path, monkeypatch):
+def test_setup_signing_key_decline_aborts(tmp_path, monkeypatch):
     env_file = tmp_path / ".env"
     monkeypatch.setenv("INKBOX_CLAUDE_ENV_FILE", str(env_file))
-    # "have a key?" -> no; "generate now?" -> no.
+    # "have a key?" -> no; "generate now?" -> no. A signing key is required, so
+    # declining must abort setup rather than disable signature verification.
     answers = iter([False, False])
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_a, **_k: next(answers))
 
-    setup_wizard._setup_signing_key("ApiKey_x", "https://inkbox.ai", lambda **_k: None)
-
-    assert "INKBOX_REQUIRE_SIGNATURE=false" in env_file.read_text()
+    with pytest.raises(SystemExit):
+        setup_wizard._setup_signing_key("ApiKey_x", "https://inkbox.ai", lambda **_k: None)
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Makes the webhook signing key mandatory in the setup wizard. You must paste or mint one; any skip or failure now aborts setup (`SystemExit`) instead of saving `INKBOX_REQUIRE_SIGNATURE=false` and running with unsigned inbound webhooks.

Brings claude-code-plugin to parity with openclaw-plugin, which already requires a signing key. Part of a 3-repo hardening sweep (claude-code-plugin, codex-plugin, hermes-agent-plugin).