### PR TITLE
Improve first-run setup guidance

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
 ## Prerequisites
 
 - **Claude Code installed and logged in.** The bridge drives a real Claude Code session, so the `claude` CLI has to be on the machine and authenticated — install it ([claude.com/claude-code](https://claude.com/claude-code)), then either sign in with a Claude Pro/Max subscription or set `ANTHROPIC_API_KEY`. `inkbox-claude doctor` checks for it.
-- **Python 3.10+.** The installer finds one and builds the bridge its own venv.
+- **Python 3.11+.** The installer finds one and builds the bridge its own venv.
 - **macOS or Linux.** Boot persistence uses a systemd user unit on Linux and a launchd agent on macOS.
 - **An Inkbox agent** — nothing to set up in advance; the setup wizard self-signs up for you (or takes an existing API key).
 
 ## Get started — one command
 
-This finds a Python 3.10+, installs the bridge in its own venv, puts `inkbox-claude` on your PATH, and runs the setup wizard:
+This finds a Python 3.11+, installs the bridge in its own venv, puts `inkbox-claude` on your PATH, and runs the setup wizard:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/inkbox-ai/claude-code-plugin/main/install.sh | bash
@@ -70,7 +70,7 @@ you (phone)  ── SMS / iMessage / email / call ──▶  Inkbox  ──▶  
 
 ## Manual install
 
-If you'd rather not run the installer (any Python 3.10+ environment):
+If you'd rather not run the installer (any Python 3.11+ environment):
 
 ```bash
 pip install -e .

--- a/inkbox_claude/daemon.py
+++ b/inkbox_claude/daemon.py
@@ -104,7 +104,13 @@ def run_foreground() -> int:
     if os.name == "posix":
         signal.signal(signal.SIGTERM, signal.default_int_handler)
 
-    gateway = InkboxGateway(read_config())
+    cfg = read_config()
+    if not cfg.api_key or not cfg.identity:
+        print("Inkbox is not set up yet.")
+        print("Run `inkbox-claude setup`, or set INKBOX_API_KEY and INKBOX_IDENTITY in your .env file.")
+        return 1
+
+    gateway = InkboxGateway(cfg)
     try:
         asyncio.run(gateway.run())
     except KeyboardInterrupt:

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@
 #
 #   ./install.sh
 #
-# Finds a Python 3.10+, sets up an isolated venv, installs the bridge, puts
+# Finds a Python 3.11+, sets up an isolated venv, installs the bridge, puts
 # `inkbox-claude` on your PATH, then runs the setup wizard. Re-runnable.
 #
 # Flags:
@@ -54,22 +54,22 @@ ok()   { echo "  ${GREEN}✓${RESET} $*"; }
 warn() { echo "  ${YELLOW}!${RESET} $*"; }
 die()  { echo "${RED}✗ $*${RESET}" >&2; exit 1; }
 
-# --- 1. find Python 3.10+ --------------------------------------------------
+# --- 1. find Python 3.11+ --------------------------------------------------
 find_python() {
   local c v maj min
-  for c in python3.13 python3.12 python3.11 python3.10 python3 python; do
+  for c in python3.13 python3.12 python3.11 python3 python; do
     command -v "$c" >/dev/null 2>&1 || continue
     v="$("$c" -c 'import sys;print("%d.%d"%sys.version_info[:2])' 2>/dev/null || echo 0.0)"
     maj="${v%.*}"; min="${v#*.}"
-    if [ "$maj" = "3" ] && [ "$min" -ge 10 ] 2>/dev/null; then
+    if [ "$maj" = "3" ] && [ "$min" -ge 11 ] 2>/dev/null; then
       echo "$c"; return 0
     fi
   done
   return 1
 }
 
-step "Looking for Python 3.10+"
-PY="$(find_python)" || die "No Python 3.10+ found. Install python3.11+ and re-run. (claude-agent-sdk needs >=3.10.)"
+step "Looking for Python 3.11+"
+PY="$(find_python)" || die "No Python 3.11+ found. Install python3.11+ and re-run."
 ok "using $($PY --version 2>&1) at $(command -v "$PY")"
 
 # --- 2. get the source -----------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "claude-code-plugin"
 version = "0.1.2"
 description = "Inkbox bridge for Claude Code — talk to your coding agent over email, SMS, iMessage, and voice"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.9",
   "inkbox>=0.4.15,<1.0.0",

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -28,6 +28,20 @@ def test_status_reports_not_running(tmp_path, monkeypatch, capsys):
     assert "not running" in capsys.readouterr().out
 
 
+def test_run_foreground_missing_config_prints_setup_hint(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("INKBOX_CLAUDE_ENV_FILE", raising=False)
+    monkeypatch.delenv("INKBOX_API_KEY", raising=False)
+    monkeypatch.delenv("INKBOX_IDENTITY", raising=False)
+
+    assert daemon.run_foreground() == 1
+    out = capsys.readouterr().out
+    assert "Inkbox is not set up yet" in out
+    assert "inkbox-claude setup" in out
+    assert "INKBOX_API_KEY" in out
+
+
 def test_stop_is_a_noop_when_not_running(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
     assert daemon.stop() == 0


### PR DESCRIPTION
## Summary
- Ask for Python 3.11+, which is what the Inkbox SDK already needs.
- Keep the README, installer, package metadata, and CI in sync on that requirement.
- When someone runs `inkbox-claude run` before setup, show a clear setup hint instead of a traceback.

Fixes #26

## Why
We found this while setting up the Inkbox agent flow end to end. The normal setup path works: after creating the Inkbox agent, verifying email, generating a signing key, and connecting iMessage, the bridge came up and registered its tunnel/webhooks successfully.

The rough part was what happens before setup is complete. A new user could hit confusing errors before they know what to do next. This PR makes that first-run path clearer.

## Validation
- `uv run --python 3.12 python -m pytest tests/test_daemon.py -q`
- `uv run --python 3.12 python -m pytest -q`
- `inkbox-claude run` with missing Inkbox env now prints the setup hint
- Completed a real setup afterward: agent created, email verified, signing key saved, iMessage connected through the Inkbox iMessage router number, bridge started

## Notes
- iMessage connection worked. The only phone-related piece not available on this plan was provisioning a dedicated SMS/voice number for the agent.
