### PR TITLE
Claude Code: serve and delegate A2A tasks

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -27,7 +27,9 @@ jobs:
 
       - name: Install bridge + latest SDK
         run: |
-          pip install -e . pytest
+          pip install \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            -e . pytest
           pip install -U claude-agent-sdk
 
       - name: Install latest Claude Code CLI

--- a/.github/workflows/live-a2a.yml
+++ b/.github/workflows/live-a2a.yml
@@ -1,0 +1,118 @@
+name: Live — Agent2Agent
+
+# Four real protocol legs cover both roles and conversation lengths:
+# inbound/outbound × single-turn/multi-turn. The plugin and remote identities
+# are preconfigured to allow one another in both directions.
+on:
+  workflow_call:
+    inputs:
+      timeout_s:
+        description: "Seconds to wait for each A2A transition"
+        required: false
+        type: string
+        default: "300"
+      orchestrated:
+        description: "True when the full-stack workflow owns the shared live lock"
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      timeout_s:
+        description: "Seconds to wait for each A2A transition"
+        required: false
+        default: "300"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ inputs.orchestrated && format('inkbox-live-child-{0}', github.run_id) || 'inkbox-live-aut-tunnel' }}
+  cancel-in-progress: false
+  queue: max
+
+jobs:
+  a2a:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        scenario:
+          - inbound-single
+          - inbound-multi
+          - outbound-single
+          - outbound-multi
+    env:
+      INKBOX_API_KEY: ${{ secrets.CLAUDE_CODE_INKBOX_API_KEY }}
+      INKBOX_SIGNING_KEY: ${{ secrets.CLAUDE_CODE_INKBOX_SIGNING_KEY }}
+      CLAUDE_PROJECT_DIR: ${{ github.workspace }}
+      INKBOX_PERMISSION_TIMEOUT_S: "30"
+      DISABLE_AUTOUPDATER: "1"
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Install bridge and protocol driver
+        run: pip install -e .
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Configure the real model and AUT identity
+        env:
+          ANTHROPIC_API_KEY_VALUE: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          HANDLE=$(python3 - <<'PY'
+          import os
+          from inkbox import Inkbox
+          client = Inkbox(api_key=os.environ["INKBOX_API_KEY"])
+          print(client.mailboxes.list()[0].email_address.split("@", 1)[0])
+          PY
+          )
+          {
+            echo "INKBOX_IDENTITY=$HANDLE"
+            echo "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY_VALUE"
+          } >> "$GITHUB_ENV"
+
+      - name: Start bridge gateway
+        run: |
+          nohup inkbox-claude run > "$RUNNER_TEMP/gateway.log" 2>&1 &
+          echo $! > "$RUNNER_TEMP/gateway.pid"
+          for _ in $(seq 1 36); do
+            grep -q "\[bridge\] ready" "$RUNNER_TEMP/gateway.log" && exit 0
+            if ! kill -0 "$(cat "$RUNNER_TEMP/gateway.pid")" 2>/dev/null; then
+              echo "::error::gateway exited during startup"
+              exit 1
+            fi
+            sleep 5
+          done
+          echo "::error::gateway did not become ready"
+          exit 1
+
+      - name: Run ${{ matrix.scenario }}
+        env:
+          A2A_SCENARIO: ${{ matrix.scenario }}
+          A2A_TIMEOUT_S: ${{ inputs.timeout_s || '300' }}
+          AUT_INKBOX_API_KEY: ${{ secrets.CLAUDE_CODE_INKBOX_API_KEY }}
+          REMOTE_INKBOX_API_KEY: ${{ secrets.REMOTE_INKBOX_API_KEY }}
+        run: python3 tests/live/a2a_driver.py
+
+      - name: Dump gateway log on failure
+        if: failure()
+        run: tail -n 300 "$RUNNER_TEMP/gateway.log" 2>/dev/null || true
+
+      - name: Stop bridge gateway
+        if: always()
+        run: |
+          kill "$(cat "$RUNNER_TEMP/gateway.pid" 2>/dev/null)" 2>/dev/null || true

--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -65,7 +65,10 @@ jobs:
           node-version: 22
 
       - name: Install bridge
-        run: pip install -e . pytest
+        run: |
+          pip install \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            -e . pytest
 
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code

--- a/.github/workflows/live-external-events.yml
+++ b/.github/workflows/live-external-events.yml
@@ -63,7 +63,10 @@ jobs:
           node-version: 22
 
       - name: Install bridge
-        run: pip install -e . pytest
+        run: |
+          pip install \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            -e . pytest
 
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code

--- a/.github/workflows/live-stack.yml
+++ b/.github/workflows/live-stack.yml
@@ -34,8 +34,24 @@ jobs:
       orchestrated: true
     secrets: inherit
 
-  voice:
+  a2a:
     needs: channels
+    if: >
+      !cancelled() &&
+      ((github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.head.repo.full_name == github.repository) ||
+       github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main'))
+    uses: ./.github/workflows/live-a2a.yml
+    with:
+      orchestrated: true
+    secrets: inherit
+
+  voice:
+    needs: a2a
     if: >
       !cancelled() &&
       ((github.event_name == 'pull_request' &&
@@ -68,7 +84,7 @@ jobs:
 
   full-stack:
     name: full-stack
-    needs: [channels, voice, external-events]
+    needs: [channels, a2a, voice, external-events]
     if: >
       !cancelled() &&
       ((github.event_name == 'pull_request' &&
@@ -83,11 +99,12 @@ jobs:
       - name: Require every live suite to pass
         env:
           CHANNELS_RESULT: ${{ needs.channels.result }}
+          A2A_RESULT: ${{ needs.a2a.result }}
           VOICE_RESULT: ${{ needs.voice.result }}
           EXTERNAL_EVENTS_RESULT: ${{ needs.external-events.result }}
         run: |
           failed=0
-          for suite in CHANNELS VOICE EXTERNAL_EVENTS; do
+          for suite in CHANNELS A2A VOICE EXTERNAL_EVENTS; do
             result_var="${suite}_RESULT"
             result="${!result_var}"
             echo "$suite: $result"
@@ -100,7 +117,7 @@ jobs:
   # One unattended page covers failures from any component or from the gate
   # itself. PR authors and manual dispatchers can see their run directly.
   notify:
-    needs: [channels, voice, external-events, full-stack]
+    needs: [channels, a2a, voice, external-events, full-stack]
     if: >
       always() &&
       github.event_name == 'workflow_run' &&
@@ -108,6 +125,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main' &&
       (needs.channels.result != 'success' ||
+       needs.a2a.result != 'success' ||
        needs.voice.result != 'success' ||
        needs.external-events.result != 'success' ||
        needs.full-stack.result != 'success')

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -56,7 +56,10 @@ jobs:
       # uvicorn[standard] matters: the bare install can't accept WebSocket
       # upgrades, and the driver's call-media endpoint is a WebSocket.
       - name: Install bridge + driver deps
-        run: pip install -e . pytest fastapi 'uvicorn[standard]'
+        run: |
+          pip install \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            -e . pytest fastapi 'uvicorn[standard]'
 
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install bridge + latest SDK
         run: |
           uv pip install --system \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@199bbd27c8dab2f70e379de52ca9cc910b0e141d#subdirectory=sdk/python" \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
             -e . pytest
           uv pip install --system -U claude-agent-sdk
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,12 @@ The agent reaches you (or third parties) through an in-process MCP server:
 - `inkbox_list_imessage_conversations` · `inkbox_get_imessage_conversation` — browse iMessage threads and history (find the `conversation_id` to send into).
 - `inkbox_lookup_contact` · `inkbox_list_contacts` · `inkbox_get_contact` — resolve and read address-book contacts (reverse-lookup by email/phone, free-text search, or full record by id).
 - `inkbox_create_contact` · `inkbox_update_contact` · `inkbox_delete_contact` — save, edit, and remove organization-wide contacts. Changes affect the shared address book. vCard export/import is not exposed.
+- `inkbox_a2a_call` · `inkbox_a2a_check` · `inkbox_a2a_reply` — delegate work to another agent and follow its task.
+- `inkbox_a2a_complete` · `inkbox_a2a_ask_caller` · `inkbox_a2a_fail` — commit the outcome of a verified inbound A2A task. These tools are rejected outside that task's isolated session.
+
+Inbound A2A serving and A2A client tools require Inkbox SDK 0.5.5 or newer.
+Other bridge features continue to support the base SDK range in
+`pyproject.toml`.
 
 On a live call, the OpenAI Realtime voice agent additionally gets `consult_agent`, `register_post_call_action` / `edit_post_call_action` / `delete_post_call_action`, and `hang_up_call` — see [Voice](#voice).
 

--- a/README.md
+++ b/README.md
@@ -239,11 +239,10 @@ The agent reaches you (or third parties) through an in-process MCP server:
 - `inkbox_lookup_contact` · `inkbox_list_contacts` · `inkbox_get_contact` — resolve and read address-book contacts (reverse-lookup by email/phone, free-text search, or full record by id).
 - `inkbox_create_contact` · `inkbox_update_contact` · `inkbox_delete_contact` — save, edit, and remove organization-wide contacts. Changes affect the shared address book. vCard export/import is not exposed.
 - `inkbox_a2a_call` · `inkbox_a2a_check` · `inkbox_a2a_reply` — delegate work to another agent and follow its task.
+- `inkbox_list_a2a_tasks` · `inkbox_list_a2a_messages` — page and search this identity's inbound and outbound A2A history, with participant, task, context, role, state, and timestamp filters.
 - `inkbox_a2a_complete` · `inkbox_a2a_ask_caller` · `inkbox_a2a_fail` — commit the outcome of a verified inbound A2A task. These tools are rejected outside that task's isolated session.
 
-Inbound A2A serving and A2A client tools require Inkbox SDK 0.5.5 or newer.
-Other bridge features continue to support the base SDK range in
-`pyproject.toml`.
+The bridge requires Inkbox SDK 0.5.6 or newer.
 
 On a live call, the OpenAI Realtime voice agent additionally gets `consult_agent`, `register_post_call_action` / `edit_post_call_action` / `delete_post_call_action`, and `hang_up_call` — see [Voice](#voice).
 

--- a/inkbox_claude/a2a_delegations.py
+++ b/inkbox_claude/a2a_delegations.py
@@ -1,0 +1,106 @@
+"""Durable caller-side A2A delegation routing records."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+from urllib.parse import urlsplit
+
+_LOCK = threading.Lock()
+
+
+def _path() -> Path:
+    root = Path(
+        os.getenv("INKBOX_CLAUDE_HOME")
+        or (Path.home() / ".inkbox-claude")
+    )
+    return root / "a2a_delegations.json"
+
+
+def _origin(url: str) -> str:
+    parsed = urlsplit(url)
+    return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}"
+
+
+def _read() -> Dict[str, Dict[str, Any]]:
+    try:
+        loaded = json.loads(_path().read_text())
+        return loaded if isinstance(loaded, dict) else {}
+    except FileNotFoundError:
+        return {}
+
+
+def _write(records: Dict[str, Dict[str, Any]]) -> None:
+    path = _path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(records, indent=2, sort_keys=True) + "\n")
+    tmp.chmod(0o600)
+    os.replace(tmp, path)
+    path.chmod(0o600)
+
+
+def record_before_send(
+    *,
+    identity_id: str,
+    rpc_url: str,
+    card_url: str,
+    message_id: str,
+    session_key: Optional[str],
+    context_id: Optional[str] = None,
+    task_id: Optional[str] = None,
+) -> str:
+    """Persist retry and routing data before the SendMessage request."""
+    origin = _origin(rpc_url)
+    context_key = context_id or f"pending:{message_id}"
+    key = f"{identity_id}|{origin}|{context_key}"
+    with _LOCK:
+        records = _read()
+        records[key] = {
+            "identity_id": identity_id,
+            "origin": origin,
+            "card_url": card_url,
+            "context_id": context_id,
+            "task_id": task_id,
+            "message_id": message_id,
+            "session_key": session_key,
+            "updated_at": time.time(),
+        }
+        _write(records)
+    return key
+
+
+def promote_after_send(
+    pending_key: str,
+    *,
+    context_id: str,
+    task_id: str,
+) -> None:
+    """Promote a provisional record to its canonical context key."""
+    with _LOCK:
+        records = _read()
+        record = records.pop(pending_key, None)
+        if record is None:
+            return
+        record["context_id"] = context_id
+        record["task_id"] = task_id
+        record["updated_at"] = time.time()
+        key = (
+            f"{record['identity_id']}|{record['origin']}|{context_id}"
+        )
+        records[key] = record
+        _write(records)
+
+
+def find_by_task(task_id: str) -> Optional[Dict[str, Any]]:
+    """Return the newest local delegation record for a remote task."""
+    matches = [
+        record
+        for record in _read().values()
+        if str(record.get("task_id") or "") == task_id
+    ]
+    return max(matches, key=lambda item: item.get("updated_at", 0), default=None)

--- a/inkbox_claude/doctor.py
+++ b/inkbox_claude/doctor.py
@@ -33,7 +33,7 @@ def run_doctor() -> List[Tuple[str, bool, str]]:
         import inkbox  # noqa: F401
         checks.append(("inkbox SDK", True, "installed"))
     except ImportError:
-        checks.append(("inkbox SDK", False, "pip install 'inkbox>=0.5.1,<1.0.0'"))
+        checks.append(("inkbox SDK", False, "pip install 'inkbox>=0.5.6,<1.0.0'"))
 
     try:
         import claude_agent_sdk  # noqa: F401

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -64,6 +64,7 @@ try:
         call_contexts_dir,
         inkbox_client_kwargs,
     )
+    from .a2a_delegations import find_by_task as find_a2a_delegation
     from .media import download_media, inbound_media_note
     from .prompts import contact_marker, strip_markdown
     from .realtime import (
@@ -76,6 +77,7 @@ try:
     from .webhook_providers import match_provider
 except ImportError:  # pragma: no cover - direct local import/test fallback
     from config import DEFAULT_WEBHOOK_PATH, INKBOX_WS_PATH, BridgeConfig, call_contexts_dir, inkbox_client_kwargs
+    from a2a_delegations import find_by_task as find_a2a_delegation
     from media import download_media, inbound_media_note
     from prompts import contact_marker, strip_markdown
     from realtime import (
@@ -409,6 +411,13 @@ IMESSAGE_EVENTS = [
     "imessage.delivery_failed",
     "imessage.reaction_received",
 ]
+A2A_EVENTS = [
+    "a2a.task.created",
+    "a2a.task.message",
+    "a2a.task.canceled",
+    "a2a.sent_task.updated",
+]
+A2A_TERMINAL_STATES = {"completed", "failed", "canceled", "rejected"}
 
 
 def _message_too_long_reason(channel: str, content: str, max_chars: int) -> str:
@@ -495,6 +504,10 @@ class InkboxGateway:
         # delivery-failure feedback loop stops waking the agent after
         # OUTBOUND_FAILURE_MAX_ATTEMPTS. Reset on inbound / delivered / TTL.
         self._outbound_failure_state: Dict[str, Dict[str, float]] = {}
+        self._a2a_registry_path = (
+            Path.home() / ".inkbox-claude" / "a2a_tasks.json"
+        )
+        self._a2a_jobs: Dict[str, set[asyncio.Task[Any]]] = {}
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -549,6 +562,7 @@ class InkboxGateway:
             on_send_rejected=self._note_send_rejection,
             health_fn=self.health_report,
         )
+        await self._catch_up_a2a_tasks()
 
         logger.info(
             "[bridge] ready — %s / %s / %s → Claude Code in %s",
@@ -657,9 +671,11 @@ class InkboxGateway:
                 "[bridge] incoming-call action for %s → %s + %s",
                 self.cfg.identity, webhook_url, ws_url,
             )
+        identity_events = list(A2A_EVENTS)
         if getattr(identity, "imessage_enabled", False):
-            _reconcile({"agent_identity_id": identity.id}, IMESSAGE_EVENTS)
-            logger.info("[bridge] iMessage for %s → %s", self.cfg.identity, webhook_url)
+            identity_events = [*IMESSAGE_EVENTS, *identity_events]
+        _reconcile({"agent_identity_id": identity.id}, identity_events)
+        logger.info("[bridge] identity events for %s → %s", self.cfg.identity, webhook_url)
 
     async def _cleanup(self) -> None:
         if self.sessions is not None:
@@ -808,6 +824,8 @@ class InkboxGateway:
                     response = await self._on_imessage_received(envelope)
                 elif event_type == "imessage.reaction_received":
                     response = await self._on_imessage_reaction_received(envelope)
+                elif event_type.startswith("a2a."):
+                    response = await self._on_a2a_event(envelope)
                 # Outbound delivery failures: tell the agent its message didn't
                 # land so it can retry or reach the human another way.
                 elif event_type == "text.delivery_failed":
@@ -877,7 +895,9 @@ class InkboxGateway:
         Returns:
             bool: True for a recognised Inkbox event shape.
         """
-        if event_type and event_type.startswith(("message.", "text.", "imessage.")):
+        if event_type and event_type.startswith(
+            ("message.", "text.", "imessage.", "a2a.")
+        ):
             return True
         # ``id`` by itself is not a call discriminator: generic external
         # webhook schemas commonly use a top-level event id.  Treat an
@@ -2176,6 +2196,227 @@ class InkboxGateway:
         # take a while (the agent may call/message someone).
         asyncio.create_task(self._run_external_turn(chat_id, prompt, directive))
         return web.json_response({"ok": True})
+
+    def _read_a2a_registry(self) -> Dict[str, Any]:
+        try:
+            loaded = json.loads(self._a2a_registry_path.read_text())
+            return loaded if isinstance(loaded, dict) else {}
+        except FileNotFoundError:
+            return {}
+
+    def _write_a2a_registry(
+        self,
+        key: str,
+        data: Dict[str, Any],
+        state: str,
+    ) -> None:
+        current = self._read_a2a_registry()
+        current[key] = {
+            "task_id": str(data.get("task_id") or ""),
+            "message_id": str(data.get("message_id") or ""),
+            "context_id": str(data.get("context_id") or ""),
+            "state": state,
+            "updated_at": time.time(),
+        }
+        self._a2a_registry_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._a2a_registry_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n")
+        tmp.chmod(0o600)
+        os.replace(tmp, self._a2a_registry_path)
+        self._a2a_registry_path.chmod(0o600)
+
+    def _track_a2a_job(
+        self,
+        task_id: str,
+        registry_key: str,
+        data: Dict[str, Any],
+    ) -> None:
+        job = asyncio.create_task(self._run_a2a_turn(registry_key, data))
+        self._a2a_jobs.setdefault(task_id, set()).add(job)
+        job.add_done_callback(
+            lambda done, value=task_id: self._a2a_jobs.get(value, set()).discard(done)
+        )
+
+    @staticmethod
+    def _a2a_event_data(task: Any) -> Dict[str, Any]:
+        message = task.messages[-1] if task.messages else None
+        return {
+            "task_id": str(task.id),
+            "context_id": str(task.context_id),
+            "state": str(getattr(task.state, "value", task.state)),
+            "caller": {
+                "identity_id": str(task.caller.identity_id),
+                "organization_id": task.caller.organization_id,
+                "handle": task.caller.handle,
+            },
+            "message_id": (
+                str(message.message_id)
+                if message is not None
+                else f"task:{task.id}"
+            ),
+            "parts": message.parts if message is not None else [],
+        }
+
+    async def _on_a2a_event(
+        self,
+        envelope: Dict[str, Any],
+    ) -> "web.Response":
+        event_type = str(envelope.get("event_type") or "")
+        data = envelope.get("data") if isinstance(envelope.get("data"), dict) else {}
+        task_id = str(data.get("task_id") or "")
+        context_id = str(data.get("context_id") or "")
+        message_id = str(data.get("message_id") or envelope.get("id") or "")
+        if not task_id or not context_id:
+            return web.json_response({"ok": True, "ignored": "invalid-a2a-event"})
+
+        if event_type == "a2a.task.canceled":
+            for job in list(self._a2a_jobs.get(task_id, set())):
+                job.cancel()
+            self._a2a_jobs.pop(task_id, None)
+            return web.json_response({"ok": True})
+        if event_type == "a2a.sent_task.updated":
+            delegation = find_a2a_delegation(task_id)
+            session_key = str((delegation or {}).get("session_key") or "")
+            if self.sessions is not None and session_key:
+                parts = data.get("parts") if isinstance(data.get("parts"), list) else []
+                text = "\n".join(
+                    str(part.get("text"))
+                    for part in parts
+                    if isinstance(part, dict) and part.get("text")
+                )
+                prompt = (
+                    f"[inkbox:a2a_sent_task_updated task_id={task_id} "
+                    f"context_id={context_id} state={data.get('state') or 'unknown'}]\n"
+                    "An A2A task you delegated changed state. Use "
+                    "inkbox_a2a_check or inkbox_a2a_reply with the stored "
+                    f"Agent Card URL {(delegation or {}).get('card_url') or 'unknown'} "
+                    "if follow-up is needed."
+                )
+                if text:
+                    prompt = f"{prompt}\n\nRemote agent message:\n{text}"
+                await self.sessions.get(session_key).handle_inbound(
+                    prompt,
+                    "external",
+                    {
+                        "a2a_task_id": task_id,
+                        "a2a_context_id": context_id,
+                    },
+                )
+            else:
+                logger.info(
+                    "[bridge] outbound A2A task updated without a local session: %s",
+                    task_id,
+                )
+            return web.json_response({"ok": True})
+
+        key = f"{task_id}:{message_id}"
+        if key in self._read_a2a_registry():
+            return web.json_response({"ok": True, "deduped": True})
+        self._write_a2a_registry(key, data, "queued")
+        self._track_a2a_job(task_id, key, data)
+        return web.json_response({"ok": True})
+
+    async def _run_a2a_turn(
+        self,
+        registry_key: str,
+        data: Dict[str, Any],
+    ) -> None:
+        task_id = str(data["task_id"])
+        context_id = str(data["context_id"])
+        caller = data.get("caller") if isinstance(data.get("caller"), dict) else {}
+        parts = data.get("parts") if isinstance(data.get("parts"), list) else []
+        text = "\n".join(
+            str(part.get("text"))
+            for part in parts
+            if isinstance(part, dict) and part.get("text")
+        )
+        marker = (
+            f"[inkbox:a2a_task caller=@{str(caller.get('handle') or 'unknown').lstrip('@')} "
+            f"caller_org={caller.get('organization_id') or 'unknown'}]"
+        )
+        context = {
+            "task_id": task_id,
+            "message_id": str(data.get("message_id") or ""),
+            "context_id": context_id,
+            "reply_intent_committed": False,
+        }
+        self._write_a2a_registry(registry_key, data, "running")
+        try:
+            if self.sessions is None:
+                return
+            session = self.sessions.get(
+                f"a2a:{self._identity.id}:{context_id}",
+                system_prompt_extra=(
+                    "You are handling an inbound A2A task. Use "
+                    "inkbox_a2a_complete, inkbox_a2a_ask_caller, or "
+                    "inkbox_a2a_fail when an explicit outcome is appropriate."
+                ),
+            )
+            reply = await session.run_consult(
+                f"{marker}\n{text}".rstrip(),
+                a2a_context=context,
+            )
+            if (
+                not context["reply_intent_committed"]
+                and reply.strip()
+                and reply.strip().upper() != "[SILENT]"
+            ):
+                authoritative = await asyncio.to_thread(
+                    self._identity.a2a_task, task_id
+                )
+                state = str(
+                    getattr(authoritative.state, "value", authoritative.state)
+                )
+                if state not in A2A_TERMINAL_STATES:
+                    await asyncio.to_thread(
+                        self._identity.a2a_reply,
+                        task_id,
+                        intent="complete",
+                        text=reply,
+                    )
+            self._write_a2a_registry(registry_key, data, "finalized")
+        except asyncio.CancelledError:
+            authoritative = await asyncio.to_thread(
+                self._identity.a2a_task, task_id
+            )
+            state = str(getattr(authoritative.state, "value", authoritative.state))
+            if state in A2A_TERMINAL_STATES:
+                self._write_a2a_registry(registry_key, data, "finalized")
+            raise
+        except Exception:
+            logger.exception("[bridge] A2A turn failed: %s", task_id)
+
+    async def _catch_up_a2a_tasks(self) -> None:
+        try:
+            for key, entry in self._read_a2a_registry().items():
+                if entry.get("state") == "finalized":
+                    continue
+                task_id = str(entry.get("task_id") or "")
+                if not task_id or self._a2a_jobs.get(task_id):
+                    continue
+                full = await asyncio.to_thread(self._identity.a2a_task, task_id)
+                state = str(getattr(full.state, "value", full.state))
+                data = self._a2a_event_data(full)
+                if state in A2A_TERMINAL_STATES:
+                    self._write_a2a_registry(key, data, "finalized")
+                else:
+                    self._track_a2a_job(task_id, key, data)
+
+            tasks = await asyncio.to_thread(
+                lambda: list(self._identity.iter_a2a_tasks(state="submitted"))
+            )
+            for task in tasks:
+                full = await asyncio.to_thread(self._identity.a2a_task, task.id)
+                data = self._a2a_event_data(full)
+                await self._on_a2a_event(
+                    {
+                        "id": f"catchup:{task.id}:{data['message_id']}",
+                        "event_type": "a2a.task.created",
+                        "data": data,
+                    }
+                )
+        except Exception:
+            logger.exception("[bridge] A2A catch-up failed")
 
     async def _run_external_turn(self, chat_id: str, prompt: str, directive: str) -> None:
         try:

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -423,8 +423,11 @@ A2A_TERMINAL_STATES = {"completed", "failed", "canceled", "rejected"}
 def _is_unsupported_a2a_event_types(exc: Exception) -> bool:
     detail = str(getattr(exc, "detail", exc))
     return (
-        getattr(exc, "status_code", None) == 422
-        and any(event_type in detail for event_type in A2A_EVENTS)
+        any(event_type in detail for event_type in A2A_EVENTS)
+        and (
+            getattr(exc, "status_code", None) == 422
+            or "does not belong to any known channel" in detail
+        )
     )
 
 

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -533,7 +533,7 @@ class InkboxGateway:
         if not AIOHTTP_AVAILABLE:
             raise RuntimeError("aiohttp is not installed; run: pip install aiohttp")
         if not INKBOX_AVAILABLE:
-            raise RuntimeError("inkbox SDK is not installed; run: pip install 'inkbox>=0.5.1,<1.0.0'")
+            raise RuntimeError("inkbox SDK is not installed; run: pip install 'inkbox>=0.5.6,<1.0.0'")
         if not self.cfg.api_key or not self.cfg.identity:
             raise RuntimeError("INKBOX_API_KEY and INKBOX_IDENTITY must be set (see README)")
 

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -635,16 +635,34 @@ class InkboxGateway:
         ws_url = f"wss://{self._public_host}{INKBOX_WS_PATH}"
         identity = self._inkbox.get_identity(self.cfg.identity)
 
-        def _reconcile(owner_kw: Dict[str, Any], event_types: List[str]) -> None:
+        def _reconcile(
+            owner_kw: Dict[str, Any],
+            event_types: List[str],
+            *,
+            subscription_url: str = webhook_url,
+        ) -> None:
             existing = self._inkbox.webhooks.subscriptions.list(**owner_kw)
+            desired_families = {
+                event_type.split(".", 1)[0] for event_type in event_types
+            }
             for sub in existing:
-                if sub.url == webhook_url and set(sub.event_types) == set(event_types):
+                if (
+                    sub.url == subscription_url
+                    and set(sub.event_types) == set(event_types)
+                ):
                     return  # already wired
-                if sub.url.endswith(DEFAULT_WEBHOOK_PATH):
-                    # A previous bridge install — replace it.
+                existing_families = {
+                    event_type.split(".", 1)[0] for event_type in sub.event_types
+                }
+                if (
+                    sub.url.split("?", 1)[0].endswith(DEFAULT_WEBHOOK_PATH)
+                    and desired_families & existing_families
+                ):
+                    # Replace only this event channel. One identity may have
+                    # separate iMessage and A2A subscriptions at the same URL.
                     self._inkbox.webhooks.subscriptions.delete(sub.id)
             self._inkbox.webhooks.subscriptions.create(
-                url=webhook_url, event_types=event_types, **owner_kw
+                url=subscription_url, event_types=event_types, **owner_kw
             )
 
         if identity.mailbox is not None:
@@ -682,11 +700,12 @@ class InkboxGateway:
                 "[bridge] incoming-call action for %s → %s + %s",
                 self.cfg.identity, webhook_url, ws_url,
             )
-        identity_events = list(A2A_EVENTS)
-        if getattr(identity, "imessage_enabled", False):
-            identity_events = [*IMESSAGE_EVENTS, *identity_events]
         try:
-            _reconcile({"agent_identity_id": identity.id}, identity_events)
+            _reconcile(
+                {"agent_identity_id": identity.id},
+                A2A_EVENTS,
+                subscription_url=f"{webhook_url}?channel=a2a",
+            )
         except Exception as exc:
             if not _is_unsupported_a2a_event_types(exc):
                 raise
@@ -694,8 +713,8 @@ class InkboxGateway:
                 "[bridge] Inkbox API does not support A2A webhook events yet; "
                 "continuing without A2A delivery until the backend is upgraded"
             )
-            if getattr(identity, "imessage_enabled", False):
-                _reconcile({"agent_identity_id": identity.id}, IMESSAGE_EVENTS)
+        if getattr(identity, "imessage_enabled", False):
+            _reconcile({"agent_identity_id": identity.id}, IMESSAGE_EVENTS)
         logger.info("[bridge] identity events for %s → %s", self.cfg.identity, webhook_url)
 
     async def _cleanup(self) -> None:

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -420,6 +420,14 @@ A2A_EVENTS = [
 A2A_TERMINAL_STATES = {"completed", "failed", "canceled", "rejected"}
 
 
+def _is_unsupported_a2a_event_types(exc: Exception) -> bool:
+    detail = str(getattr(exc, "detail", exc))
+    return (
+        getattr(exc, "status_code", None) == 422
+        and any(event_type in detail for event_type in A2A_EVENTS)
+    )
+
+
 def _message_too_long_reason(channel: str, content: str, max_chars: int) -> str:
     char_count = len(content or "")
     return (
@@ -674,7 +682,17 @@ class InkboxGateway:
         identity_events = list(A2A_EVENTS)
         if getattr(identity, "imessage_enabled", False):
             identity_events = [*IMESSAGE_EVENTS, *identity_events]
-        _reconcile({"agent_identity_id": identity.id}, identity_events)
+        try:
+            _reconcile({"agent_identity_id": identity.id}, identity_events)
+        except Exception as exc:
+            if not _is_unsupported_a2a_event_types(exc):
+                raise
+            logger.warning(
+                "[bridge] Inkbox API does not support A2A webhook events yet; "
+                "continuing without A2A delivery until the backend is upgraded"
+            )
+            if getattr(identity, "imessage_enabled", False):
+                _reconcile({"agent_identity_id": identity.id}, IMESSAGE_EVENTS)
         logger.info("[bridge] identity events for %s → %s", self.cfg.identity, webhook_url)
 
     async def _cleanup(self) -> None:

--- a/inkbox_claude/sessions.py
+++ b/inkbox_claude/sessions.py
@@ -88,6 +88,7 @@ class _Turn:
 
     text: str
     future: Optional["asyncio.Future[str]"] = None
+    a2a_context: Optional[Dict[str, Any]] = None
 
 # Leading slash-commands the human can text to steer the conversation itself.
 # The bridge acts on these locally — they never reach Claude as a turn.
@@ -647,6 +648,13 @@ class ContactSession:
         self._current_turn = turn
         typing_task: Optional[asyncio.Task] = None
         retried_missing_resume = False
+        a2a_token = None
+        if turn.a2a_context is not None:
+            try:
+                from .tools import A2A_TURN_CONTEXT
+            except ImportError:  # pragma: no cover
+                from tools import A2A_TURN_CONTEXT
+            a2a_token = A2A_TURN_CONTEXT.set(turn.a2a_context)
         try:
             while True:
                 try:
@@ -697,6 +705,8 @@ class ContactSession:
                 return
             raise
         finally:
+            if a2a_token is not None:
+                A2A_TURN_CONTEXT.reset(a2a_token)
             self._turn_active = False
             self._current_turn = None
             if typing_task is not None:
@@ -766,7 +776,12 @@ class ContactSession:
                     self.chat_id, self.mode, self.reply_meta, reply, exc
                 )
 
-    async def run_consult(self, query: str) -> str:
+    async def run_consult(
+        self,
+        query: str,
+        *,
+        a2a_context: Optional[Dict[str, Any]] = None,
+    ) -> str:
         """Run one Claude Code turn and RETURN its text (don't send it).
 
         Used by the Realtime voice bridge, post-call actions, and delivery-
@@ -786,7 +801,9 @@ class ContactSession:
         """
         loop = asyncio.get_running_loop()
         future: asyncio.Future[str] = loop.create_future()
-        await self._queue.put(_Turn(text=query, future=future))
+        await self._queue.put(
+            _Turn(text=query, future=future, a2a_context=a2a_context)
+        )
         if self._worker is None or self._worker.done():
             self._worker = asyncio.create_task(self._drain())
         return await future

--- a/inkbox_claude/setup_wizard.py
+++ b/inkbox_claude/setup_wizard.py
@@ -35,8 +35,8 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
 
 # Packages the wizard itself needs to talk to Inkbox during setup. The
 # gateway's other dependency (claude-agent-sdk) is checked by doctor.
-INKBOX_MIN_VERSION = (0, 5, 0)
-INKBOX_REQUIREMENTS = ("inkbox>=0.5.1,<1.0.0", "aiohttp>=3.9")
+INKBOX_MIN_VERSION = (0, 5, 6)
+INKBOX_REQUIREMENTS = ("inkbox>=0.5.6,<1.0.0", "aiohttp>=3.9")
 _BRACKETED_PASTE_PATTERN = re.compile(r"\x1b\[\s*200~|\x1b\[\s*201~")
 
 # Bundled avatar attached to the agent's Inkbox contact card during setup.

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -14,6 +14,7 @@ import logging
 import mimetypes
 import secrets
 import time
+import uuid
 from contextvars import ContextVar
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -26,8 +27,18 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
 
 try:
     from .config import INKBOX_WS_PATH, call_contexts_dir
+    from .a2a_delegations import (
+        find_by_task,
+        promote_after_send,
+        record_before_send,
+    )
 except ImportError:  # pragma: no cover - direct local import/test fallback
     from config import INKBOX_WS_PATH, call_contexts_dir
+    from a2a_delegations import (
+        find_by_task,
+        promote_after_send,
+        record_before_send,
+    )
 
 try:
     from claude_agent_sdk import create_sdk_mcp_server, tool
@@ -48,6 +59,10 @@ IMESSAGE_MAX_LENGTH = 18995
 # is long-lived and its ``mode`` mutates per inbound message, giving tools a
 # live view of the conversation's channel.
 CURRENT_SESSION: ContextVar[Any] = ContextVar("inkbox_claude_current_session", default=None)
+A2A_TURN_CONTEXT: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
+    "inkbox_claude_a2a_turn",
+    default=None,
+)
 
 
 def _mark_tool_delivery(mode: str, target: str) -> None:
@@ -738,16 +753,46 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
     )
     async def inkbox_a2a_call(args: Dict[str, Any]) -> Dict[str, Any]:
         def _run():
-            a2a = _identity().a2a_client()
+            identity = _identity()
+            a2a = identity.a2a_client()
             try:
                 target = a2a.fetch_card(str(args["card_url"]))
-                return a2a.send(
+                message_id = str(args.get("message_id") or uuid.uuid4())
+                session = CURRENT_SESSION.get()
+                pending_key = record_before_send(
+                    identity_id=str(identity.id),
+                    rpc_url=str(
+                        getattr(target, "rpc_url", None)
+                        or target["rpc_url"]
+                    ),
+                    card_url=str(args["card_url"]),
+                    message_id=message_id,
+                    context_id=args.get("context_id") or None,
+                    task_id=args.get("task_id") or None,
+                    session_key=getattr(session, "chat_id", None),
+                )
+                result = a2a.send(
                     target,
                     text=str(args["text"]),
                     context_id=args.get("context_id") or None,
                     task_id=args.get("task_id") or None,
-                    message_id=args.get("message_id") or None,
+                    message_id=message_id,
                 )
+                task = getattr(result, "task", None)
+                if task is None and isinstance(result, dict):
+                    task = result.get("task")
+                task_id = getattr(task, "id", None)
+                context_id = getattr(task, "context_id", None)
+                if isinstance(task, dict):
+                    task_id = task.get("id")
+                    context_id = task.get("context_id") or task.get("contextId")
+                if task_id and context_id:
+                    promote_after_send(
+                        pending_key,
+                        context_id=str(context_id),
+                        task_id=str(task_id),
+                    )
+                return result
             finally:
                 a2a.close()
 
@@ -784,20 +829,110 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
     )
     async def inkbox_a2a_reply(args: Dict[str, Any]) -> Dict[str, Any]:
         def _run():
-            a2a = _identity().a2a_client()
+            identity = _identity()
+            a2a = identity.a2a_client()
             try:
                 target = a2a.fetch_card(str(args["card_url"]))
-                return a2a.send(
-                    target,
-                    task_id=str(args["task_id"]),
-                    text=str(args["text"]),
-                    message_id=args.get("message_id") or None,
+                task_id = str(args["task_id"])
+                existing = find_by_task(task_id) or {}
+                message_id = str(args.get("message_id") or uuid.uuid4())
+                session = CURRENT_SESSION.get()
+                pending_key = record_before_send(
+                    identity_id=str(identity.id),
+                    rpc_url=str(
+                        getattr(target, "rpc_url", None)
+                        or target["rpc_url"]
+                    ),
+                    card_url=str(args["card_url"]),
+                    message_id=message_id,
+                    context_id=existing.get("context_id"),
+                    task_id=task_id,
+                    session_key=(
+                        getattr(session, "chat_id", None)
+                        or existing.get("session_key")
+                    ),
                 )
+                result = a2a.send(
+                    target,
+                    task_id=task_id,
+                    text=str(args["text"]),
+                    message_id=message_id,
+                )
+                task = getattr(result, "task", None)
+                if task is None and isinstance(result, dict):
+                    task = result.get("task")
+                context_id = getattr(task, "context_id", None)
+                if isinstance(task, dict):
+                    context_id = task.get("context_id") or task.get("contextId")
+                if context_id:
+                    promote_after_send(
+                        pending_key,
+                        context_id=str(context_id),
+                        task_id=task_id,
+                    )
+                return result
             finally:
                 a2a.close()
 
         try:
             return _result(await asyncio.to_thread(_run))
+        except Exception as exc:
+            return _error(str(exc))
+
+    def _a2a_intent(intent: str, text: str) -> Any:
+        context = A2A_TURN_CONTEXT.get()
+        if context is None:
+            raise RuntimeError("This tool is only available during an inbound A2A task")
+        result = _identity().a2a_reply(
+            context["task_id"],
+            intent=intent,
+            text=text,
+        )
+        context["reply_intent_committed"] = True
+        return result
+
+    @tool(
+        "inkbox_a2a_complete",
+        "Complete the active inbound A2A task with a final answer.",
+        {"text": str},
+    )
+    async def inkbox_a2a_complete(args: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            return _result(
+                await asyncio.to_thread(
+                    _a2a_intent, "complete", str(args["text"])
+                )
+            )
+        except Exception as exc:
+            return _error(str(exc))
+
+    @tool(
+        "inkbox_a2a_ask_caller",
+        "Ask the caller for more input on the active inbound A2A task.",
+        {"text": str},
+    )
+    async def inkbox_a2a_ask_caller(args: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            return _result(
+                await asyncio.to_thread(
+                    _a2a_intent, "ask_caller", str(args["text"])
+                )
+            )
+        except Exception as exc:
+            return _error(str(exc))
+
+    @tool(
+        "inkbox_a2a_fail",
+        "Fail the active inbound A2A task with a reason.",
+        {"reason": str},
+    )
+    async def inkbox_a2a_fail(args: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            return _result(
+                await asyncio.to_thread(
+                    _a2a_intent, "fail", str(args["reason"])
+                )
+            )
         except Exception as exc:
             return _error(str(exc))
 
@@ -822,6 +957,9 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         inkbox_a2a_call,
         inkbox_a2a_check,
         inkbox_a2a_reply,
+        inkbox_a2a_complete,
+        inkbox_a2a_ask_caller,
+        inkbox_a2a_fail,
     ]
     server = create_sdk_mcp_server(name="inkbox", version="0.1.0", tools=tools)
     tool_names = [
@@ -845,5 +983,8 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         "mcp__inkbox__inkbox_a2a_call",
         "mcp__inkbox__inkbox_a2a_check",
         "mcp__inkbox__inkbox_a2a_reply",
+        "mcp__inkbox__inkbox_a2a_complete",
+        "mcp__inkbox__inkbox_a2a_ask_caller",
+        "mcp__inkbox__inkbox_a2a_fail",
     ]
     return server, tool_names

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -729,6 +729,78 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         except Exception as exc:
             return _error(str(exc))
 
+    @tool(
+        "inkbox_a2a_call",
+        "Send a task to an A2A 1.0 Agent Card. Keep the returned task and "
+        "context ids for later checks or replies.",
+        {"card_url": str, "text": str, "context_id": str, "task_id": str,
+         "message_id": str},
+    )
+    async def inkbox_a2a_call(args: Dict[str, Any]) -> Dict[str, Any]:
+        def _run():
+            a2a = _identity().a2a_client()
+            try:
+                target = a2a.fetch_card(str(args["card_url"]))
+                return a2a.send(
+                    target,
+                    text=str(args["text"]),
+                    context_id=args.get("context_id") or None,
+                    task_id=args.get("task_id") or None,
+                    message_id=args.get("message_id") or None,
+                )
+            finally:
+                a2a.close()
+
+        try:
+            return _result(await asyncio.to_thread(_run))
+        except Exception as exc:
+            return _error(str(exc))
+
+    @tool(
+        "inkbox_a2a_check",
+        "Fetch an A2A task, or wait until it reaches a final or input-required state.",
+        {"card_url": str, "task_id": str, "wait": bool},
+    )
+    async def inkbox_a2a_check(args: Dict[str, Any]) -> Dict[str, Any]:
+        def _run():
+            a2a = _identity().a2a_client()
+            try:
+                target = a2a.fetch_card(str(args["card_url"]))
+                if args.get("wait"):
+                    return a2a.wait(target, str(args["task_id"]))
+                return a2a.get_task(target, str(args["task_id"]))
+            finally:
+                a2a.close()
+
+        try:
+            return _result(await asyncio.to_thread(_run))
+        except Exception as exc:
+            return _error(str(exc))
+
+    @tool(
+        "inkbox_a2a_reply",
+        "Reply to a remote A2A task that requested more input.",
+        {"card_url": str, "task_id": str, "text": str, "message_id": str},
+    )
+    async def inkbox_a2a_reply(args: Dict[str, Any]) -> Dict[str, Any]:
+        def _run():
+            a2a = _identity().a2a_client()
+            try:
+                target = a2a.fetch_card(str(args["card_url"]))
+                return a2a.send(
+                    target,
+                    task_id=str(args["task_id"]),
+                    text=str(args["text"]),
+                    message_id=args.get("message_id") or None,
+                )
+            finally:
+                a2a.close()
+
+        try:
+            return _result(await asyncio.to_thread(_run))
+        except Exception as exc:
+            return _error(str(exc))
+
     tools = [
         inkbox_whoami,
         inkbox_send_email,
@@ -747,6 +819,9 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         inkbox_create_contact,
         inkbox_update_contact,
         inkbox_delete_contact,
+        inkbox_a2a_call,
+        inkbox_a2a_check,
+        inkbox_a2a_reply,
     ]
     server = create_sdk_mcp_server(name="inkbox", version="0.1.0", tools=tools)
     tool_names = [
@@ -767,5 +842,8 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         "mcp__inkbox__inkbox_create_contact",
         "mcp__inkbox__inkbox_update_contact",
         "mcp__inkbox__inkbox_delete_contact",
+        "mcp__inkbox__inkbox_a2a_call",
+        "mcp__inkbox__inkbox_a2a_check",
+        "mcp__inkbox__inkbox_a2a_reply",
     ]
     return server, tool_names

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -879,6 +879,71 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         except Exception as exc:
             return _error(str(exc))
 
+    def _a2a_history_options(args: Dict[str, Any], *, messages: bool) -> Dict[str, Any]:
+        limit = int(args.get("limit") or 50)
+        if not 1 <= limit <= 100:
+            raise ValueError("limit must be between 1 and 100")
+        options: Dict[str, Any] = {
+            "direction": str(args.get("direction") or "").strip() or None,
+            "requester_handle": str(args.get("requester_handle") or "").strip() or None,
+            "worker_handle": str(args.get("worker_handle") or "").strip() or None,
+            "context_id": str(args.get("context_id") or "").strip() or None,
+            "q": str(args.get("query") or "").strip() or None,
+            "since": str(args.get("since") or "").strip() or None,
+            "cursor": str(args.get("cursor") or "").strip() or None,
+            "limit": limit,
+        }
+        if messages:
+            options["task_id"] = str(args.get("task_id") or "").strip() or None
+            options["role"] = str(args.get("role") or "").strip() or None
+        else:
+            options["state"] = str(args.get("state") or "").strip() or None
+        return options
+
+    @tool(
+        "inkbox_list_a2a_tasks",
+        "List this identity's A2A task history with optional direction, "
+        "participant, state, context, keyword, timestamp, and cursor filters. "
+        "Direction defaults to inbound.",
+        {
+            "direction": str, "requester_handle": str, "worker_handle": str,
+            "state": str, "context_id": str, "query": str, "since": str,
+            "cursor": str, "limit": int,
+        },
+    )
+    async def inkbox_list_a2a_tasks(args: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            return _result(
+                await asyncio.to_thread(
+                    _identity().a2a_tasks,
+                    **_a2a_history_options(args, messages=False),
+                )
+            )
+        except Exception as exc:
+            return _error(str(exc))
+
+    @tool(
+        "inkbox_list_a2a_messages",
+        "List messages from this identity's inbound and outbound A2A history "
+        "with optional participant, task, context, role, keyword, timestamp, "
+        "and cursor filters.",
+        {
+            "direction": str, "requester_handle": str, "worker_handle": str,
+            "task_id": str, "context_id": str, "role": str, "query": str,
+            "since": str, "cursor": str, "limit": int,
+        },
+    )
+    async def inkbox_list_a2a_messages(args: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            return _result(
+                await asyncio.to_thread(
+                    _identity().a2a_messages,
+                    **_a2a_history_options(args, messages=True),
+                )
+            )
+        except Exception as exc:
+            return _error(str(exc))
+
     def _a2a_intent(intent: str, text: str) -> Any:
         context = A2A_TURN_CONTEXT.get()
         if context is None:
@@ -957,6 +1022,8 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         inkbox_a2a_call,
         inkbox_a2a_check,
         inkbox_a2a_reply,
+        inkbox_list_a2a_tasks,
+        inkbox_list_a2a_messages,
         inkbox_a2a_complete,
         inkbox_a2a_ask_caller,
         inkbox_a2a_fail,
@@ -983,6 +1050,8 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         "mcp__inkbox__inkbox_a2a_call",
         "mcp__inkbox__inkbox_a2a_check",
         "mcp__inkbox__inkbox_a2a_reply",
+        "mcp__inkbox__inkbox_list_a2a_tasks",
+        "mcp__inkbox__inkbox_list_a2a_messages",
         "mcp__inkbox__inkbox_a2a_complete",
         "mcp__inkbox__inkbox_a2a_ask_caller",
         "mcp__inkbox__inkbox_a2a_fail",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Inkbox bridge for Claude Code — talk to your coding agent over 
 requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.5.1,<1.0.0",
+  "inkbox>=0.5.6,<1.0.0",
   "claude-agent-sdk>=0.1.0",
   "segno>=1.5",  # terminal QR codes for the iMessage connect step
 ]

--- a/tests/live/a2a_driver.py
+++ b/tests/live/a2a_driver.py
@@ -89,10 +89,11 @@ def _send_task(a2a: Any, target: Any, text: str) -> Any:
 def _find_inbound_task(identity: Any, token: str, timeout: float) -> Any:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        page = identity.a2a_tasks(direction="inbound", limit=100)
+        page = identity.a2a_tasks(direction="inbound", q=token, limit=10)
         for item in page.items:
-            if token in _rest_history_text(item):
-                return identity.a2a_task(item.id)
+            task = identity.a2a_task(item.id)
+            if token in _rest_history_text(task):
+                return task
         time.sleep(1)
     raise TimeoutError("Plugin did not create the expected outbound A2A task")
 

--- a/tests/live/a2a_driver.py
+++ b/tests/live/a2a_driver.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Drive one real A2A scenario between the plugin and a remote identity."""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from typing import Any
+
+from inkbox import Inkbox
+
+STOPPED_WIRE_STATES = {
+    "TASK_STATE_COMPLETED",
+    "TASK_STATE_FAILED",
+    "TASK_STATE_CANCELED",
+    "TASK_STATE_REJECTED",
+    "TASK_STATE_INPUT_REQUIRED",
+    "TASK_STATE_AUTH_REQUIRED",
+}
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+def _enum_value(value: Any) -> str:
+    return str(getattr(value, "value", value))
+
+
+def _identity(client: Inkbox):
+    mailboxes = client.mailboxes.list()
+    if len(mailboxes) != 1:
+        raise RuntimeError("Live A2A credentials must resolve to exactly one mailbox")
+    handle = mailboxes[0].email_address.split("@", 1)[0]
+    return client.get_identity(handle), handle
+
+
+def _parts_text(parts: list[dict[str, Any]]) -> str:
+    return "\n".join(
+        str(part["text"])
+        for part in parts
+        if isinstance(part, dict) and part.get("text") is not None
+    )
+
+
+def _wire_history_text(task: Any) -> str:
+    return "\n".join(
+        _parts_text(message.get("parts", []))
+        for message in task.raw.get("history", [])
+        if isinstance(message, dict)
+    )
+
+
+def _rest_history_text(task: Any) -> str:
+    return "\n".join(_parts_text(message.parts) for message in task.messages)
+
+
+def _wait_protocol_task(
+    a2a: Any,
+    target: Any,
+    task_id: str,
+    *,
+    expected: set[str],
+    timeout: float,
+) -> Any:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        task = a2a.get_task(target, task_id, history_length=50)
+        state = _enum_value(task.state)
+        if state in expected:
+            return task
+        if state in STOPPED_WIRE_STATES:
+            raise AssertionError(f"A2A task stopped in unexpected state {state}")
+        time.sleep(1)
+    raise TimeoutError(f"A2A task did not reach {sorted(expected)} before timeout")
+
+
+def _send_task(a2a: Any, target: Any, text: str) -> Any:
+    result = a2a.send(target, text=text, message_id=str(uuid.uuid4()))
+    if result.kind != "task" or result.task is None:
+        raise AssertionError("A2A SendMessage did not return a task")
+    return result.task
+
+
+def _find_inbound_task(identity: Any, token: str, timeout: float) -> Any:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        page = identity.a2a_tasks(direction="inbound", limit=100)
+        for item in page.items:
+            if token in _rest_history_text(item):
+                return identity.a2a_task(item.id)
+        time.sleep(1)
+    raise TimeoutError("Plugin did not create the expected outbound A2A task")
+
+
+def _wait_for_caller_message(
+    identity: Any,
+    task_id: str,
+    token: str,
+    timeout: float,
+) -> Any:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        task = identity.a2a_task(task_id)
+        for message in task.messages:
+            if _enum_value(message.role) == "caller" and token in _parts_text(message.parts):
+                return task
+        state = _enum_value(task.state)
+        if state in {"completed", "failed", "canceled", "rejected"}:
+            raise AssertionError(
+                f"Outbound A2A task stopped before caller follow-up: {state}"
+            )
+        time.sleep(1)
+    raise TimeoutError("Plugin did not answer the worker's input request")
+
+
+def _assert_outer_is_open(a2a: Any, target: Any, task_id: str) -> None:
+    state = _enum_value(a2a.get_task(target, task_id).state)
+    if state in STOPPED_WIRE_STATES:
+        raise AssertionError("Plugin completed the outer task before its delegation")
+
+
+def _cancel_if_open(a2a: Any, target: Any, task_id: str) -> None:
+    try:
+        state = _enum_value(a2a.get_task(target, task_id).state)
+        if state not in STOPPED_WIRE_STATES:
+            a2a.cancel(target, task_id)
+    except Exception:
+        pass
+
+
+def _fail_if_open(identity: Any, task_id: str) -> None:
+    try:
+        task = identity.a2a_task(task_id)
+        if _enum_value(task.state) not in {
+            "completed",
+            "failed",
+            "canceled",
+            "rejected",
+        }:
+            identity.a2a_reply(
+                task_id,
+                intent="fail",
+                text="Automated A2A test cleanup.",
+            )
+    except Exception:
+        pass
+
+
+def _inbound_single(a2a: Any, target: Any, timeout: float, run: str) -> None:
+    completion = f"a2a-ci-inbound-single-{run}"
+    task = _send_task(
+        a2a,
+        target,
+        "Complete this A2A task without requesting input. "
+        f"The final answer must contain `{completion}`.",
+    )
+    try:
+        final = _wait_protocol_task(
+            a2a,
+            target,
+            task.id,
+            expected={"TASK_STATE_COMPLETED"},
+            timeout=timeout,
+        )
+        if completion not in _wire_history_text(final):
+            raise AssertionError("Inbound single-turn completion token is missing")
+    finally:
+        _cancel_if_open(a2a, target, task.id)
+
+
+def _inbound_multi(a2a: Any, target: Any, timeout: float, run: str) -> None:
+    answer = f"a2a-ci-answer-{run}"
+    completion = f"a2a-ci-inbound-multi-{run}"
+    task = _send_task(
+        a2a,
+        target,
+        "First call inkbox_a2a_ask_caller to request the access code. "
+        "Do not complete or fail the task before the caller responds. "
+        "After the caller replies, call inkbox_a2a_complete and include both "
+        f"the supplied code and `{completion}` in the final answer.",
+    )
+    try:
+        waiting = _wait_protocol_task(
+            a2a,
+            target,
+            task.id,
+            expected={"TASK_STATE_INPUT_REQUIRED"},
+            timeout=timeout,
+        )
+        a2a.send(
+            target,
+            text=answer,
+            message_id=str(uuid.uuid4()),
+            context_id=waiting.context_id,
+            task_id=waiting.id,
+        )
+        final = _wait_protocol_task(
+            a2a,
+            target,
+            task.id,
+            expected={"TASK_STATE_COMPLETED"},
+            timeout=timeout,
+        )
+        history = _wire_history_text(final)
+        if answer not in history or completion not in history:
+            raise AssertionError("Inbound multi-turn history is incomplete")
+    finally:
+        _cancel_if_open(a2a, target, task.id)
+
+
+def _outbound_single(
+    a2a: Any,
+    target: Any,
+    remote_identity: Any,
+    remote_card_url: str,
+    timeout: float,
+    run: str,
+) -> None:
+    inner_token = f"a2a-ci-outbound-single-task-{run}"
+    worker_result = f"a2a-ci-outbound-single-result-{run}"
+    outer = _send_task(
+        a2a,
+        target,
+        "Delegate a new task with inkbox_a2a_call to the Agent Card at "
+        f"{remote_card_url}. The delegated task text must contain "
+        f"`{inner_token}`. Wait for it with inkbox_a2a_check and do not "
+        "complete this outer task first. After the worker completes, call "
+        "inkbox_a2a_complete and include the worker's response in the answer.",
+    )
+    inner = None
+    try:
+        inner = _find_inbound_task(remote_identity, inner_token, timeout)
+        _assert_outer_is_open(a2a, target, outer.id)
+        remote_identity.a2a_reply(
+            inner.id,
+            intent="complete",
+            text=worker_result,
+        )
+        final = _wait_protocol_task(
+            a2a,
+            target,
+            outer.id,
+            expected={"TASK_STATE_COMPLETED"},
+            timeout=timeout,
+        )
+        if worker_result not in _wire_history_text(final):
+            raise AssertionError("Outbound single-turn worker result is missing")
+    finally:
+        if inner is not None:
+            _fail_if_open(remote_identity, inner.id)
+        _cancel_if_open(a2a, target, outer.id)
+
+
+def _outbound_multi(
+    a2a: Any,
+    target: Any,
+    remote_identity: Any,
+    remote_card_url: str,
+    timeout: float,
+    run: str,
+) -> None:
+    inner_token = f"a2a-ci-outbound-multi-task-{run}"
+    answer = f"a2a-ci-outbound-multi-answer-{run}"
+    worker_result = f"a2a-ci-outbound-multi-result-{run}"
+    outer = _send_task(
+        a2a,
+        target,
+        "Delegate a new task with inkbox_a2a_call to the Agent Card at "
+        f"{remote_card_url}. The delegated task text must contain "
+        f"`{inner_token}`. The worker will request input; reply with "
+        f"`{answer}` using inkbox_a2a_reply, then wait again with "
+        "inkbox_a2a_check. Do not complete this outer task before the worker. "
+        "Finally call inkbox_a2a_complete with the worker's response.",
+    )
+    inner = None
+    try:
+        inner = _find_inbound_task(remote_identity, inner_token, timeout)
+        _assert_outer_is_open(a2a, target, outer.id)
+        remote_identity.a2a_reply(
+            inner.id,
+            intent="ask_caller",
+            text="Provide the requested verification value.",
+        )
+        _wait_for_caller_message(remote_identity, inner.id, answer, timeout)
+        _assert_outer_is_open(a2a, target, outer.id)
+        remote_identity.a2a_reply(
+            inner.id,
+            intent="complete",
+            text=worker_result,
+        )
+        final = _wait_protocol_task(
+            a2a,
+            target,
+            outer.id,
+            expected={"TASK_STATE_COMPLETED"},
+            timeout=timeout,
+        )
+        if worker_result not in _wire_history_text(final):
+            raise AssertionError("Outbound multi-turn worker result is missing")
+    finally:
+        if inner is not None:
+            _fail_if_open(remote_identity, inner.id)
+        _cancel_if_open(a2a, target, outer.id)
+
+
+def main() -> None:
+    scenario = _required_env("A2A_SCENARIO")
+    timeout = float(os.environ.get("A2A_TIMEOUT_S", "240"))
+    base_url = os.environ.get("INKBOX_BASE_URL", "https://inkbox.ai").rstrip("/")
+    aut = Inkbox(api_key=_required_env("AUT_INKBOX_API_KEY"), base_url=base_url)
+    remote = Inkbox(api_key=_required_env("REMOTE_INKBOX_API_KEY"), base_url=base_url)
+    _, aut_handle = _identity(aut)
+    remote_identity, remote_handle = _identity(remote)
+    a2a = remote_identity.a2a_client()
+    target = a2a.fetch_card(f"{base_url}/a2a/{aut_handle}/card")
+    remote_card_url = f"{base_url}/a2a/{remote_handle}/card"
+    run = uuid.uuid4().hex[:12]
+    try:
+        if scenario == "inbound-single":
+            _inbound_single(a2a, target, timeout, run)
+        elif scenario == "inbound-multi":
+            _inbound_multi(a2a, target, timeout, run)
+        elif scenario == "outbound-single":
+            _outbound_single(
+                a2a, target, remote_identity, remote_card_url, timeout, run
+            )
+        elif scenario == "outbound-multi":
+            _outbound_multi(
+                a2a, target, remote_identity, remote_card_url, timeout, run
+            )
+        else:
+            raise RuntimeError(f"Unknown A2A_SCENARIO: {scenario}")
+    finally:
+        a2a.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_a2a_gateway.py
+++ b/tests/test_a2a_gateway.py
@@ -1,0 +1,172 @@
+import asyncio
+import json
+import types
+
+import pytest
+
+from inkbox_claude import gateway as gateway_mod
+from inkbox_claude.gateway import InkboxGateway
+
+
+@pytest.fixture(autouse=True)
+def fake_web(monkeypatch):
+    monkeypatch.setattr(
+        gateway_mod,
+        "web",
+        types.SimpleNamespace(
+            json_response=lambda payload: types.SimpleNamespace(
+                status=200,
+                text=json.dumps(payload),
+            )
+        ),
+    )
+
+
+class _Session:
+    def __init__(self):
+        self.calls = []
+        self.inbound = []
+
+    async def run_consult(self, prompt, *, a2a_context=None):
+        self.calls.append((prompt, a2a_context))
+        return "Completed."
+
+    async def handle_inbound(self, prompt, mode, meta):
+        self.inbound.append((prompt, mode, meta))
+
+
+class _Sessions:
+    def __init__(self):
+        self.session = _Session()
+        self.keys = []
+
+    def get(self, key, system_prompt_extra=""):
+        self.keys.append((key, system_prompt_extra))
+        return self.session
+
+
+def _gateway(tmp_path):
+    gateway = object.__new__(InkboxGateway)
+    gateway._a2a_registry_path = tmp_path / "a2a.json"
+    gateway._a2a_jobs = {}
+    gateway._identity = types.SimpleNamespace(
+        id="identity-1",
+        a2a_task=lambda _task_id: types.SimpleNamespace(state="submitted"),
+        a2a_reply=lambda task_id, **kwargs: gateway.replies.append(
+            (task_id, kwargs)
+        ),
+    )
+    gateway.replies = []
+    gateway.sessions = _Sessions()
+    return gateway
+
+
+def _event():
+    return {
+        "id": "evt-1",
+        "event_type": "a2a.task.created",
+        "data": {
+            "task_id": "task-1",
+            "context_id": "context-1",
+            "message_id": "message-1",
+            "caller": {
+                "identity_id": "caller-1",
+                "organization_id": "org-1",
+                "handle": "caller",
+            },
+            "parts": [{"text": "Investigate."}],
+        },
+    }
+
+
+def test_a2a_gateway_persists_dedupes_and_completes(tmp_path, monkeypatch):
+    async def inline(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(gateway_mod.asyncio, "to_thread", inline)
+    gateway = _gateway(tmp_path)
+
+    async def scenario():
+        first = await gateway._on_a2a_event(_event())
+        await asyncio.gather(*gateway._a2a_jobs["task-1"])
+        second = await gateway._on_a2a_event(_event())
+        return first, second
+
+    first, second = asyncio.run(scenario())
+    registry = json.loads(gateway._a2a_registry_path.read_text())
+
+    assert first.status == 200
+    assert json.loads(second.text)["deduped"] is True
+    assert registry["task-1:message-1"]["state"] == "finalized"
+    assert gateway.sessions.keys[0][0] == "a2a:identity-1:context-1"
+    assert gateway.replies == [
+        ("task-1", {"intent": "complete", "text": "Completed."})
+    ]
+
+
+def test_a2a_gateway_resumes_nonfinal_registry_entries(tmp_path, monkeypatch):
+    async def inline(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(gateway_mod.asyncio, "to_thread", inline)
+    gateway = _gateway(tmp_path)
+    task = types.SimpleNamespace(
+        id="task-1",
+        context_id="context-1",
+        state="working",
+        caller=types.SimpleNamespace(
+            identity_id="caller-1",
+            organization_id="org-1",
+            handle="caller",
+        ),
+        messages=[
+            types.SimpleNamespace(
+                message_id="message-1",
+                parts=[{"text": "Resume this."}],
+            )
+        ],
+    )
+    gateway._identity.a2a_task = lambda _task_id: task
+    gateway._identity.iter_a2a_tasks = lambda **_kwargs: iter(())
+    gateway._write_a2a_registry(
+        "task-1:message-1",
+        _event()["data"],
+        "running",
+    )
+
+    async def scenario():
+        await gateway._catch_up_a2a_tasks()
+        await asyncio.gather(*gateway._a2a_jobs["task-1"])
+
+    asyncio.run(scenario())
+    registry = json.loads(gateway._a2a_registry_path.read_text())
+
+    assert registry["task-1:message-1"]["state"] == "finalized"
+    assert gateway.sessions.session.calls[0][0].endswith("Resume this.")
+
+
+def test_a2a_sent_update_returns_to_the_delegating_session(
+    tmp_path,
+    monkeypatch,
+):
+    gateway = _gateway(tmp_path)
+    monkeypatch.setattr(
+        gateway_mod,
+        "find_a2a_delegation",
+        lambda _task_id: {
+            "session_key": "contact-1",
+            "card_url": "https://target.example/card",
+        },
+    )
+    event = _event()
+    event["event_type"] = "a2a.sent_task.updated"
+    event["data"]["state"] = "input_required"
+    event["data"]["parts"] = [{"text": "Which region?"}]
+
+    asyncio.run(gateway._on_a2a_event(event))
+
+    assert gateway.sessions.keys[0][0] == "contact-1"
+    prompt, mode, meta = gateway.sessions.session.inbound[0]
+    assert "Which region?" in prompt
+    assert mode == "external"
+    assert meta["a2a_task_id"] == "task-1"

--- a/tests/test_gateway_call_config.py
+++ b/tests/test_gateway_call_config.py
@@ -30,10 +30,9 @@ class _UnsupportedA2ASubscriptions(_FakeSubscriptions):
     def create(self, **kwargs):
         self.attempted.append(kwargs)
         if any(event.startswith("a2a.") for event in kwargs["event_types"]):
-            error = RuntimeError("unsupported A2A events")
-            error.status_code = 422
-            error.detail = "a2a.task.created is not a valid event type"
-            raise error
+            raise ValueError(
+                "event_type 'a2a.task.created' does not belong to any known channel"
+            )
         return super().create(**kwargs)
 
 

--- a/tests/test_gateway_call_config.py
+++ b/tests/test_gateway_call_config.py
@@ -22,6 +22,21 @@ class _FakeSubscriptions:
         self.created.append(kwargs)
 
 
+class _UnsupportedA2ASubscriptions(_FakeSubscriptions):
+    def __init__(self):
+        super().__init__()
+        self.attempted = []
+
+    def create(self, **kwargs):
+        self.attempted.append(kwargs)
+        if any(event.startswith("a2a.") for event in kwargs["event_types"]):
+            error = RuntimeError("unsupported A2A events")
+            error.status_code = 422
+            error.detail = "a2a.task.created is not a valid event type"
+            raise error
+        return super().create(**kwargs)
+
+
 class _FakePhoneNumbers:
     def __init__(self):
         self.updated = []
@@ -31,9 +46,11 @@ class _FakePhoneNumbers:
 
 
 class _FakeInkbox:
-    def __init__(self, identity):
+    def __init__(self, identity, subscriptions=None):
         self._identity = identity
-        self.webhooks = types.SimpleNamespace(subscriptions=_FakeSubscriptions())
+        self.webhooks = types.SimpleNamespace(
+            subscriptions=subscriptions or _FakeSubscriptions()
+        )
         self.phone_numbers = _FakePhoneNumbers()
 
     def get_identity(self, _handle):
@@ -70,9 +87,9 @@ def _phone():
     return types.SimpleNamespace(id="phone-1", number="+15550001111")
 
 
-def _patched_gateway(identity):
+def _patched_gateway(identity, subscriptions=None):
     gw = gateway.InkboxGateway(BridgeConfig(identity="claude", require_signature=False))
-    gw._inkbox = _FakeInkbox(identity)
+    gw._inkbox = _FakeInkbox(identity, subscriptions)
     gw._public_url = "https://agent.example"
     gw._public_host = "agent.example"
     gw._patch_identity_objects()
@@ -132,3 +149,23 @@ def test_legacy_sdk_cannot_configure_imessage_only_identity():
     gw = _patched_gateway(identity)
 
     assert gw._inkbox.phone_numbers.updated == []
+
+
+def test_a2a_subscription_falls_back_to_imessage_on_older_api():
+    subscriptions = _UnsupportedA2ASubscriptions()
+    _patched_gateway(
+        _Identity(phone=None, imessage_enabled=True),
+        subscriptions=subscriptions,
+    )
+
+    assert subscriptions.created[-1]["event_types"] == gateway.IMESSAGE_EVENTS
+
+
+def test_a2a_only_subscription_is_skipped_on_older_api():
+    subscriptions = _UnsupportedA2ASubscriptions()
+    _patched_gateway(
+        _Identity(phone=None, imessage_enabled=False),
+        subscriptions=subscriptions,
+    )
+
+    assert subscriptions.created == []

--- a/tests/test_gateway_call_config.py
+++ b/tests/test_gateway_call_config.py
@@ -12,14 +12,19 @@ from inkbox_claude.config import BridgeConfig
 
 
 class _FakeSubscriptions:
-    def __init__(self):
+    def __init__(self, existing=()):
         self.created = []
+        self.existing = list(existing)
+        self.deleted = []
 
     def list(self, **_owner):
-        return []
+        return list(self.existing)
 
     def create(self, **kwargs):
         self.created.append(kwargs)
+
+    def delete(self, sub_id):
+        self.deleted.append(sub_id)
 
 
 class _UnsupportedA2ASubscriptions(_FakeSubscriptions):
@@ -175,6 +180,22 @@ def test_a2a_and_imessage_use_channel_coherent_subscriptions():
         "https://agent.example/webhook?channel=a2a",
         "https://agent.example/webhook",
     ]
+
+
+def test_imessage_reconcile_preserves_existing_a2a_channel_subscription():
+    a2a = types.SimpleNamespace(
+        id="sub-a2a",
+        url="https://agent.example/webhook?channel=a2a",
+        event_types=gateway.A2A_EVENTS,
+    )
+    subscriptions = _FakeSubscriptions([a2a])
+    _patched_gateway(
+        _Identity(phone=None, imessage_enabled=True),
+        subscriptions=subscriptions,
+    )
+
+    assert subscriptions.deleted == []
+    assert subscriptions.created[-1]["event_types"] == gateway.IMESSAGE_EVENTS
 
 
 def test_a2a_only_subscription_is_skipped_on_older_api():

--- a/tests/test_gateway_call_config.py
+++ b/tests/test_gateway_call_config.py
@@ -160,6 +160,23 @@ def test_a2a_subscription_falls_back_to_imessage_on_older_api():
     assert subscriptions.created[-1]["event_types"] == gateway.IMESSAGE_EVENTS
 
 
+def test_a2a_and_imessage_use_channel_coherent_subscriptions():
+    subscriptions = _FakeSubscriptions()
+    _patched_gateway(
+        _Identity(phone=None, imessage_enabled=True),
+        subscriptions=subscriptions,
+    )
+
+    assert [created["event_types"] for created in subscriptions.created] == [
+        gateway.A2A_EVENTS,
+        gateway.IMESSAGE_EVENTS,
+    ]
+    assert [created["url"] for created in subscriptions.created] == [
+        "https://agent.example/webhook?channel=a2a",
+        "https://agent.example/webhook",
+    ]
+
+
 def test_a2a_only_subscription_is_skipped_on_older_api():
     subscriptions = _UnsupportedA2ASubscriptions()
     _patched_gateway(

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -88,7 +88,7 @@ def test_install_command_prefers_uv_when_available(monkeypatch):
         "install",
         "--python",
         "/tmp/venv/bin/python",
-        "inkbox>=0.5.1,<1.0.0",
+        "inkbox>=0.5.6,<1.0.0",
         "aiohttp>=3.9",
     ]]
 
@@ -98,10 +98,10 @@ def test_install_command_falls_back_to_pip_and_ensurepip(monkeypatch):
     monkeypatch.setattr(setup_wizard.shutil, "which", lambda _name: None)
 
     assert setup_wizard._install_commands() == [
-        [["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.1,<1.0.0", "aiohttp>=3.9"]],
+        [["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.6,<1.0.0", "aiohttp>=3.9"]],
         [
             ["/tmp/venv/bin/python", "-m", "ensurepip", "--upgrade"],
-            ["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.1,<1.0.0", "aiohttp>=3.9"],
+            ["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.6,<1.0.0", "aiohttp>=3.9"],
         ],
     ]
 
@@ -120,7 +120,7 @@ def test_missing_sdk_guidance_prints_interpreter(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "/tmp/venv/bin/python" in out
     assert "uv pip install --python" in out
-    assert "inkbox>=0.5.1,<1.0.0" in out
+    assert "inkbox>=0.5.6,<1.0.0" in out
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -72,6 +72,7 @@ class _FakeIdentity:
         self.sent_emails = []
         self.sent_texts = []
         self.sent_imessages = []
+        self.a2a = _FakeA2AClient()
 
     def place_call(self, **kwargs):
         self.place_call_kwargs = kwargs
@@ -101,6 +102,34 @@ class _FakeIdentity:
     def send_text(self, **kwargs):
         self.sent_texts.append(kwargs)
         return type("Message", (), {"id": "sms-1"})()
+
+    def a2a_client(self):
+        return self.a2a
+
+
+class _FakeA2AClient:
+    def __init__(self):
+        self.calls = []
+        self.closed = False
+
+    def fetch_card(self, card_url):
+        self.calls.append(("fetch_card", card_url))
+        return {"rpc_url": "https://target.example/a2a"}
+
+    def send(self, target, **kwargs):
+        self.calls.append(("send", target, kwargs))
+        return {"kind": "task", "task": {"id": "task-1"}}
+
+    def get_task(self, target, task_id):
+        self.calls.append(("get_task", target, task_id))
+        return {"id": task_id, "state": "TASK_STATE_WORKING"}
+
+    def wait(self, target, task_id):
+        self.calls.append(("wait", target, task_id))
+        return {"id": task_id, "state": "TASK_STATE_COMPLETED"}
+
+    def close(self):
+        self.closed = True
 
 
 class _FakeContacts:
@@ -165,6 +194,9 @@ def test_coding_agent_tool_tier_is_registered():
         "inkbox_create_contact",
         "inkbox_update_contact",
         "inkbox_delete_contact",
+        "inkbox_a2a_call",
+        "inkbox_a2a_check",
+        "inkbox_a2a_reply",
     }
 
     assert set(tools) == expected
@@ -180,6 +212,42 @@ def test_get_contact_and_delete_contact_tools():
     assert contact["id"] == "contact-1"
     assert deleted["deleted"] == "contact-1"
     assert client.contacts.deleted == ["contact-1"]
+
+
+def test_a2a_tools_send_check_and_reply():
+    client = _FakeClient()
+    card_url = "https://target.example/card"
+
+    sent = _call(
+        client,
+        "inkbox_a2a_call",
+        {"card_url": card_url, "text": "Investigate.", "message_id": "msg-1"},
+    )
+    checked = _call(
+        client,
+        "inkbox_a2a_check",
+        {"card_url": card_url, "task_id": "task-1", "wait": True},
+    )
+    replied = _call(
+        client,
+        "inkbox_a2a_reply",
+        {
+            "card_url": card_url,
+            "task_id": "task-1",
+            "text": "More context.",
+            "message_id": "msg-2",
+        },
+    )
+
+    assert sent["task"]["id"] == "task-1"
+    assert checked["state"] == "TASK_STATE_COMPLETED"
+    assert replied["task"]["id"] == "task-1"
+    assert (
+        "wait",
+        {"rpc_url": "https://target.example/a2a"},
+        "task-1",
+    ) in client.identity.a2a.calls
+    assert client.identity.a2a.closed is True
 
 
 def test_place_call_writes_context_and_tags_websocket_url(tmp_path, monkeypatch):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -11,7 +11,8 @@ from inkbox_claude import tools as tools_mod
 
 
 @pytest.fixture(autouse=True)
-def _fake_claude_sdk(monkeypatch):
+def _fake_claude_sdk(monkeypatch, tmp_path):
+    monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
     async def immediate(func, /, *args, **kwargs):
         return func(*args, **kwargs)
 
@@ -53,6 +54,7 @@ class _FakeTranscript:
 
 class _FakeIdentity:
     def __init__(self):
+        self.id = "identity-1"
         self.agent_handle = "claude-agent"
         self.mailbox = type("Mailbox", (), {"email_address": "claude@inkbox.ai"})()
         self.phone_number = type(
@@ -73,6 +75,7 @@ class _FakeIdentity:
         self.sent_texts = []
         self.sent_imessages = []
         self.a2a = _FakeA2AClient()
+        self.a2a_replies = []
 
     def place_call(self, **kwargs):
         self.place_call_kwargs = kwargs
@@ -106,6 +109,10 @@ class _FakeIdentity:
     def a2a_client(self):
         return self.a2a
 
+    def a2a_reply(self, task_id, **kwargs):
+        self.a2a_replies.append((task_id, kwargs))
+        return {"id": task_id, "state": kwargs["intent"]}
+
 
 class _FakeA2AClient:
     def __init__(self):
@@ -118,7 +125,10 @@ class _FakeA2AClient:
 
     def send(self, target, **kwargs):
         self.calls.append(("send", target, kwargs))
-        return {"kind": "task", "task": {"id": "task-1"}}
+        return {
+            "kind": "task",
+            "task": {"id": "task-1", "context_id": "context-1"},
+        }
 
     def get_task(self, target, task_id):
         self.calls.append(("get_task", target, task_id))
@@ -197,6 +207,9 @@ def test_coding_agent_tool_tier_is_registered():
         "inkbox_a2a_call",
         "inkbox_a2a_check",
         "inkbox_a2a_reply",
+        "inkbox_a2a_complete",
+        "inkbox_a2a_ask_caller",
+        "inkbox_a2a_fail",
     }
 
     assert set(tools) == expected
@@ -248,6 +261,32 @@ def test_a2a_tools_send_check_and_reply():
         "task-1",
     ) in client.identity.a2a.calls
     assert client.identity.a2a.closed is True
+
+
+def test_a2a_intent_tools_require_trusted_turn_context():
+    client = _FakeClient()
+
+    outside = _call(client, "inkbox_a2a_complete", {"text": "Done."})
+    token = tools_mod.A2A_TURN_CONTEXT.set(
+        {
+            "task_id": "task-1",
+            "message_id": "message-1",
+            "context_id": "context-1",
+            "reply_intent_committed": False,
+        }
+    )
+    try:
+        inside = _call(client, "inkbox_a2a_ask_caller", {"text": "Which region?"})
+        context = tools_mod.A2A_TURN_CONTEXT.get()
+    finally:
+        tools_mod.A2A_TURN_CONTEXT.reset(token)
+
+    assert "only available during an inbound A2A task" in outside["error"]
+    assert inside["state"] == "ask_caller"
+    assert context["reply_intent_committed"] is True
+    assert client.identity.a2a_replies == [
+        ("task-1", {"intent": "ask_caller", "text": "Which region?"})
+    ]
 
 
 def test_place_call_writes_context_and_tags_websocket_url(tmp_path, monkeypatch):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -76,6 +76,7 @@ class _FakeIdentity:
         self.sent_imessages = []
         self.a2a = _FakeA2AClient()
         self.a2a_replies = []
+        self.a2a_history_calls = []
 
     def place_call(self, **kwargs):
         self.place_call_kwargs = kwargs
@@ -112,6 +113,14 @@ class _FakeIdentity:
     def a2a_reply(self, task_id, **kwargs):
         self.a2a_replies.append((task_id, kwargs))
         return {"id": task_id, "state": kwargs["intent"]}
+
+    def a2a_tasks(self, **kwargs):
+        self.a2a_history_calls.append(("tasks", kwargs))
+        return {"items": [{"id": "task-1"}], "next_cursor": "task-next"}
+
+    def a2a_messages(self, **kwargs):
+        self.a2a_history_calls.append(("messages", kwargs))
+        return {"items": [{"id": "message-1"}], "next_cursor": "message-next"}
 
 
 class _FakeA2AClient:
@@ -207,6 +216,8 @@ def test_coding_agent_tool_tier_is_registered():
         "inkbox_a2a_call",
         "inkbox_a2a_check",
         "inkbox_a2a_reply",
+        "inkbox_list_a2a_tasks",
+        "inkbox_list_a2a_messages",
         "inkbox_a2a_complete",
         "inkbox_a2a_ask_caller",
         "inkbox_a2a_fail",
@@ -261,6 +272,78 @@ def test_a2a_tools_send_check_and_reply():
         "task-1",
     ) in client.identity.a2a.calls
     assert client.identity.a2a.closed is True
+
+
+def test_a2a_history_tools_forward_filters_and_pagination():
+    client = _FakeClient()
+    tasks = _call(
+        client,
+        "inkbox_list_a2a_tasks",
+        {
+            "direction": "both",
+            "requester_handle": "requester",
+            "worker_handle": "worker",
+            "state": "completed",
+            "context_id": "context-1",
+            "query": "summary",
+            "since": "2026-07-01T00:00:00Z",
+            "cursor": "task-cursor",
+            "limit": 3,
+        },
+    )
+    messages = _call(
+        client,
+        "inkbox_list_a2a_messages",
+        {
+            "direction": "outbound",
+            "requester_handle": "requester",
+            "worker_handle": "worker",
+            "task_id": "task-1",
+            "context_id": "context-1",
+            "role": "agent",
+            "query": "done",
+            "since": "2026-07-01T00:00:00Z",
+            "cursor": "message-cursor",
+            "limit": 4,
+        },
+    )
+
+    assert tasks["next_cursor"] == "task-next"
+    assert messages["next_cursor"] == "message-next"
+    assert client.identity.a2a_history_calls == [
+        (
+            "tasks",
+            {
+                "direction": "both",
+                "requester_handle": "requester",
+                "worker_handle": "worker",
+                "context_id": "context-1",
+                "q": "summary",
+                "since": "2026-07-01T00:00:00Z",
+                "cursor": "task-cursor",
+                "limit": 3,
+                "state": "completed",
+            },
+        ),
+        (
+            "messages",
+            {
+                "direction": "outbound",
+                "requester_handle": "requester",
+                "worker_handle": "worker",
+                "context_id": "context-1",
+                "q": "done",
+                "since": "2026-07-01T00:00:00Z",
+                "cursor": "message-cursor",
+                "limit": 4,
+                "task_id": "task-1",
+                "role": "agent",
+            },
+        ),
+    ]
+
+    invalid = _call(client, "inkbox_list_a2a_tasks", {"limit": 101})
+    assert invalid["error"] == "limit must be between 1 and 100"
 
 
 def test_a2a_intent_tools_require_trusted_turn_context():


### PR DESCRIPTION
## Decisions

- **Live protocol coverage:** Exercise inbound and outbound behavior at both single-turn and multi-turn lengths. Serialize the four cases because they share live identities and one tunnel endpoint.
- **Durability:** Write receiver deliveries before acknowledgement and reconcile registry state before paging every submitted task on restart.
- **Session isolation:** Serialize inbound work in `a2a:{identity}:{context}` sessions and expose complete, ask-caller, and fail only through verified turn context.
- **Delegation continuity:** Persist outbound message and retry data before `SendMessage`, promote it to `(identity, RPC origin, context)` after submission, and inject later task updates into the originating Claude session.
- **Compatibility:** Keep the base SDK range for non-A2A users, while requiring Inkbox SDK 0.5.6 or newer for A2A.

## Changes

- Add a published-SDK live A2A workflow that boots the real host and verifies all four protocol legs.
- Add A2A call, check/wait, reply, and explicit inbound outcome tools.
- Subscribe and serve inbound A2A tasks with durable deduplication, context sessions, cancellation, restart recovery, and guarded default completion.
- Persist caller-side delegation routing and return `a2a.sent_task.updated` events to the delegating session.
- Bump the plugin to 0.1.4.

## Related pull requests

- SDK: [Inkbox PR #123](https://github.com/inkbox-ai/inkbox/pull/123)
- Hosts: [Hermes PR #75](https://github.com/inkbox-ai/hermes-agent-plugin/pull/75), [Codex PR #26](https://github.com/inkbox-ai/codex-plugin/pull/26), [OpenCode PR #9](https://github.com/inkbox-ai/opencode-plugin/pull/9), [OpenClaw PR #43](https://github.com/inkbox-ai/openclaw-plugin/pull/43)

## Verification

- [Tests](https://github.com/inkbox-ai/claude-code-plugin/actions/runs/30244722826): Python 3.11 and 3.12 unit suites and the Claude Code host contract passed.
- [Full stack e2e](https://github.com/inkbox-ai/claude-code-plugin/actions/runs/30250737372): mock and real channel suites, inbound and outbound A2A at single-turn and multi-turn lengths, both voice scenarios, external events, and the aggregate gate passed.
- `uv run --with pytest python -m pytest -q`: 303 passed, 22 skipped.