### PR TITLE
Suppress expected tunnel idle-cap warnings

### DIFF
--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -421,6 +421,28 @@ def _tunnel_state_dir() -> Path:
     return root
 
 
+class _ExpectedTunnelIdleFilter(logging.Filter):
+    """Drop the SDK's per-slot warning for a normal idle intake timeout."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        # Match narrowly: only the healthy idle-cap 408 is expected noise.
+        # Anything else on this logger (401s, disconnects) must stay visible.
+        message = record.getMessage()
+        return not (
+            record.name == "inkbox.tunnels"
+            and "/_system/intake slot=" in message
+            and "status=408" in message
+            and "reason='intake-idle-cap'" in message
+        )
+
+
+def _install_tunnel_log_filter() -> None:
+    """Attach ``_ExpectedTunnelIdleFilter`` to the SDK tunnel logger once."""
+    tunnel_logger = logging.getLogger("inkbox.tunnels")
+    if not any(isinstance(item, _ExpectedTunnelIdleFilter) for item in tunnel_logger.filters):
+        tunnel_logger.addFilter(_ExpectedTunnelIdleFilter())
+
+
 class InkboxGateway:
     """Routes Inkbox webhooks into contact-keyed Claude Code sessions."""
 
@@ -531,6 +553,9 @@ class InkboxGateway:
     async def _open_tunnel(self) -> None:
         if not INKBOX_TUNNEL_AVAILABLE:
             raise RuntimeError("inkbox SDK tunnel client unavailable; upgrade: pip install -U inkbox")
+        # A healthy gateway gets one idle-cap warning per parked intake slot;
+        # mute those before the runtime starts so real errors stand out.
+        _install_tunnel_log_filter()
         state_dir = _tunnel_state_dir()
         # Wipe SDK tunnel state so a stale tunnel_id can't wedge reconnects.
         shutil.rmtree(state_dir, ignore_errors=True)

--- a/tests/test_gateway_tunnel_logging.py
+++ b/tests/test_gateway_tunnel_logging.py
@@ -1,0 +1,66 @@
+import logging
+
+from inkbox_claude import gateway
+
+
+def _record(message, *args, level=logging.WARNING):
+    return logging.LogRecord("inkbox.tunnels", level, __file__, 1, message, args, None)
+
+
+def test_expected_intake_idle_cap_warning_is_filtered():
+    record = _record(
+        "/_system/intake slot=%d -> status=%s reason=%r body=%r",
+        10,
+        "408",
+        "intake-idle-cap",
+        b"",
+    )
+    assert gateway._ExpectedTunnelIdleFilter().filter(record) is False
+
+
+def test_auth_failure_warning_remains_visible():
+    record = _record(
+        "/_system/intake slot=%d -> status=%s reason=%r body=%r",
+        10,
+        "401",
+        "owner-token-invalid",
+        b"",
+    )
+    assert gateway._ExpectedTunnelIdleFilter().filter(record) is True
+
+
+def test_408_with_other_reason_remains_visible():
+    # Same status, different reason — only the exact idle-cap shape is muted.
+    record = _record(
+        "/_system/intake slot=%d -> status=%s reason=%r body=%r",
+        10,
+        "408",
+        "handshake-timeout",
+        b"",
+    )
+    assert gateway._ExpectedTunnelIdleFilter().filter(record) is True
+
+
+def test_unrelated_tunnel_warning_remains_visible():
+    assert gateway._ExpectedTunnelIdleFilter().filter(_record("tunnel runtime disconnected")) is True
+
+
+def test_installing_filter_is_idempotent():
+    logger = logging.getLogger("inkbox.tunnels")
+    original_filters = list(logger.filters)
+    try:
+        logger.filters = [
+            item for item in logger.filters
+            if not isinstance(item, gateway._ExpectedTunnelIdleFilter)
+        ]
+
+        gateway._install_tunnel_log_filter()
+        gateway._install_tunnel_log_filter()
+
+        installed = [
+            item for item in logger.filters
+            if isinstance(item, gateway._ExpectedTunnelIdleFilter)
+        ]
+        assert len(installed) == 1
+    finally:
+        logger.filters = original_filters


### PR DESCRIPTION
## Why

A healthy gateway emits one `inkbox.tunnels` warning per parked intake slot whenever the server idle-caps it (`status=408 reason='intake-idle-cap'`). That's expected steady-state churn, and it buries the log lines that matter.

## How

- Add a `logging.Filter` on the `inkbox.tunnels` logger that drops a record only when it matches the exact idle-cap shape (`/_system/intake slot=` + `status=408` + `reason='intake-idle-cap'`). Auth failures (401), disconnects, and 408s with any other reason still surface — muting the whole logger would hide real tunnel problems.
- Install it (idempotently) in `_open_tunnel` before the tunnel runtime starts.
- Fail-safe: if the server ever changes the message, the warnings reappear instead of errors getting eaten.

Mirrors inkbox-ai/hermes-agent-plugin#56.

## Tests

`tests/test_gateway_tunnel_logging.py`: idle-cap record filtered; 401, unrelated warnings, and 408-with-different-reason preserved; install idempotency.