### PR TITLE
feat: tag claude-code harness on signup + plugin-setup prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      # The inkbox SDK is intentionally not installed here: the tests mock it,
-      # and the pinned inkbox>=0.4.10 (with the harness= signup kwarg) isn't on
-      # PyPI yet. claude-agent-sdk is needed for the gateway-health tests.
+      # inkbox is mocked in the tests, so install only what they import.
       - name: Install test deps
         run: pip install pytest aiohttp segno claude-agent-sdk
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # The inkbox SDK is intentionally not installed here: the tests mock it,
+      # and the pinned inkbox>=0.4.10 (with the harness= signup kwarg) isn't on
+      # PyPI yet. claude-agent-sdk is needed for the gateway-health tests.
+      - name: Install test deps
+        run: pip install pytest aiohttp segno claude-agent-sdk
+
+      - name: Test
+        run: pytest -q

--- a/inkbox_claude/doctor.py
+++ b/inkbox_claude/doctor.py
@@ -33,7 +33,7 @@ def run_doctor() -> List[Tuple[str, bool, str]]:
         import inkbox  # noqa: F401
         checks.append(("inkbox SDK", True, "installed"))
     except ImportError:
-        checks.append(("inkbox SDK", False, "pip install 'inkbox>=0.4.9'"))
+        checks.append(("inkbox SDK", False, "pip install 'inkbox>=0.4.10'"))
 
     try:
         import claude_agent_sdk  # noqa: F401

--- a/inkbox_claude/doctor.py
+++ b/inkbox_claude/doctor.py
@@ -33,7 +33,7 @@ def run_doctor() -> List[Tuple[str, bool, str]]:
         import inkbox  # noqa: F401
         checks.append(("inkbox SDK", True, "installed"))
     except ImportError:
-        checks.append(("inkbox SDK", False, "pip install 'inkbox>=0.4.7'"))
+        checks.append(("inkbox SDK", False, "pip install 'inkbox>=0.4.9'"))
 
     try:
         import claude_agent_sdk  # noqa: F401

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -211,7 +211,7 @@ class InkboxGateway:
         if not AIOHTTP_AVAILABLE:
             raise RuntimeError("aiohttp is not installed; run: pip install aiohttp")
         if not INKBOX_AVAILABLE:
-            raise RuntimeError("inkbox SDK is not installed; run: pip install 'inkbox>=0.4.7'")
+            raise RuntimeError("inkbox SDK is not installed; run: pip install 'inkbox>=0.4.9'")
         if not self.cfg.api_key or not self.cfg.identity:
             raise RuntimeError("INKBOX_API_KEY and INKBOX_IDENTITY must be set (see README)")
 

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -211,7 +211,7 @@ class InkboxGateway:
         if not AIOHTTP_AVAILABLE:
             raise RuntimeError("aiohttp is not installed; run: pip install aiohttp")
         if not INKBOX_AVAILABLE:
-            raise RuntimeError("inkbox SDK is not installed; run: pip install 'inkbox>=0.4.9'")
+            raise RuntimeError("inkbox SDK is not installed; run: pip install 'inkbox>=0.4.10'")
         if not self.cfg.api_key or not self.cfg.identity:
             raise RuntimeError("INKBOX_API_KEY and INKBOX_IDENTITY must be set (see README)")
 

--- a/inkbox_claude/prompts.py
+++ b/inkbox_claude/prompts.py
@@ -54,6 +54,13 @@ inkbox_send_imessage, ...) to reach the human or third parties
 proactively — e.g. "email me the full report" or a cron-style ping.
 Replies on the channel you were messaged on are sent automatically;
 only use these tools for a *different* channel or recipient.
+
+# Setting up this plugin
+
+If you self-signed-up to Inkbox but this plugin isn't yet configured in
+your runtime, ask the human for permission before setting it up — the
+plugin wires native messaging channels directly into your runtime, so
+that's the human's call to make, not yours.
 """.strip()
 
 

--- a/inkbox_claude/prompts.py
+++ b/inkbox_claude/prompts.py
@@ -54,14 +54,6 @@ inkbox_send_imessage, ...) to reach the human or third parties
 proactively — e.g. "email me the full report" or a cron-style ping.
 Replies on the channel you were messaged on are sent automatically;
 only use these tools for a *different* channel or recipient.
-
-# Setting up the Inkbox plugin
-
-If you self-signed up to Inkbox but this plugin isn't configured in your
-runtime yet, ask your human for permission before you start — once they
-approve, you can set it up yourself. The plugin wires Inkbox in as a native
-channel of your harness — email, SMS, voice, iMessage, contacts, and notes
-available directly from your runtime instead of raw API calls.
 """.strip()
 
 

--- a/inkbox_claude/prompts.py
+++ b/inkbox_claude/prompts.py
@@ -55,12 +55,13 @@ proactively — e.g. "email me the full report" or a cron-style ping.
 Replies on the channel you were messaged on are sent automatically;
 only use these tools for a *different* channel or recipient.
 
-# Setting up this plugin
+# Setting up the Inkbox plugin
 
-If you self-signed-up to Inkbox but this plugin isn't yet configured in
-your runtime, ask the human for permission before setting it up — the
-plugin wires native messaging channels directly into your runtime, so
-that's the human's call to make, not yours.
+If you self-signed up to Inkbox but this plugin isn't configured in your
+runtime yet, ask the human for permission before setting it up — it's the
+human's call to make, not yours. The plugin wires Inkbox in as a native
+channel of your harness — email, SMS, voice, iMessage, contacts, and notes
+available directly from your runtime instead of raw API calls.
 """.strip()
 
 

--- a/inkbox_claude/prompts.py
+++ b/inkbox_claude/prompts.py
@@ -58,8 +58,8 @@ only use these tools for a *different* channel or recipient.
 # Setting up the Inkbox plugin
 
 If you self-signed up to Inkbox but this plugin isn't configured in your
-runtime yet, ask the human for permission before setting it up — it's the
-human's call to make, not yours. The plugin wires Inkbox in as a native
+runtime yet, don't set it up on your own — confirm with your human and do
+it together before you start. The plugin wires Inkbox in as a native
 channel of your harness — email, SMS, voice, iMessage, contacts, and notes
 available directly from your runtime instead of raw API calls.
 """.strip()

--- a/inkbox_claude/prompts.py
+++ b/inkbox_claude/prompts.py
@@ -58,8 +58,8 @@ only use these tools for a *different* channel or recipient.
 # Setting up the Inkbox plugin
 
 If you self-signed up to Inkbox but this plugin isn't configured in your
-runtime yet, don't set it up on your own — confirm with your human and do
-it together before you start. The plugin wires Inkbox in as a native
+runtime yet, ask your human for permission before you start — once they
+approve, you can set it up yourself. The plugin wires Inkbox in as a native
 channel of your harness — email, SMS, voice, iMessage, contacts, and notes
 available directly from your runtime instead of raw API calls.
 """.strip()

--- a/inkbox_claude/setup_wizard.py
+++ b/inkbox_claude/setup_wizard.py
@@ -36,8 +36,6 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
 
 # Packages the wizard itself needs to talk to Inkbox during setup. The
 # gateway's other dependency (claude-agent-sdk) is checked by doctor.
-# The harness= kwarg on Inkbox.signup landed in inkbox 0.4.10; older SDKs
-# raise TypeError before the request ever reaches the server.
 INKBOX_MIN_VERSION = (0, 4, 10)
 INKBOX_REQUIREMENTS = ("inkbox>=0.4.10", "aiohttp>=3.9")
 _BRACKETED_PASTE_PATTERN = re.compile(r"\x1b\[\s*200~|\x1b\[\s*201~")
@@ -370,9 +368,6 @@ def _load_inkbox_symbols() -> dict[str, Any]:
 
 
 def _inkbox_version_ok() -> bool:
-    # Guard against an already-installed but too-old SDK that predates the
-    # harness= signup kwarg. Prefer importlib.metadata + packaging; fall back
-    # to a tuple comparison parsed off the version string.
     try:
         from importlib.metadata import version
 
@@ -399,8 +394,6 @@ def _ensure_inkbox_sdk() -> dict[str, Any] | None:
     """
     try:
         symbols = _load_inkbox_symbols()
-        # A too-old SDK imports fine but lacks the harness= signup kwarg —
-        # treat it like an unsatisfied requirement and route to the upgrade path.
         if _inkbox_version_ok():
             return symbols
         first_error = (
@@ -1142,7 +1135,7 @@ def _self_signup_flow(base_url: str, Inkbox: Any, InkboxAPIError: Any) -> tuple[
                 note_to_human=note,
                 agent_handle=handle,
                 base_url=base_url,
-                harness="claude-code",  # tag which harness self-signed-up
+                harness="claude-code",
             )
             break
         except InkboxAPIError as exc:

--- a/inkbox_claude/setup_wizard.py
+++ b/inkbox_claude/setup_wizard.py
@@ -36,10 +36,10 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
 
 # Packages the wizard itself needs to talk to Inkbox during setup. The
 # gateway's other dependency (claude-agent-sdk) is checked by doctor.
-# The harness= kwarg on Inkbox.signup landed in inkbox 0.4.9; older SDKs
+# The harness= kwarg on Inkbox.signup landed in inkbox 0.4.10; older SDKs
 # raise TypeError before the request ever reaches the server.
-INKBOX_MIN_VERSION = (0, 4, 9)
-INKBOX_REQUIREMENTS = ("inkbox>=0.4.9", "aiohttp>=3.9")
+INKBOX_MIN_VERSION = (0, 4, 10)
+INKBOX_REQUIREMENTS = ("inkbox>=0.4.10", "aiohttp>=3.9")
 _BRACKETED_PASTE_PATTERN = re.compile(r"\x1b\[\s*200~|\x1b\[\s*201~")
 
 # Bundled avatar attached to the agent's Inkbox contact card during setup.

--- a/inkbox_claude/setup_wizard.py
+++ b/inkbox_claude/setup_wizard.py
@@ -1109,6 +1109,7 @@ def _self_signup_flow(base_url: str, Inkbox: Any, InkboxAPIError: Any) -> tuple[
                 note_to_human=note,
                 agent_handle=handle,
                 base_url=base_url,
+                harness="claude-code",  # tag which harness self-signed-up
             )
             break
         except InkboxAPIError as exc:

--- a/inkbox_claude/setup_wizard.py
+++ b/inkbox_claude/setup_wizard.py
@@ -36,7 +36,10 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
 
 # Packages the wizard itself needs to talk to Inkbox during setup. The
 # gateway's other dependency (claude-agent-sdk) is checked by doctor.
-INKBOX_REQUIREMENTS = ("inkbox>=0.4.7", "aiohttp>=3.9")
+# The harness= kwarg on Inkbox.signup landed in inkbox 0.4.9; older SDKs
+# raise TypeError before the request ever reaches the server.
+INKBOX_MIN_VERSION = (0, 4, 9)
+INKBOX_REQUIREMENTS = ("inkbox>=0.4.9", "aiohttp>=3.9")
 _BRACKETED_PASTE_PATTERN = re.compile(r"\x1b\[\s*200~|\x1b\[\s*201~")
 
 # Bundled avatar attached to the agent's Inkbox contact card during setup.
@@ -366,6 +369,28 @@ def _load_inkbox_symbols() -> dict[str, Any]:
     }
 
 
+def _inkbox_version_ok() -> bool:
+    # Guard against an already-installed but too-old SDK that predates the
+    # harness= signup kwarg. Prefer importlib.metadata + packaging; fall back
+    # to a tuple comparison parsed off the version string.
+    try:
+        from importlib.metadata import version
+
+        raw = version("inkbox")
+    except Exception:
+        return True  # can't tell — let the import/runtime path surface it
+    try:
+        from packaging.version import Version
+
+        return Version(raw) >= Version(".".join(str(p) for p in INKBOX_MIN_VERSION))
+    except Exception:
+        parts = []
+        for chunk in raw.split(".")[:3]:
+            digits = "".join(c for c in chunk if c.isdigit())
+            parts.append(int(digits) if digits else 0)
+        return tuple(parts) >= INKBOX_MIN_VERSION
+
+
 def _ensure_inkbox_sdk() -> dict[str, Any] | None:
     """Import the Inkbox SDK, offering to install it into this env if missing.
 
@@ -373,11 +398,19 @@ def _ensure_inkbox_sdk() -> dict[str, Any] | None:
         dict[str, Any] | None: SDK symbols on success, None if unavailable.
     """
     try:
-        return _load_inkbox_symbols()
+        symbols = _load_inkbox_symbols()
+        # A too-old SDK imports fine but lacks the harness= signup kwarg —
+        # treat it like an unsatisfied requirement and route to the upgrade path.
+        if _inkbox_version_ok():
+            return symbols
+        first_error = (
+            "the installed inkbox SDK is older than "
+            f"{'.'.join(str(p) for p in INKBOX_MIN_VERSION)}"
+        )
     except Exception as exc:
         first_error = exc
 
-    print_warning("The Python Inkbox SDK is not available in this environment.")
+    print_warning("The Python Inkbox SDK is missing or too old in this environment.")
     print_info("The setup command is running under:")
     print_info(f"  {sys.executable}")
     print_info("Install or upgrade the SDK in that exact environment with:")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Inkbox bridge for Claude Code — talk to your coding agent over 
 requires-python = ">=3.10"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.4.7",
+  "inkbox>=0.4.9",
   "claude-agent-sdk>=0.1.0",
   "segno>=1.5",  # terminal QR codes for the iMessage connect step
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Inkbox bridge for Claude Code — talk to your coding agent over 
 requires-python = ">=3.10"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.4.9",
+  "inkbox>=0.4.10",
   "claude-agent-sdk>=0.1.0",
   "segno>=1.5",  # terminal QR codes for the iMessage connect step
 ]

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -83,7 +83,7 @@ def test_install_command_prefers_uv_when_available(monkeypatch):
         "install",
         "--python",
         "/tmp/venv/bin/python",
-        "inkbox>=0.4.9",
+        "inkbox>=0.4.10",
         "aiohttp>=3.9",
     ]]
 
@@ -93,10 +93,10 @@ def test_install_command_falls_back_to_pip_and_ensurepip(monkeypatch):
     monkeypatch.setattr(setup_wizard.shutil, "which", lambda _name: None)
 
     assert setup_wizard._install_commands() == [
-        [["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.9", "aiohttp>=3.9"]],
+        [["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.10", "aiohttp>=3.9"]],
         [
             ["/tmp/venv/bin/python", "-m", "ensurepip", "--upgrade"],
-            ["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.9", "aiohttp>=3.9"],
+            ["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.10", "aiohttp>=3.9"],
         ],
     ]
 
@@ -115,7 +115,7 @@ def test_missing_sdk_guidance_prints_interpreter(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "/tmp/venv/bin/python" in out
     assert "uv pip install --python" in out
-    assert "inkbox>=0.4.9" in out
+    assert "inkbox>=0.4.10" in out
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -83,7 +83,7 @@ def test_install_command_prefers_uv_when_available(monkeypatch):
         "install",
         "--python",
         "/tmp/venv/bin/python",
-        "inkbox>=0.4.7",
+        "inkbox>=0.4.9",
         "aiohttp>=3.9",
     ]]
 
@@ -93,10 +93,10 @@ def test_install_command_falls_back_to_pip_and_ensurepip(monkeypatch):
     monkeypatch.setattr(setup_wizard.shutil, "which", lambda _name: None)
 
     assert setup_wizard._install_commands() == [
-        [["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.7", "aiohttp>=3.9"]],
+        [["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.9", "aiohttp>=3.9"]],
         [
             ["/tmp/venv/bin/python", "-m", "ensurepip", "--upgrade"],
-            ["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.7", "aiohttp>=3.9"],
+            ["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.4.9", "aiohttp>=3.9"],
         ],
     ]
 
@@ -115,7 +115,7 @@ def test_missing_sdk_guidance_prints_interpreter(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "/tmp/venv/bin/python" in out
     assert "uv pip install --python" in out
-    assert "inkbox>=0.4.7" in out
+    assert "inkbox>=0.4.9" in out
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Tags this harness on self-signup and gives the in-session agent a heads-up about setting up the plugin.

## Changes
- `setup_wizard.py`: pass `harness="claude-code"` to `Inkbox.signup(...)` so the backend records which harness self-signed-up.
- `prompts.py`: add a short `CHANNEL_PROMPT` note telling the agent to ask the human for permission before configuring this plugin, since it wires native messaging channels into the runtime.

## Dependency
Depends on the Inkbox SDK gaining the optional `harness` parameter on `signup(...)` (coordinated PR). Passing it is forward-compatible.


## Related PRs (agent-signup `harness`)
- inkbox-ai/inkbox#79 — SDK (py/ts) + CLI + self-signup skill (adds the `harness` param this builds on)
- inkbox-ai/claude-code-plugin#17
- inkbox-ai/codex-plugin#5
- inkbox-ai/openclaw-plugin#20
- inkbox-ai/hermes-agent-plugin#19