### PR TITLE
Pin inkbox SDK <0.4.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Inkbox bridge for Claude Code — talk to your coding agent over 
 requires-python = ">=3.10"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.4.10",
+  "inkbox>=0.4.10,<0.4.15",
   "claude-agent-sdk>=0.1.0",
   "segno>=1.5",  # terminal QR codes for the iMessage connect step
 ]


### PR DESCRIPTION
Pins the Inkbox SDK below 0.4.15. That release reworks the phone/call surface around agent identities and removes the number-scoped call/transcript methods (inkbox-ai/inkbox#90), so it is source-breaking for open-ended `>=` / `^` ranges. This ceiling keeps installs and CI on 0.4.14 until the plugin migrates to the new surface (follow-up).