### PR TITLE
Reject unknown API key subtypes in setup

### DIFF
--- a/inkbox_claude/setup_wizard.py
+++ b/inkbox_claude/setup_wizard.py
@@ -1356,9 +1356,9 @@ def _api_key_flow(
     if subtype == _enum_value(ADMIN_SCOPED):
         return _pick_admin_scoped(client, api_key, IdentityPhoneNumberCreateOptions, InkboxAPIError)
 
-    print_warning(f"  Unrecognized API-key subtype: {subtype!r}.")
-    print_info("  Falling back to list_identities().")
-    return _pick_admin_scoped(client, api_key, IdentityPhoneNumberCreateOptions, InkboxAPIError)
+    print_error(f"  Unsupported API-key subtype: {subtype!r}.")
+    print_info("  Use an admin-scoped or agent-scoped Inkbox API key.")
+    return None, "", False
 
 
 def _pick_agent_scoped(client: Any, api_key: str) -> tuple[Any | None, str, bool]:

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -119,6 +119,43 @@ def test_missing_sdk_guidance_prints_interpreter(monkeypatch, capsys):
 
 
 # ----------------------------------------------------------------------
+# API key scope handling
+# ----------------------------------------------------------------------
+
+
+def test_api_key_flow_rejects_unknown_auth_subtype(monkeypatch, capsys):
+    class FakeWhoamiApiKeyResponse:
+        auth_subtype = "future_scope"
+        organization_id = "org_123"
+
+    class FakeInkbox:
+        def __init__(self, **_kwargs):
+            pass
+
+        def whoami(self):
+            return FakeWhoamiApiKeyResponse()
+
+        def list_identities(self):
+            raise AssertionError("unknown subtypes must not fall back to identity listing")
+
+    monkeypatch.setattr(setup_wizard, "prompt", lambda *_args, **_kwargs: "ApiKey_test")
+
+    result = setup_wizard._api_key_flow(
+        "https://inkbox.ai",
+        FakeInkbox,
+        Exception,
+        FakeWhoamiApiKeyResponse,
+        "admin_scoped",
+        "agent_scoped_claimed",
+        "agent_scoped_unclaimed",
+        object,
+    )
+
+    assert result == (None, "", False)
+    assert "Unsupported API-key subtype" in capsys.readouterr().out
+
+
+# ----------------------------------------------------------------------
 # Project directory
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
Summary:
- Reject unsupported whoami auth subtypes during BYO API-key setup
- Stop falling back to admin identity listing for unknown future scopes
- Add a setup wizard regression test

Testing:
- python3 -m pytest tests/test_setup_wizard.py