### PR TITLE
Prevent live voice call contamination

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Inkbox bridge for Claude Code — talk to your coding agent over 
 requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.4.20,<1.0.0",
+  "inkbox>=0.4.24,<1.0.0",
   "claude-agent-sdk>=0.1.0",
   "segno>=1.5",  # terminal QR codes for the iMessage connect step
 ]

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -33,6 +33,8 @@ from __future__ import annotations
 
 import os
 import re
+import threading
+import time
 import uuid
 
 import pytest
@@ -60,6 +62,120 @@ def _client(key: str):
     from inkbox import Inkbox
 
     return Inkbox(api_key=key, base_url=BASE_URL)
+
+
+_ENDED_CALL_STATUSES = {"completed", "failed", "canceled"}
+
+
+def _owned_calls(client, local_phone: str):
+    """Newest calls owned by this live identity, keyed by call id."""
+    return {
+        str(call.id): call
+        for call in client.calls.list(limit=100)
+        if getattr(call, "local_phone_number", None) == local_phone
+    }
+
+
+def _call_status(call) -> str:
+    return str(getattr(call, "status", "") or "").lower()
+
+
+def _hang_up_owned_call(client, call) -> str | None:
+    """Send the authoritative hangup command, tolerating an ended-call race."""
+    call_id = str(call.id)
+    if _call_status(call) in _ENDED_CALL_STATUSES:
+        return None
+    try:
+        client.calls.hangup(call_id)
+        return None
+    except Exception as exc:
+        try:
+            current = client.calls.get(call_id)
+        except Exception as get_exc:
+            return f"hangup={exc!r}; get={get_exc!r}"
+        if _call_status(current) in _ENDED_CALL_STATUSES:
+            return None
+        return f"hangup={exc!r}; status={_call_status(current)!r}"
+
+
+def _finish_new_calls(client, local_phone: str, baseline: set[str]) -> None:
+    """Hang up and verify every call created by this pytest session."""
+    deadline = time.monotonic() + 12
+    last_errors: dict[str, str] = {}
+    while True:
+        current = _owned_calls(client, local_phone)
+        live = {
+            call_id: call
+            for call_id, call in current.items()
+            if call_id not in baseline and _call_status(call) not in _ENDED_CALL_STATUSES
+        }
+        if not live:
+            return
+        for call_id, call in live.items():
+            error = _hang_up_owned_call(client, call)
+            if error:
+                last_errors[call_id] = error
+        if time.monotonic() >= deadline:
+            states = {call_id: _call_status(call) for call_id, call in live.items()}
+            raise RuntimeError(
+                f"live-test calls remained active after API cleanup: "
+                f"states={states!r} errors={last_errors!r}"
+            )
+        time.sleep(0.5)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _clean_up_calls_created_by_live_session():
+    """Own all calls created by this live process and never leak a carrier leg.
+
+    Non-voice suites run a watchdog because a model can unexpectedly choose the
+    phone tool while answering an SMS/email test. Voice tests own their expected
+    call ids directly and use this fixture as a final safety net.
+    """
+    if not AUT_KEY:
+        yield
+        return
+
+    client = _client(AUT_KEY)
+    numbers = client.phone_numbers.list()
+    if not numbers:
+        raise RuntimeError("live-test identity has no phone number for call cleanup")
+    local_phone = numbers[0].number
+    baseline = set(_owned_calls(client, local_phone))
+    watch_client = _client(AUT_KEY)
+    voice_session = bool(os.environ.get("VOICE_SCENARIO"))
+    stop = threading.Event()
+
+    def watchdog() -> None:
+        attempted: set[str] = set()
+        while not stop.wait(1):
+            try:
+                current = _owned_calls(watch_client, local_phone)
+            except Exception:
+                continue
+            for call_id, call in current.items():
+                if (
+                    call_id in baseline
+                    or call_id in attempted
+                    or _call_status(call) in _ENDED_CALL_STATUSES
+                ):
+                    continue
+                attempted.add(call_id)
+                _hang_up_owned_call(watch_client, call)
+
+    watcher = None
+    if not voice_session:
+        watcher = threading.Thread(target=watchdog, name="live-call-cleanup", daemon=True)
+        watcher.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        if watcher is not None:
+            watcher.join(timeout=3)
+        # Catch a call created during the last model turn / watcher shutdown.
+        time.sleep(1)
+        _finish_new_calls(client, local_phone, baseline)
 
 
 def _digits(s: str) -> str:

--- a/tests/live/test_cross_channel.py
+++ b/tests/live/test_cross_channel.py
@@ -68,7 +68,8 @@ def xc():
     rnums = remote.phone_numbers.list()
     anums = aut.phone_numbers.list()
     assert rnums and anums, "both identities need a phone number for cross-channel"
-    remote_phone, remote_pid = rnums[0].number, str(rnums[0].id)
+    remote_number = rnums[0]
+    remote_phone, remote_pid = remote_number.number, str(remote_number.id)
     aut_phone = anums[0].number
 
     # The agent can only cross channels if the sender's card has BOTH an email and a
@@ -95,11 +96,20 @@ def xc():
         if changed:
             aut.contacts.update(c.id, emails=emails, phones=phones)
 
-    return {
-        "remote": remote, "aut": aut,
-        "remote_email": remote_email, "remote_pid": remote_pid,
-        "aut_email": aut_email, "aut_phone": aut_phone,
-    }
+    # These tests only need proof that the AUT attempted a fresh dial. Keep the
+    # driver parked on auto-reject so each probe terminates immediately instead
+    # of occupying both identities until the server's ten-minute duration cap.
+    # Re-assert the known idle baseline during teardown as well: preserving a
+    # stale auto-accept value here contaminates the voice suite that runs next.
+    remote.phone_numbers.update(remote_pid, incoming_call_action="auto_reject")
+    try:
+        yield {
+            "remote": remote, "aut": aut,
+            "remote_email": remote_email, "remote_pid": remote_pid,
+            "aut_email": aut_email, "aut_phone": aut_phone,
+        }
+    finally:
+        remote.phone_numbers.update(remote_pid, incoming_call_action="auto_reject")
 
 
 def test_email_request_gets_sms_response(xc):
@@ -180,14 +190,13 @@ def _wait_for_new_call(remote, remote_pid: str, aut_phone: str, before: set):
     pytest.fail(f"agent did not place a call to the driver within {TIMEOUT_S:.0f}s")
 
 
-# The bridge has no way to hang up a call it placed (the SDK exposes only
-# list/get/place), so a test call rides the server's max-duration cap and stays
-# "active" for the whole run. The AUT also keys ONE session per contact across
-# channels, so back-to-back call legs share context: after the first dial the
-# agent reasons "I already called this person" and answers the next "call me"
-# with a text instead of dialing again. Resetting the session before each leg
-# (the bridge's ``/clear`` control command, intercepted locally and never sent to
-# Claude) drops that context so every ask lands in a fresh conversation.
+# The driver auto-rejects these call probes so they cannot leak into the voice
+# suite. The AUT still keys ONE session per contact across channels, however, so
+# back-to-back call legs share context: after the first dial the agent reasons
+# "I already called this person" and answers the next "call me" with a text
+# instead of dialing again. Resetting the session before each leg (the bridge's
+# ``/clear`` control command, intercepted locally and never sent to Claude)
+# drops that context so every ask lands in a fresh conversation.
 RESET_SETTLE_S = 5.0
 
 

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -49,6 +49,7 @@ SCENARIO = os.environ.get("VOICE_SCENARIO", "")
 STATE_FILE = os.environ.get("VOICE_DRIVER_STATE", "/tmp/voice_driver_state.json")
 TIMEOUT_S = float(os.environ.get("LIVE_VOICE_TIMEOUT", "220"))
 POLL_EVERY_S = 6.0
+TERMINAL_FAILURE_STATUSES = {"canceled", "failed"}
 
 pytestmark = pytest.mark.skipif(
     not (REMOTE_KEY and AUT_KEY and REAL),
@@ -86,21 +87,44 @@ def _segments(remote, number_id, call_id):
     return segs, rem, loc
 
 
+def _call_state(remote, call_id) -> tuple[str, str]:
+    """Compact current call state for progress and terminal-failure output."""
+    call = remote.calls.get(call_id)
+    status = (getattr(call, "status", "") or "").lower()
+    fields = (
+        f"status={status!r}",
+        f"reason={getattr(call, 'reason', None)!r}",
+        f"hangup_reason={getattr(call, 'hangup_reason', None)!r}",
+        f"started_at={getattr(call, 'started_at', None)!r}",
+        f"ended_at={getattr(call, 'ended_at', None)!r}",
+        f"is_blocked={getattr(call, 'is_blocked', None)!r}",
+    )
+    return status, " ".join(fields)
+
+
 def _wait_for_two_way_call(remote, number_id, call_id):
     """Block until the call transcript shows BOTH the agent and the driver spoke."""
     deadline = time.monotonic() + TIMEOUT_S
     last = ""
     while time.monotonic() < deadline:
+        transcript_state = ""
         try:
             _all, rem, loc = _segments(remote, number_id, call_id)
         except Exception as exc:  # transcripts may 404 until the call is set up
-            last = f"transcripts not ready: {exc!r}"
-            time.sleep(POLL_EVERY_S)
-            continue
-        if rem and loc:
+            rem, loc = [], []
+            transcript_state = f"transcripts not ready: {exc!r}"
+        if not transcript_state and rem and loc:
             agent_said = " | ".join(s.text.strip() for s in rem)
             return agent_said  # the agent reached the caller out loud, in a two-way call
-        last = f"segments so far: remote={len(rem)} local={len(loc)}"
+        try:
+            status, state = _call_state(remote, call_id)
+        except Exception as exc:
+            state = f"call state unavailable: {exc!r}"
+            status = ""
+        progress = transcript_state or f"segments so far: remote={len(rem)} local={len(loc)}"
+        last = f"{progress}; {state}"
+        if status in TERMINAL_FAILURE_STATUSES:
+            pytest.fail(f"call ended before a two-way conversation ({last})")
         time.sleep(POLL_EVERY_S)
     pytest.fail(f"agent never held a two-way call within {TIMEOUT_S:.0f}s ({last})")
 

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -143,6 +143,29 @@ def _aut_speech_mode(aut, direction, driver_number):
     return c.use_inkbox_tts, c.use_inkbox_stt
 
 
+def _hangup_call(client, call_id) -> None:
+    """End a live test call through the control API, tolerating an ended race."""
+    if not call_id:
+        return
+    try:
+        client.calls.hangup(call_id)
+        return
+    except Exception as hangup_error:
+        deadline = time.monotonic() + 10
+        status = "unknown"
+        while time.monotonic() < deadline:
+            try:
+                status = (getattr(client.calls.get(call_id), "status", "") or "").lower()
+            except Exception:
+                status = "unknown"
+            if status in {"completed", "canceled", "failed"}:
+                return
+            time.sleep(0.5)
+        raise RuntimeError(
+            f"failed to hang up live test call {call_id}; status={status!r}"
+        ) from hangup_error
+
+
 @pytest.mark.skipif(SCENARIO != "inbound_inkbox", reason="inbound Inkbox STT/TTS leg only")
 def test_inbound_call_inkbox_tts_stt():
     """Driver calls the agent; the agent answers via Inkbox STT/TTS and replies."""
@@ -154,11 +177,14 @@ def test_inbound_call_inkbox_tts_stt():
     call = remote.calls.place(
         from_number=st["number"], to_number=aut_phone, client_websocket_url=st["ws_url"],
     )
-    agent_said = _wait_for_two_way_call(remote, st["number_id"], call.id)
-    assert agent_said, "agent produced no speech on the inbound call"
+    try:
+        agent_said = _wait_for_two_way_call(remote, st["number_id"], call.id)
+        assert agent_said, "agent produced no speech on the inbound call"
 
-    tts, stt = _aut_speech_mode(aut, "inbound", st["number"])
-    assert tts and stt, f"inbound call should run Inkbox STT/TTS, got tts={tts} stt={stt}"
+        tts, stt = _aut_speech_mode(aut, "inbound", st["number"])
+        assert tts and stt, f"inbound call should run Inkbox STT/TTS, got tts={tts} stt={stt}"
+    finally:
+        _hangup_call(remote, call.id)
 
 
 @pytest.mark.skipif(SCENARIO != "outbound_realtime", reason="outbound realtime leg only")
@@ -177,20 +203,23 @@ def test_outbound_call_realtime():
     before = {c.id for c in _inbound_from_aut()}
     remote.texts.send(st["number_id"], to=aut_phone, text=_call_me_text())
 
-    # Wait for the agent to dial back, then verify the call transcript.
-    deadline = time.monotonic() + TIMEOUT_S
     call_id = None
-    while time.monotonic() < deadline:
-        fresh = [c for c in _inbound_from_aut() if c.id not in before]
-        if fresh:
-            call_id = fresh[0].id
-            break
-        time.sleep(POLL_EVERY_S)
-    assert call_id, f"agent never placed a call back within {TIMEOUT_S:.0f}s"
+    try:
+        # Wait for the agent to dial back, then verify the call transcript.
+        deadline = time.monotonic() + TIMEOUT_S
+        while time.monotonic() < deadline:
+            fresh = [c for c in _inbound_from_aut() if c.id not in before]
+            if fresh:
+                call_id = fresh[0].id
+                break
+            time.sleep(POLL_EVERY_S)
+        assert call_id, f"agent never placed a call back within {TIMEOUT_S:.0f}s"
 
-    agent_said = _wait_for_two_way_call(remote, st["number_id"], call_id)
-    assert agent_said, "agent produced no speech on the outbound call"
+        agent_said = _wait_for_two_way_call(remote, st["number_id"], call_id)
+        assert agent_said, "agent produced no speech on the outbound call"
 
-    tts, stt = _aut_speech_mode(aut, "outbound", st["number"])
-    assert tts is False and stt is False, \
-        f"outbound call must be powered by the realtime API (Inkbox speech off), got tts={tts} stt={stt}"
+        tts, stt = _aut_speech_mode(aut, "outbound", st["number"])
+        assert tts is False and stt is False, \
+            f"outbound call must be powered by the realtime API (Inkbox speech off), got tts={tts} stt={stt}"
+    finally:
+        _hangup_call(remote, call_id)

--- a/tests/live/voice_driver.py
+++ b/tests/live/voice_driver.py
@@ -148,7 +148,6 @@ def main() -> None:
     log.info("tunnel ready: %s", ws_url)
 
     # Auto-accept inbound calls (agent → driver) straight onto this WS.
-    prev_action = getattr(num, "incoming_call_action", None)
     client.phone_numbers.update(num.id, incoming_call_action="auto_accept", client_websocket_url=ws_url)
 
     Path(STATE_FILE).write_text(json.dumps({
@@ -159,9 +158,12 @@ def main() -> None:
     try:
         listener.wait()
     finally:
-        # Leave the number as we found it so other suites aren't affected.
+        # auto_reject is the driver's known idle baseline. Restoring an
+        # arbitrary previous value can preserve a stale auto-accept setting,
+        # causing earlier call-placement probes to remain active and collide
+        # with the next voice run.
         try:
-            client.phone_numbers.update(num.id, incoming_call_action=prev_action or "auto_reject")
+            client.phone_numbers.update(num.id, incoming_call_action="auto_reject")
         except Exception as exc:  # noqa: BLE001
             log.info("number revert failed: %r", exc)
         listener.close()

--- a/tests/test_live_voice_helpers.py
+++ b/tests/test_live_voice_helpers.py
@@ -1,0 +1,82 @@
+"""Offline coverage for failure handling in the real-call live-test helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _load_live_voice_module():
+    path = Path(__file__).parent / "live" / "test_voice.py"
+    spec = importlib.util.spec_from_file_location("live_voice_helpers", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Calls:
+    def __init__(self, *, call, transcripts):
+        self.call = call
+        self._transcripts = transcripts
+
+    def get(self, _call_id):
+        return self.call
+
+    def transcripts(self, _call_id):
+        if isinstance(self._transcripts, Exception):
+            raise self._transcripts
+        return self._transcripts
+
+
+def test_wait_for_two_way_call_fails_immediately_on_canceled_leg():
+    voice = _load_live_voice_module()
+    remote = SimpleNamespace(calls=_Calls(
+        call=SimpleNamespace(
+            status="canceled", reason=None, hangup_reason="remote",
+            started_at=None, ended_at="now", is_blocked=False,
+        ),
+        transcripts=[],
+    ))
+
+    with pytest.raises(pytest.fail.Exception, match="call ended before a two-way conversation") as exc:
+        voice._wait_for_two_way_call(remote, "unused-number-id", "call-id")
+
+    message = str(exc.value)
+    assert "status='canceled'" in message
+    assert "hangup_reason='remote'" in message
+    assert "is_blocked=False" in message
+
+
+def test_wait_for_two_way_call_returns_remote_speech_when_both_parties_spoke():
+    voice = _load_live_voice_module()
+    segments = [
+        SimpleNamespace(party="remote", text="hello"),
+        SimpleNamespace(party="local", text="hi back"),
+    ]
+    remote = SimpleNamespace(calls=_Calls(
+        call=SimpleNamespace(status="answered"),
+        transcripts=segments,
+    ))
+
+    assert voice._wait_for_two_way_call(remote, "unused-number-id", "call-id") == "hello"
+
+
+def test_wait_for_two_way_call_checks_terminal_state_while_transcripts_are_unavailable():
+    voice = _load_live_voice_module()
+    remote = SimpleNamespace(calls=_Calls(
+        call=SimpleNamespace(
+            status="failed", reason="upstream", hangup_reason=None,
+            started_at=None, ended_at="now", is_blocked=False,
+        ),
+        transcripts=RuntimeError("404 Call not found"),
+    ))
+
+    with pytest.raises(pytest.fail.Exception, match="call ended before a two-way conversation") as exc:
+        voice._wait_for_two_way_call(remote, "unused-number-id", "call-id")
+
+    assert "transcripts not ready" in str(exc.value)
+    assert "status='failed'" in str(exc.value)


### PR DESCRIPTION
## Summary

- hang up every expected live voice call through `calls.hangup(call_id)` in a `finally` block
- snapshot calls owned by each live pytest process, watchdog accidental calls in non-voice suites, and verify every new call is terminal during teardown
- require Inkbox SDK 0.4.24, which exposes the external call-control hangup API
- keep the earlier terminal-state diagnostics and cross-channel contamination fixes
- preserve inbound and outbound live voice coverage

## Root cause

The voice test returned as soon as it observed a two-way transcript, then CI killed the driver before its delayed media `stop` frame. Closing the media WebSocket does not end the carrier leg, so successful tests left calls alive until the ten-minute server cap.

Call records also proved that a general real-channel job can unexpectedly choose the phone tool and create calls outside `test_voice.py`. The session-level ownership watchdog now terminates those calls within its polling interval, while voice tests retain direct per-call cleanup and use the session guard as a fallback.

Those leaked calls exhausted the shared test organization's rolling phone-minute quota; the inbound quota gate then rejected later calls before contact rules, auto-accept, or the plugin ran.

## Validation

- 282 passed, 22 skipped
- simulated cleanup preserved baseline/other-identity calls and terminated the newly owned call
- live voice tests collect successfully
- workflow YAML and `git diff --check` passed
