### PR TITLE
Harden Claude stale-session recovery

### DIFF
--- a/inkbox_claude/sessions.py
+++ b/inkbox_claude/sessions.py
@@ -618,41 +618,49 @@ class ContactSession:
         self._interrupting = False  # fresh turn starts un-interrupted
         self._current_turn = turn
         typing_task: Optional[asyncio.Task] = None
+        retried_missing_resume = False
         try:
-            try:
-                client = await self._ensure_client()
-            except Exception as exc:
-                if not self.resume_session_id or not _is_missing_resume_error(exc):
-                    raise
-                logger.warning(
-                    "[session %s] Claude resume id %s is stale; retrying fresh",
-                    self.chat_id,
-                    self.resume_session_id,
-                )
-                self.resume_session_id = None
-                if self.on_clear is not None:
-                    self.on_clear(self.chat_id)
-                await self.close()
-                client = await self._ensure_client()
-            # Keep a typing indicator alive on the human's channel for the whole
-            # turn, then always tear it down — even if the turn raises.
-            self._turn_active = True
-            typing_task = asyncio.create_task(self._typing_loop())
-            await client.query(turn.text)
+            while True:
+                try:
+                    client = await self._ensure_client()
+                    # Keep a typing indicator alive on the human's channel for
+                    # the whole turn, then always tear it down — even if the
+                    # turn raises.
+                    self._turn_active = True
+                    typing_task = asyncio.create_task(self._typing_loop())
+                    await client.query(turn.text)
 
-            chunks: list[str] = []
-            final: Optional[str] = None
-            async for message in client.receive_response():
-                if isinstance(message, AssistantMessage):
-                    for block in message.content:
-                        if isinstance(block, TextBlock):
-                            chunks.append(block.text)
-                elif isinstance(message, ResultMessage):
-                    final = message.result
-                    if message.session_id and self.on_session_id:
-                        self.resume_session_id = message.session_id
-                        self.on_session_id(self.chat_id, message.session_id)
-            reply = (final or "\n\n".join(chunks)).strip()
+                    chunks: list[str] = []
+                    final: Optional[str] = None
+                    async for message in client.receive_response():
+                        if isinstance(message, AssistantMessage):
+                            for block in message.content:
+                                if isinstance(block, TextBlock):
+                                    chunks.append(block.text)
+                        elif isinstance(message, ResultMessage):
+                            final = message.result
+                            if message.session_id and self.on_session_id:
+                                self.resume_session_id = message.session_id
+                                self.on_session_id(self.chat_id, message.session_id)
+                    reply = (final or "\n\n".join(chunks)).strip()
+                    break
+                except Exception as exc:
+                    if (
+                        retried_missing_resume
+                        or not self.resume_session_id
+                        or not _is_missing_resume_error(exc)
+                    ):
+                        raise
+                    retried_missing_resume = True
+                    if typing_task is not None:
+                        typing_task.cancel()
+                        try:
+                            await typing_task
+                        except asyncio.CancelledError:
+                            pass
+                        typing_task = None
+                    self._turn_active = False
+                    await self._clear_stale_resume()
         except Exception as exc:
             # A capture turn must always settle its waiter — surface the error
             # there. A normal turn re-raises so _drain shows the human a notice.
@@ -682,6 +690,19 @@ class ContactSession:
             return
         if reply:
             await self._deliver_reply(turn, reply)
+
+    async def _clear_stale_resume(self) -> None:
+        """Forget a stale Claude resume id and reset conversation-scoped state."""
+        logger.warning(
+            "[session %s] Claude resume id %s is stale; retrying fresh",
+            self.chat_id,
+            self.resume_session_id,
+        )
+        self.resume_session_id = None
+        if self.on_clear is not None:
+            self.on_clear(self.chat_id)
+        self.always_allowed.clear()
+        await self.close()
 
     async def _deliver_reply(self, turn: _Turn, reply: str) -> None:
         """Send a normal turn's reply, recovering once if the send is rejected.

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -261,6 +261,7 @@ def test_stale_resume_id_retries_once_fresh(monkeypatch):
         session = make_session([])
         session.resume_session_id = "old-session"
         session.on_clear = lambda chat_id: cleared.append(chat_id)
+        session.always_allowed.add("Bash")
 
         class FakeClient:
             async def connect(self):
@@ -286,7 +287,44 @@ def test_stale_resume_id_retries_once_fresh(monkeypatch):
         assert attempts == ["old-session", None]
         assert session.resume_session_id is None
         assert cleared == ["contact-1"]
+        assert session.always_allowed == set()
         assert session._client is not None
+
+    asyncio.run(scenario())
+
+
+def test_stale_resume_error_during_query_retries_fresh(monkeypatch):
+    async def scenario():
+        cleared = []
+        query_resume_ids = []
+        session = make_session([])
+        session.resume_session_id = "old-session"
+        session.on_clear = lambda chat_id: cleared.append(chat_id)
+
+        class FakeClient:
+            async def connect(self):
+                pass
+
+            async def query(self, _text):
+                query_resume_ids.append(session.resume_session_id)
+                if len(query_resume_ids) == 1:
+                    raise RuntimeError("No conversation found with session ID: old-session")
+
+            async def receive_response(self):
+                if False:
+                    yield None
+
+            async def disconnect(self):
+                pass
+
+        monkeypatch.setattr(sessions_mod, "CLAUDE_SDK_AVAILABLE", True)
+        monkeypatch.setattr(sessions_mod, "ClaudeSDKClient", lambda options: FakeClient())
+
+        await session._run_turn(_Turn(text="hello"))
+
+        assert query_resume_ids == ["old-session", None]
+        assert session.resume_session_id is None
+        assert cleared == ["contact-1"]
 
     asyncio.run(scenario())
 
@@ -310,6 +348,44 @@ def test_failed_connect_does_not_keep_broken_client(monkeypatch):
 
         assert raised is True
         assert session._client is None
+
+    asyncio.run(scenario())
+
+
+def test_turn_query_failure_sends_notice_and_closes_client(monkeypatch):
+    async def scenario():
+        sent = []
+        clients = []
+        session = make_session(sent)
+
+        class FakeClient:
+            def __init__(self):
+                self.disconnects = 0
+                clients.append(self)
+
+            async def connect(self):
+                pass
+
+            async def query(self, _text):
+                raise RuntimeError("Claude Code process exited")
+
+            async def receive_response(self):
+                if False:
+                    yield None
+
+            async def disconnect(self):
+                self.disconnects += 1
+
+        monkeypatch.setattr(sessions_mod, "CLAUDE_SDK_AVAILABLE", True)
+        monkeypatch.setattr(sessions_mod, "ClaudeSDKClient", lambda options: FakeClient())
+
+        await session._queue.put(_Turn(text="hello"))
+        await session._drain()
+
+        assert clients[0].disconnects == 1
+        assert session._client is None
+        assert "/health" in sent[-1][1]
+        assert "/clear" in sent[-1][1]
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## Summary
- Retry the stale Claude resume-session recovery when the missing-session error happens during turn submission/response handling, not only during client startup.
- Move stale-resume cleanup into one helper that clears the resume id, persisted state, live client, and conversation-scoped tool grants.
- Keep generic Claude turn failures on the existing actionable `/health` or `/clear` notice path while closing the broken client.

Fixes #31

## Why
PR #29 fixed the exact failure we hit through real Inkbox iMessage testing: Claude Code could not find an old saved conversation id, and the bridge now clears that stale id when the failure happens during startup.

This follow-up tightens the adjacent edge cases. The same missing-session error can surface after the client has connected, while the bridge submits the turn or starts reading the response. That is still the same recoverable stale-resume problem, so it should use the same one-time fresh retry instead of falling through to an error notice.

The cleanup also now drops conversation-scoped always-allowed tool grants when abandoning the old Claude conversation, so the fresh session does not inherit grants from stale context.

## Validation
- `.venv/bin/python -m pytest tests/test_sessions.py -q`
- `.venv/bin/python -m pytest -q`

## Notes
- The retry is still intentionally limited to the known `No conversation found with session ID` case.
- This does not try to recover every Claude process, login, permission, or SDK failure.
- Live iMessage delivery with a real mid-query stale resume error was not reproduced; this is covered with targeted regression tests.
