### PR TITLE
Don't wake the agent on text.delivery_unconfirmed

### DIFF
--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -764,8 +764,14 @@ class InkboxGateway:
                     response = await self._on_imessage_reaction_received(envelope)
                 # Outbound delivery failures: tell the agent its message didn't
                 # land so it can retry or reach the human another way.
-                elif event_type in ("text.delivery_failed", "text.delivery_unconfirmed"):
+                elif event_type == "text.delivery_failed":
                     response = await self._on_text_delivery_failed(envelope, event_type)
+                # Carrier uncertainty, not a hard failure - the message often
+                # still landed, so log it but don't wake the agent. Waking here
+                # would resend a message that was likely delivered.
+                elif event_type == "text.delivery_unconfirmed":
+                    logger.debug("[bridge] text.delivery_unconfirmed (telemetry) - not waking agent")
+                    response = web.json_response({"ok": True, "ignored": event_type})
                 elif event_type == "imessage.delivery_failed":
                     response = await self._on_imessage_delivery_failed(envelope)
                 elif event_type in ("message.bounced", "message.failed"):
@@ -1739,8 +1745,6 @@ class InkboxGateway:
                 if not recipient:
                     recipient = rec_number.strip()
                 break
-        if event_type == "text.delivery_unconfirmed" and not reason:
-            reason = "carrier could not confirm delivery"
         conversation_id = str(message.get("conversation_id") or message.get("conversationId") or "").strip()
         chat_id = self._chat_key(data, recipient, self._thread_key("sms", conversation_id))
         logger.info("[bridge] SMS delivery failed to %s: %s", recipient, reason or event_type)

--- a/tests/test_gateway_delivery_failures.py
+++ b/tests/test_gateway_delivery_failures.py
@@ -49,7 +49,7 @@ async def _drain():
 
 def _dispatch(gw, envelope, event_type):
     async def go():
-        if event_type in ("text.delivery_failed", "text.delivery_unconfirmed"):
+        if event_type == "text.delivery_failed":
             r = await gw._on_text_delivery_failed(envelope, event_type)
         elif event_type == "imessage.delivery_failed":
             r = await gw._on_imessage_delivery_failed(envelope)
@@ -58,6 +58,38 @@ def _dispatch(gw, envelope, event_type):
         await _drain()
         return r
     return asyncio.run(go())
+
+
+class _FakeRequest:
+    """Drives the real _handle_webhook (Inkbox-signed; verification off)."""
+
+    def __init__(self, envelope, *, request_id="req-1"):
+        self._body = json.dumps(envelope).encode()
+        self.headers = {
+            "X-Inkbox-Request-Id": request_id,
+            "X-Inkbox-Signature": "sha256=test",
+        }
+        self.url = "https://agent.example/webhook"
+
+    async def read(self):
+        return self._body
+
+
+def test_delivery_unconfirmed_does_not_wake_agent():
+    # Fleet standard: text.delivery_unconfirmed is carrier uncertainty, not a
+    # hard failure. It must NOT wake the agent - waking would resend a message
+    # that likely landed. Driven through the real _handle_webhook dispatch.
+    gw = _gw()
+    envelope = {"event_type": "text.delivery_unconfirmed", "data": {"text_message": {
+        "id": "u1", "direction": "outbound", "remote_phone_number": "+15551234567",
+        "text": "your appointment is confirmed for 3pm",
+    }, "contacts": [{"id": "contact-1"}]}}
+
+    resp = asyncio.run(gw._handle_webhook(_FakeRequest(envelope)))
+
+    # Logged and acked, but no session was woken.
+    assert json.loads(resp.text)["ignored"] == "text.delivery_unconfirmed"
+    assert gw.sessions.by_id == {}
 
 
 def test_sms_delivery_failure_notifies_session():


### PR DESCRIPTION
Fixes #35.

`text.delivery_unconfirmed` was routed into the delivery-failure path and woke the agent, but unconfirmed just means the carrier couldn't confirm delivery - the message usually still landed. Waking on it made the agent resend, so the recipient got a duplicate and it burned a retry-budget slot. The standard also lists "unconfirmed doesn't wake" as an acceptance criterion.

## What this does

- Route `text.delivery_unconfirmed` to a log-only branch, like `sent`/`delivered`, instead of the delivery-failed handler
- Add a test that unconfirmed doesn't wake

**Before:** agent wakes on attempt 1/3 and is told to resend.
**After:** logged and ignored, no wake. Full suite green.
