### PR TITLE
Recover cleanly from stale Claude resume sessions

### DIFF
--- a/inkbox_claude/sessions.py
+++ b/inkbox_claude/sessions.py
@@ -173,6 +173,33 @@ def _send_rejected_prompt(reply: str, reason: str) -> str:
     ])
 
 
+def _exception_text(exc: Exception) -> str:
+    """Flatten an exception plus SDK stderr into text for classification."""
+    parts = [str(exc)]
+    stderr = getattr(exc, "stderr", None)
+    if stderr:
+        parts.append(str(stderr))
+    return "\n".join(p for p in parts if p)
+
+
+def _is_missing_resume_error(exc: Exception) -> bool:
+    return "No conversation found with session ID" in _exception_text(exc)
+
+
+def _turn_error_notice(exc: Exception) -> str:
+    """Build the text the human sees when a Claude turn cannot start/finish."""
+    if _is_missing_resume_error(exc):
+        return (
+            "Claude Code couldn't find the old conversation I tried to resume. "
+            "I cleared that stale session; send your message again to start fresh, "
+            "or text /health to check the bridge."
+        )
+    return (
+        "Sorry — Claude Code hit an error while working on that. "
+        "Text /health to check the bridge, or /clear to start fresh."
+    )
+
+
 def _transcript_dir(project_dir: Optional[str]) -> Optional[Path]:
     """Locate Claude Code's transcript folder for a project.
 
@@ -419,18 +446,16 @@ class ContactSession:
             turn = await self._queue.get()
             try:
                 await self._run_turn(turn)
-            except Exception:
+            except Exception as exc:
                 # An interrupt aborts the turn on purpose — the next queued
                 # message takes over, so it is not an error to report.
                 if self._interrupting:
                     logger.info("[session %s] turn interrupted by a new message", self.chat_id)
                     continue
                 logger.exception("[session %s] turn failed", self.chat_id)
+                await self.close()
                 try:
-                    await self._reply(
-                        "Sorry — I hit an error while working on that and had to stop. "
-                        "Try sending it again."
-                    )
+                    await self._reply(_turn_error_notice(exc))
                 except Exception:
                     logger.exception("[session %s] could not send the error notice", self.chat_id)
 
@@ -594,7 +619,21 @@ class ContactSession:
         self._current_turn = turn
         typing_task: Optional[asyncio.Task] = None
         try:
-            client = await self._ensure_client()
+            try:
+                client = await self._ensure_client()
+            except Exception as exc:
+                if not self.resume_session_id or not _is_missing_resume_error(exc):
+                    raise
+                logger.warning(
+                    "[session %s] Claude resume id %s is stale; retrying fresh",
+                    self.chat_id,
+                    self.resume_session_id,
+                )
+                self.resume_session_id = None
+                if self.on_clear is not None:
+                    self.on_clear(self.chat_id)
+                await self.close()
+                client = await self._ensure_client()
             # Keep a typing indicator alive on the human's channel for the whole
             # turn, then always tear it down — even if the turn raises.
             self._turn_active = True
@@ -766,7 +805,11 @@ class ContactSession:
             resume=self.resume_session_id or None,
         )
         self._client = ClaudeSDKClient(options=options)
-        await self._client.connect()
+        try:
+            await self._client.connect()
+        except Exception:
+            self._client = None
+            raise
         logger.info(
             "[session %s] Claude Code session started (resume=%s)",
             self.chat_id, self.resume_session_id or "fresh",

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -254,6 +254,106 @@ def test_clear_command_starts_fresh_session():
     asyncio.run(scenario())
 
 
+def test_stale_resume_id_retries_once_fresh(monkeypatch):
+    async def scenario():
+        cleared = []
+        attempts = []
+        session = make_session([])
+        session.resume_session_id = "old-session"
+        session.on_clear = lambda chat_id: cleared.append(chat_id)
+
+        class FakeClient:
+            async def connect(self):
+                attempts.append(session.resume_session_id)
+                if len(attempts) == 1:
+                    raise RuntimeError("No conversation found with session ID: old-session")
+
+            async def query(self, _text):
+                pass
+
+            async def receive_response(self):
+                if False:
+                    yield None
+
+            async def disconnect(self):
+                pass
+
+        monkeypatch.setattr(sessions_mod, "CLAUDE_SDK_AVAILABLE", True)
+        monkeypatch.setattr(sessions_mod, "ClaudeSDKClient", lambda options: FakeClient())
+
+        await session._run_turn(_Turn(text="hello"))
+
+        assert attempts == ["old-session", None]
+        assert session.resume_session_id is None
+        assert cleared == ["contact-1"]
+        assert session._client is not None
+
+    asyncio.run(scenario())
+
+
+def test_failed_connect_does_not_keep_broken_client(monkeypatch):
+    async def scenario():
+        session = make_session([])
+
+        class FakeClient:
+            async def connect(self):
+                raise RuntimeError("Claude Code could not start")
+
+        monkeypatch.setattr(sessions_mod, "CLAUDE_SDK_AVAILABLE", True)
+        monkeypatch.setattr(sessions_mod, "ClaudeSDKClient", lambda options: FakeClient())
+
+        raised = False
+        try:
+            await session._ensure_client()
+        except RuntimeError:
+            raised = True
+
+        assert raised is True
+        assert session._client is None
+
+    asyncio.run(scenario())
+
+
+def test_turn_failure_sends_actionable_notice_and_closes_client():
+    async def scenario():
+        sent = []
+        session = make_session(sent)
+
+        class FakeClient:
+            def __init__(self):
+                self.disconnects = 0
+
+            async def disconnect(self):
+                self.disconnects += 1
+
+        fake = FakeClient()
+        session._client = fake
+
+        async def fail(_turn):
+            raise RuntimeError("Claude Code could not start")
+
+        session._run_turn = fail
+        await session._queue.put(_Turn(text="hello"))
+        await session._drain()
+
+        assert fake.disconnects == 1
+        assert session._client is None
+        assert "/health" in sent[-1][1]
+        assert "/clear" in sent[-1][1]
+        assert "Try sending it again" not in sent[-1][1]
+
+    asyncio.run(scenario())
+
+
+def test_missing_resume_notice_mentions_stale_session():
+    notice = sessions_mod._turn_error_notice(
+        RuntimeError("No conversation found with session ID: old-session")
+    )
+
+    assert "old conversation" in notice
+    assert "/health" in notice
+
+
 def test_stop_command_interrupts_turn_without_clearing():
     async def scenario():
         sent = []


### PR DESCRIPTION
## Summary
- Clear a stale Claude Code resume id when Claude reports that the saved conversation no longer exists.
- Retry that turn once with a fresh Claude session instead of immediately failing the iMessage user.
- Replace the generic turn failure text with a more actionable `/health` or `/clear` hint.
- Drop a failed Claude client on connect failure so the next message starts from a clean state.

Fixes #28

## Why
We found this while testing the bridge from actual Inkbox iMessage usage. The iMessage side was working: the router delivered the text to the bridge, the bridge was registered, and local Claude CLI smoke checks passed from the target project directory.

The rough part was the Claude Code resume path. The bridge had a saved session id for the contact, but Claude Code reported that the conversation no longer existed. The log had the real error, but the phone only saw a vague retry message. That made a real runtime issue look like a mystery iMessage failure.

This PR keeps the normal resume behavior, but handles the missing-session case by forgetting the stale id and trying once fresh. If startup still fails, the user gets a concrete recovery path instead of a dead-end message.

## Validation
- `.venv/bin/python -m pytest tests/test_sessions.py -q`
- `.venv/bin/python -m pytest -q`
- Restarted the local launchd bridge after the patch; gateway log shows it ready for `shreyas-claude-code` in `/Users/shreyas/CloudAI-Autotune`

## Notes
- This PR does not change Inkbox setup or iMessage provisioning.
- The retry is intentionally limited to the known missing-resume case, so unrelated Claude startup failures do not loop.
- Live iMessage delivery after this patch was not re-tested in the PR branch beyond restarting the bridge.
