### PR TITLE
Adopt inkbox SDK 0.4.15 identity-centered phone API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "claude-code-plugin"
-version = "0.1.0"
+version = "0.1.1"
 description = "Inkbox bridge for Claude Code — talk to your coding agent over email, SMS, iMessage, and voice"
 requires-python = ">=3.10"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.4.10,<0.4.15",
+  "inkbox>=0.4.15",
   "claude-agent-sdk>=0.1.0",
   "segno>=1.5",  # terminal QR codes for the iMessage connect step
 ]

--- a/tests/live/test_cross_channel.py
+++ b/tests/live/test_cross_channel.py
@@ -156,7 +156,7 @@ def test_sms_request_gets_email_response(xc):
 def _inbound_calls_from_aut(remote, remote_pid: str, aut_phone: str):
     """The driver's inbound calls originating from the AUT's number."""
     tail = _digits(aut_phone)[-10:]
-    return [c for c in remote.calls.list(remote_pid, limit=30)
+    return [c for c in remote.calls.list(limit=30)
             if (getattr(c, "direction", "") or "").lower() == "inbound"
             and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
 

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -60,7 +60,8 @@ def _aut_phone(aut) -> str:
 
 def _segments(remote, number_id, call_id):
     """Transcript segments for a call, split by who spoke."""
-    segs = remote.transcripts.list(number_id, call_id)
+    # Identity-centered transcript read (SDK 0.4.15+); number_id is vestigial.
+    segs = remote.calls.transcripts(call_id)
     rem = [s for s in segs if (getattr(s, "party", "") or "").lower() == "remote" and (s.text or "").strip()]
     loc = [s for s in segs if (getattr(s, "party", "") or "").lower() == "local" and (s.text or "").strip()]
     return segs, rem, loc
@@ -89,9 +90,8 @@ def _aut_speech_mode(aut, direction, driver_number):
     """(use_inkbox_tts, use_inkbox_stt) of the agent's most recent answered call
     in `direction` with the driver. Tells Inkbox STT/TTS (True/True) from realtime
     (False/False), so each leg can prove it ran the speech path it claims."""
-    num_id = str(aut.phone_numbers.list()[0].id)
     tail = _digits(driver_number)[-10:]
-    answered = [c for c in aut.calls.list(num_id, limit=10)
+    answered = [c for c in aut.calls.list(limit=10)
                 if (getattr(c, "direction", "") or "").lower() == direction
                 and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail
                 and c.use_inkbox_tts is not None]
@@ -127,7 +127,7 @@ def test_outbound_call_realtime():
     tail = _digits(aut_phone)[-10:]
 
     def _inbound_from_aut():
-        return [c for c in remote.calls.list(st["number_id"], limit=30)
+        return [c for c in remote.calls.list(limit=30)
                 if (getattr(c, "direction", "") or "").lower() == "inbound"
                 and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
 


### PR DESCRIPTION
inkbox SDK 0.4.15 (inkbox-ai/inkbox#90) re-centered the phone module on the agent identity and removed the number-scoped call/transcript paths. CI here is still green because the live suites install via `pip install -e .` and #22 pinned `inkbox<0.4.15` — this migrates forward and lifts that pin.

- Tests: `calls.list(number_id, ...)` → keyword-only `calls.list(...)` (identity-scoped keys resolve their own identity); `transcripts.list(number_id, call_id)` → `calls.transcripts(call_id)`.
- pyproject: `inkbox>=0.4.10,<0.4.15` → `inkbox>=0.4.15`; version 0.1.0 → 0.1.1.

Runtime code never used the dropped paths — the call tools go through identity delegators (`list_calls`/`list_transcripts`), which are signature-stable in 0.4.15.