### PR TITLE
Page live-stack failures only for scheduled canaries

### DIFF
--- a/.github/workflows/live-stack.yml
+++ b/.github/workflows/live-stack.yml
@@ -104,6 +104,7 @@ jobs:
     if: >
       always() &&
       github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'schedule' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main' &&
       (needs.channels.result != 'success' ||


### PR DESCRIPTION
## Summary
- require the upstream Canary event to be `schedule` before the chained live-stack notifier pages Google Chat
- preserve live-stack execution for manual canary dispatches while keeping those attended failures notification-free

## Validation
- actionlint (with the GitHub-supported `concurrency.queue` key ignored for the older local actionlint schema)
- `git diff --check`

Follow-up to #40.