### PR TITLE
Isolate live call legs into fresh sessions

### DIFF
--- a/tests/live/test_cross_channel.py
+++ b/tests/live/test_cross_channel.py
@@ -16,6 +16,10 @@ on the driver's number within the window — proof the request reasoned its way 
   * email -> call: email asks the agent to call; we poll the driver's calls.
   * SMS   -> call: SMS asks the agent to call; we poll the driver's calls.
 
+Each call leg first resets the AUT's session (see ``_reset_aut_session``) so it
+starts from a clean conversation — otherwise a placed call lingers in context and
+the next "call me" is answered with a text instead of a fresh dial.
+
 More channels (iMessage) get added here. Real-model only.
 """
 
@@ -176,9 +180,27 @@ def _wait_for_new_call(remote, remote_pid: str, aut_phone: str, before: set):
     pytest.fail(f"agent did not place a call to the driver within {TIMEOUT_S:.0f}s")
 
 
+# The bridge has no way to hang up a call it placed (the SDK exposes only
+# list/get/place), so a test call rides the server's max-duration cap and stays
+# "active" for the whole run. The AUT also keys ONE session per contact across
+# channels, so back-to-back call legs share context: after the first dial the
+# agent reasons "I already called this person" and answers the next "call me"
+# with a text instead of dialing again. Resetting the session before each leg
+# (the bridge's ``/clear`` control command, intercepted locally and never sent to
+# Claude) drops that context so every ask lands in a fresh conversation.
+RESET_SETTLE_S = 5.0
+
+
+def _reset_aut_session(remote, remote_pid: str, aut_phone: str) -> None:
+    """Reset the AUT's session for the driver contact via the ``/clear`` control SMS."""
+    remote.texts.send(remote_pid, to=aut_phone, text="/clear")
+    time.sleep(RESET_SETTLE_S)  # let the bridge intercept + reset before the real ask
+
+
 def test_email_request_gets_call(xc):
     """Email asks the agent to CALL; a new inbound call must land on the driver."""
     remote, remote_pid, aut_phone = xc["remote"], xc["remote_pid"], xc["aut_phone"]
+    _reset_aut_session(remote, remote_pid, aut_phone)  # fresh session, no prior-call context
     # Snapshot BEFORE sending so a pre-existing call can't be mistaken for the reply.
     before = {c.id for c in _inbound_calls_from_aut(remote, remote_pid, aut_phone)}
     remote.messages.send(
@@ -191,6 +213,12 @@ def test_email_request_gets_call(xc):
 def test_sms_request_gets_call(xc):
     """SMS asks the agent to CALL; a new inbound call must land on the driver."""
     remote, remote_pid, aut_phone = xc["remote"], xc["remote_pid"], xc["aut_phone"]
+    _reset_aut_session(remote, remote_pid, aut_phone)  # fresh session, no prior-call context
     before = {c.id for c in _inbound_calls_from_aut(remote, remote_pid, aut_phone)}
-    remote.texts.send(remote_pid, to=aut_phone, text="Call me please — give me a ring now.")
+    # Be explicit that we want an actual dial — a terse "call me" lets the model
+    # answer by text; the email leg's wording is unambiguous, so match it here.
+    remote.texts.send(
+        remote_pid, to=aut_phone,
+        text="Please place a phone call to my number right now — actually call me, don't text back.",
+    )
     _wait_for_new_call(remote, remote_pid, aut_phone, before)


### PR DESCRIPTION
## Summary
The `Live channels e2e` **real** leg started failing on `test_sms_request_gets_call` (call not placed within the window) while `test_email_request_gets_call` kept passing — on an unchanged repo SHA. Root cause is a test-harness gap, not plugin/API/infra:

- Both call legs share **one AUT session** (the bridge keys a session per contact across channels).
- The bridge has **no way to hang up** a call it placed — the SDK's `CallsResource` exposes only `list` / `get` / `place`. So the email leg's call rides the server's 10-min max-duration cap and stays "active" for the rest of the run.
- With that call still in session context, the newer upstream Claude Code model answers the SMS "call me" with *"I already called you"* (a text) instead of dialing again → the SMS leg times out.

Evidence: in the failed run the AUT bridge issued exactly **one** `POST /phone/place-call` (the email leg), then replied to the SMS with texts — no second dial. The failing SHA `43f9ed6` was green ~12h earlier; the only moving part is `@anthropic-ai/claude-code` latest (2.1.205, published after the last green run).

## What this does
- Reset the AUT session via the bridge's `/clear` control command (intercepted locally, never sent to Claude) before **each** call leg, so every ask lands in a fresh conversation with no prior-call baggage.
- Make the SMS→call prompt as unambiguous as the email one, so a terse "call me" can't be answered by text even in a clean session.

Scoped to `tests/live/test_cross_channel.py`; no product code changes.

## Follow-up (not in this PR)
The underlying gap — no way to terminate a call, so every live run burns a full 10 minutes of voice on an abandoned call — is worth a real fix: a server `hangup` endpoint → SDK `calls.hangup()` → gateway tool. Happy to file that separately.