### PR TITLE
Align contacts with organization-wide access

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install bridge + latest SDK
         run: |
           uv pip install --system \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@8f4b37c56cd153a2acc6cfabe27dbbeb43510f00#subdirectory=sdk/python" \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@199bbd27c8dab2f70e379de52ca9cc910b0e141d#subdirectory=sdk/python" \
             -e . pytest
           uv pip install --system -U claude-agent-sdk
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ The agent reaches you (or third parties) through an in-process MCP server:
 - `inkbox_list_text_conversations` · `inkbox_get_text_conversation` — browse SMS threads and history.
 - `inkbox_list_imessage_conversations` · `inkbox_get_imessage_conversation` — browse iMessage threads and history (find the `conversation_id` to send into).
 - `inkbox_lookup_contact` · `inkbox_list_contacts` · `inkbox_get_contact` — resolve and read address-book contacts (reverse-lookup by email/phone, free-text search, or full record by id).
-- `inkbox_create_contact` · `inkbox_update_contact` · `inkbox_delete_contact` — save, edit, and remove contacts. Reads and writes are filtered server-side to what this identity may see. vCard export/import is not exposed.
+- `inkbox_create_contact` · `inkbox_update_contact` · `inkbox_delete_contact` — save, edit, and remove organization-wide contacts. Changes affect the shared address book. vCard export/import is not exposed.
 
 On a live call, the OpenAI Realtime voice agent additionally gets `consult_agent`, `register_post_call_action` / `edit_post_call_action` / `delete_post_call_action`, and `hang_up_call` — see [Voice](#voice).
 

--- a/inkbox_claude/doctor.py
+++ b/inkbox_claude/doctor.py
@@ -33,7 +33,7 @@ def run_doctor() -> List[Tuple[str, bool, str]]:
         import inkbox  # noqa: F401
         checks.append(("inkbox SDK", True, "installed"))
     except ImportError:
-        checks.append(("inkbox SDK", False, "pip install 'inkbox>=0.5.0,<1.0.0'"))
+        checks.append(("inkbox SDK", False, "pip install 'inkbox>=0.5.1,<1.0.0'"))
 
     try:
         import claude_agent_sdk  # noqa: F401

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -488,7 +488,7 @@ class InkboxGateway:
         if not AIOHTTP_AVAILABLE:
             raise RuntimeError("aiohttp is not installed; run: pip install aiohttp")
         if not INKBOX_AVAILABLE:
-            raise RuntimeError("inkbox SDK is not installed; run: pip install 'inkbox>=0.5.0,<1.0.0'")
+            raise RuntimeError("inkbox SDK is not installed; run: pip install 'inkbox>=0.5.1,<1.0.0'")
         if not self.cfg.api_key or not self.cfg.identity:
             raise RuntimeError("INKBOX_API_KEY and INKBOX_IDENTITY must be set (see README)")
 

--- a/inkbox_claude/prompts.py
+++ b/inkbox_claude/prompts.py
@@ -70,7 +70,7 @@ follows the current conversation's channel, or the only line available.
 
 # Inkbox contacts
 
-Claude can read and write Inkbox contacts visible to this configured identity.
+Claude can read and write the organization's shared Inkbox contacts.
 
 - Use inkbox_list_contacts for name-based searches like "who is Alex?".
 - Use inkbox_lookup_contact when you have an exact or partial email/phone filter.
@@ -79,7 +79,7 @@ Claude can read and write Inkbox contacts visible to this configured identity.
 - Use inkbox_update_contact when the user asks you to change an existing contact; look up the contact first if you do not already have its UUID.
 - Use inkbox_delete_contact only after the target contact is explicit and confirmed.
 - There is no vCard export/import, contact access, or contact rule tool in this harness.
-- Contact tools operate only on contacts visible/writable to the configured identity.
+- Every identity in the organization can read contacts. Creating, updating, or deleting a contact affects the shared address book.
 """.strip()
 
 

--- a/inkbox_claude/setup_wizard.py
+++ b/inkbox_claude/setup_wizard.py
@@ -36,7 +36,7 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
 # Packages the wizard itself needs to talk to Inkbox during setup. The
 # gateway's other dependency (claude-agent-sdk) is checked by doctor.
 INKBOX_MIN_VERSION = (0, 5, 0)
-INKBOX_REQUIREMENTS = ("inkbox>=0.5.0,<1.0.0", "aiohttp>=3.9")
+INKBOX_REQUIREMENTS = ("inkbox>=0.5.1,<1.0.0", "aiohttp>=3.9")
 _BRACKETED_PASTE_PATTERN = re.compile(r"\x1b\[\s*200~|\x1b\[\s*201~")
 
 # Bundled avatar attached to the agent's Inkbox contact card during setup.

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -587,8 +587,7 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
             return _error(str(exc))
 
     # ------------------------------------------------------------------
-    # Contacts — the org address book, filtered server-side to what this
-    # identity may see.
+    # Contacts — the shared organization address book.
     # ------------------------------------------------------------------
 
     @tool(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Inkbox bridge for Claude Code — talk to your coding agent over 
 requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.5.0,<1.0.0",
+  "inkbox>=0.5.1,<1.0.0",
   "claude-agent-sdk>=0.1.0",
   "segno>=1.5",  # terminal QR codes for the iMessage connect step
 ]

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -56,7 +56,8 @@ def test_channel_prompt_mentions_identity_and_dir():
     assert "dev-agent@inkbox.ai" in text
     assert "jargon" in text.lower()
     assert "AskUserQuestion" in text
-    assert "Claude can read and write Inkbox contacts" in text
+    assert "shared Inkbox contacts" in text
+    assert "shared address book" in text
     assert "inkbox_create_contact" in text
     assert "inkbox_update_contact" in text
     assert "inkbox_delete_contact" in text

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -88,7 +88,7 @@ def test_install_command_prefers_uv_when_available(monkeypatch):
         "install",
         "--python",
         "/tmp/venv/bin/python",
-        "inkbox>=0.5.0,<1.0.0",
+        "inkbox>=0.5.1,<1.0.0",
         "aiohttp>=3.9",
     ]]
 
@@ -98,10 +98,10 @@ def test_install_command_falls_back_to_pip_and_ensurepip(monkeypatch):
     monkeypatch.setattr(setup_wizard.shutil, "which", lambda _name: None)
 
     assert setup_wizard._install_commands() == [
-        [["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.0,<1.0.0", "aiohttp>=3.9"]],
+        [["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.1,<1.0.0", "aiohttp>=3.9"]],
         [
             ["/tmp/venv/bin/python", "-m", "ensurepip", "--upgrade"],
-            ["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.0,<1.0.0", "aiohttp>=3.9"],
+            ["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.1,<1.0.0", "aiohttp>=3.9"],
         ],
     ]
 
@@ -120,7 +120,7 @@ def test_missing_sdk_guidance_prints_interpreter(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "/tmp/venv/bin/python" in out
     assert "uv pip install --python" in out
-    assert "inkbox>=0.5.0,<1.0.0" in out
+    assert "inkbox>=0.5.1,<1.0.0" in out
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Decisions

- **Plugin surface:** Kept the existing contact CRUD tools because they remain compatible, while replacing obsolete per-identity visibility guidance with organization-wide behavior.
- **SDK compatibility:** Raised the SDK floor to 0.5.1 and pinned contract CI to the SDK 0.5.1 source revision.

## Changes

- Update prompts, tool comments, setup requirements, diagnostics, and documentation.
- Explain that all identities can read contacts and mutations affect the shared address book.

## Verification

- `pytest -q` against SDK 0.5.1 source (282 passed, 22 skipped)

## Related Changes

- SDK: https://github.com/inkbox-ai/inkbox/pull/119
- OpenCode: https://github.com/inkbox-ai/opencode-plugin/pull/8
- OpenClaw: https://github.com/inkbox-ai/openclaw-plugin/pull/42
- Hermes: https://github.com/inkbox-ai/hermes-agent-plugin/pull/70
- Codex: https://github.com/inkbox-ai/codex-plugin/pull/25