### PR TITLE
Report the bridge's real state at the end of setup

### DIFF
--- a/inkbox_claude/daemon.py
+++ b/inkbox_claude/daemon.py
@@ -210,6 +210,18 @@ def stop() -> int:
     return 0
 
 
+def running_pid() -> int | None:
+    """Return the PID of the background gateway, or None when it is not running.
+
+    Public wrapper over the PID-file probe so callers outside this module can
+    ask "is one already up?" without reaching for a private helper.
+
+    Returns:
+        int | None: Live background gateway PID, else None.
+    """
+    return _read_pid()
+
+
 def status() -> int:
     """Report whether the background gateway is running.
 

--- a/inkbox_claude/daemon.py
+++ b/inkbox_claude/daemon.py
@@ -52,6 +52,29 @@ def _log_file() -> Path:
     return _state_dir() / "gateway.log"
 
 
+def _exited_as_our_child(pid: int) -> bool:
+    """Reap ``pid`` if it is our own child and has already exited.
+
+    ``start`` forks the gateway from whatever process launched it, so a crashed
+    gateway stays a zombie until that parent waits on it - and ``os.kill(pid, 0)``
+    succeeds on a zombie. Without this reap, a dead bridge probes as alive for as
+    long as the launching process lives, which no amount of extra waiting fixes.
+
+    Args:
+        pid (int): PID recorded in the PID file.
+
+    Returns:
+        bool: True when the process was our child and has exited. False when it
+        is still running, or is not our child at all (a separate ``status`` or
+        ``stop`` invocation), in which case the signal probe is authoritative.
+    """
+    try:
+        reaped, _status = os.waitpid(pid, os.WNOHANG)
+    except (ChildProcessError, OSError, AttributeError):
+        return False
+    return reaped == pid
+
+
 def _read_pid() -> int | None:
     """Return the PID of a live daemon, or None (clearing a stale PID file).
 
@@ -61,6 +84,9 @@ def _read_pid() -> int | None:
     try:
         pid = int(_pid_file().read_text().strip())
     except (FileNotFoundError, ValueError):
+        return None
+    if _exited_as_our_child(pid):
+        _pid_file().unlink(missing_ok=True)  # crashed under us — not a live pid
         return None
     try:
         os.kill(pid, 0)  # signal 0 just probes liveness

--- a/inkbox_claude/daemon.py
+++ b/inkbox_claude/daemon.py
@@ -180,37 +180,45 @@ def start() -> int:
         return 1
 
     log_path = _log_file()
-    pid = os.fork()
-    if pid > 0:
-        # Parent: record the daemon's PID, then give it a moment to fail fast
-        # (bad tunnel, 401, ...) so we can surface that instead of "started".
-        _pid_file().write_text(f"{pid}\n")
-        time.sleep(1.5)
-        if _read_pid() != pid:
-            print("Gateway exited right after starting — check the log:")
-            print(f"  {log_path}")
-            return 1
-        print(f"inkbox-claude gateway started in the background (pid {pid}).")
-        print(f"  logs:  {log_path}")
-        print(f"  tail:  tail -f {log_path}")
-        print("  stop:  inkbox-claude stop")
-        return 0
+    # Spawn a FRESH interpreter instead of os.fork(). Forking a process that has
+    # already driven the SDK hands the child a half-initialised copy of httpx's
+    # connection pools and threads, and it can die before logging is even
+    # configured -- which is why a start from the setup wizard could fail while
+    # the identical `start` from a shell seconds later worked. This is also the
+    # exact command the systemd/launchd units run.
+    try:
+        logf = open(log_path, "a", buffering=1)  # line-buffered so `tail -f` is live
+    except OSError as exc:
+        print(f"Could not open the log at {log_path}: {exc}")
+        return 1
+    try:
+        proc = subprocess.Popen(
+            [_launcher_path(), "run"],
+            stdin=subprocess.DEVNULL,
+            stdout=logf,
+            stderr=logf,
+            start_new_session=True,  # own session, so it outlives this terminal
+            env=os.environ.copy(),   # carry values the wizard just saved
+        )
+    except OSError as exc:
+        print(f"Could not start the gateway: {exc}")
+        return 1
+    finally:
+        logf.close()  # the child holds its own dup of the fd
 
-    # Child: detach from the terminal and run the gateway.
-    os.setsid()
-    _redirect_stdio(log_path)
-    run_foreground()
-    os._exit(0)
-
-
-def _redirect_stdio(log_path: Path) -> None:
-    sys.stdout.flush()
-    sys.stderr.flush()
-    with open(os.devnull, "rb") as devnull:
-        os.dup2(devnull.fileno(), sys.stdin.fileno())
-    logf = open(log_path, "a", buffering=1)  # line-buffered so `tail -f` is live
-    os.dup2(logf.fileno(), sys.stdout.fileno())
-    os.dup2(logf.fileno(), sys.stderr.fileno())
+    # Give it a moment to fail fast (bad tunnel, port in use, 401) so we can
+    # surface that instead of reporting "started".
+    _pid_file().write_text(f"{proc.pid}\n")
+    time.sleep(1.5)
+    if _read_pid() != proc.pid:
+        print("Gateway exited right after starting — check the log:")
+        print(f"  {log_path}")
+        return 1
+    print(f"inkbox-claude gateway started in the background (pid {proc.pid}).")
+    print(f"  logs:  {log_path}")
+    print(f"  tail:  tail -f {log_path}")
+    print("  stop:  inkbox-claude stop")
+    return 0
 
 
 def stop() -> int:

--- a/inkbox_claude/daemon.py
+++ b/inkbox_claude/daemon.py
@@ -32,6 +32,18 @@ def _state_dir() -> Path:
     return root
 
 
+def state_dir() -> Path:
+    """Return the bridge's state directory, creating it if needed.
+
+    Public wrapper so the setup wizard can resolve the same ``.env`` the daemon
+    falls back to, instead of keeping its own copy of the path rule.
+
+    Returns:
+        Path: ``$INKBOX_CLAUDE_HOME`` or ``~/.inkbox-claude``.
+    """
+    return _state_dir()
+
+
 def _pid_file() -> Path:
     return _state_dir() / "gateway.pid"
 

--- a/inkbox_claude/doctor.py
+++ b/inkbox_claude/doctor.py
@@ -18,6 +18,15 @@ def run_doctor() -> List[Tuple[str, bool, str]]:
     Returns:
         List[Tuple[str, bool, str]]: (check name, passed, detail) rows.
     """
+    # Read the same .env the bridge does before judging anything missing —
+    # otherwise doctor reports "missing" for credentials that are on disk and
+    # working, purely because this process did not inherit them.
+    try:
+        from .daemon import _maybe_load_env_file
+    except ImportError:  # pragma: no cover - direct local import/test fallback
+        from daemon import _maybe_load_env_file
+    _maybe_load_env_file()
+
     cfg = read_config()
     checks: List[Tuple[str, bool, str]] = []
 

--- a/inkbox_claude/setup_wizard.py
+++ b/inkbox_claude/setup_wizard.py
@@ -1605,11 +1605,12 @@ def _configure_project_dir() -> None:
     print_success(f"  Claude Code will work in {chosen}")
 
 
-def _configure_autostart() -> None:
+def _configure_autostart() -> bool:
     """Offer to keep the gateway running — on boot, or just in the background.
 
     Returns:
-        None
+        bool: True when a bridge is running by the time this returns, so the
+        caller can close on a status banner instead of a to-do list.
     """
     print()
     print(color("  --- Keep the bridge running ---", Colors.CYAN))
@@ -1622,36 +1623,62 @@ def _configure_autostart() -> None:
         from daemon import install_autostart, restart as daemon_restart, running_pid
         from daemon import start as daemon_start
 
-    def bring_up() -> None:
+    def bring_up() -> bool:
         # `start` no-ops on a live PID, so a rerun would leave the bridge on
         # the .env this wizard just replaced. Restart it instead.
         pid = running_pid()
         if pid:
             print_info(f"  A background bridge is already running (pid {pid}) on the old config.")
             print_info("  Restarting it so it picks up the new settings.")
-            daemon_restart()
-            return
-        daemon_start()
+            return daemon_restart() == 0
+        return daemon_start() == 0
 
     env_file = str(_env_file_path().resolve())
 
     if prompt_yes_no("  Start it now and automatically on every boot?", True):
         if install_autostart(env_file):
-            return
+            return True
         print_warning("  Couldn't set up boot autostart — starting in the background for now.")
-        bring_up()
-        return
+        return bring_up()
 
     if prompt_yes_no("  Start it in the background now (until you reboot)?", True):
-        bring_up()
-        return
+        return bring_up()
 
     print_info("  Start it yourself anytime with:  inkbox-claude start")
+    return False
 
 
 # ----------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------
+
+
+def _print_ready_banner(handle: str) -> None:
+    """Print the closing banner for a setup that ended with a live bridge.
+
+    Args:
+        handle (str): Inkbox agent identity the bridge is now running as.
+
+    Returns:
+        None: Replaces the closing to-do lines - there is nothing left to run.
+    """
+    rows = (("Inkbox identity", handle), ("Check its health", "inkbox-claude doctor"))
+    label_width = max(len(label) for label, _ in rows) + 1  # +1 for the colon
+    body = [
+        "Your Claude Code agent is set up and running on Inkbox.",
+        "",
+        *(f"  {(label + ':').ljust(label_width)}  {value}" for label, value in rows),
+    ]
+    width = max(len(line) for line in body) + 4
+    print()
+    print(color("╭" + "─" * (width - 2) + "╮", Colors.GREEN))
+    for line in body:
+        print(
+            color("│ ", Colors.GREEN)
+            + color(line.ljust(width - 4), Colors.GREEN, Colors.BOLD)
+            + color(" │", Colors.GREEN)
+        )
+    print(color("╰" + "─" * (width - 2) + "╯", Colors.GREEN))
 
 
 def _print_agent_summary(identity: Any) -> None:
@@ -1812,9 +1839,15 @@ def interactive_setup() -> None:
 
     _configure_project_dir()
 
-    _configure_autostart()
+    # A live bridge means setup finished the job, so close on that rather than
+    # a to-do list. Only when nothing is listening is there a step left.
+    if _configure_autostart():
+        _print_ready_banner(identity.agent_handle)
+        print_info("  Logs: ~/.inkbox-claude/gateway.log")
+        return
 
     print()
     print(color("Setup complete.", Colors.GREEN, Colors.BOLD))
+    print("  Start it with:          inkbox-claude start")
     print("  Check it anytime with:  inkbox-claude doctor")
     print("  Logs:                   ~/.inkbox-claude/gateway.log")

--- a/inkbox_claude/setup_wizard.py
+++ b/inkbox_claude/setup_wizard.py
@@ -112,16 +112,35 @@ def _show_qr(data: str) -> bool:
 # ----------------------------------------------------------------------
 
 
+# A bridge that dies on bad config can outlive the daemon's own ~1.5s startup
+# probe, so re-check for a beat before calling the start a success.
+BRIDGE_CONFIRM_TIMEOUT = 5.0
+
+
 def _env_file_path() -> Path:
     """Resolve the ``.env`` file the wizard reads from and writes to.
 
+    Mirrors the daemon's candidate order exactly (see
+    ``daemon._maybe_load_env_file``) so the file this writes is the file the
+    bridge later reads. Writing to cwd unconditionally meant running setup from
+    a home directory dropped an API key into ``~/.env`` that a globally
+    installed bridge never looks at.
+
     Returns:
-        Path: ``$INKBOX_CLAUDE_ENV_FILE`` if set, else ``.env`` in cwd.
+        Path: ``$INKBOX_CLAUDE_ENV_FILE`` if set, else an existing ``./.env``
+        (a repo-local setup already in use), else the state dir's ``.env``.
     """
     override = os.getenv("INKBOX_CLAUDE_ENV_FILE")
     if override:
         return Path(override).expanduser()
-    return Path.cwd() / ".env"
+    local = Path.cwd() / ".env"
+    if local.exists():
+        return local
+    try:
+        from .daemon import state_dir
+    except ImportError:  # pragma: no cover - direct local import/test fallback
+        from daemon import state_dir
+    return state_dir() / ".env"
 
 
 def _save(name: str, value: str) -> None:
@@ -1605,6 +1624,31 @@ def _configure_project_dir() -> None:
     print_success(f"  Claude Code will work in {chosen}")
 
 
+def _confirm_bridge_running(running_pid: Any, timeout: float = BRIDGE_CONFIRM_TIMEOUT) -> bool:
+    """Re-check that a just-started bridge is still alive.
+
+    Args:
+        running_pid (Any): Callable returning the live bridge PID, or None.
+        timeout (float): Seconds to keep re-checking before giving up.
+
+    Returns:
+        bool: True while a PID stays live across the window. A bridge that
+        exits on bad config can outlive the daemon's own short startup probe,
+        so a single check right after start can report a process that is gone.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        pid = running_pid()
+        if pid is None:
+            print_warning("  The bridge exited right after starting.")
+            print_info("  Check the log: ~/.inkbox-claude/gateway.log")
+            print_info("  Then rerun:    inkbox-claude start")
+            return False
+        if time.monotonic() >= deadline:
+            return True
+        time.sleep(0.5)
+
+
 def _configure_autostart() -> bool:
     """Offer to keep the gateway running — on boot, or just in the background.
 
@@ -1630,8 +1674,15 @@ def _configure_autostart() -> bool:
         if pid:
             print_info(f"  A background bridge is already running (pid {pid}) on the old config.")
             print_info("  Restarting it so it picks up the new settings.")
-            return daemon_restart() == 0
-        return daemon_start() == 0
+            code = daemon_restart()
+        else:
+            code = daemon_start()
+        if code != 0:
+            return False
+        # `start` only watches the child for ~1.5s before reporting success, and
+        # a bridge that dies just after that still prints a pid. Confirm it is
+        # actually still there rather than take the exit code's word for it.
+        return _confirm_bridge_running(running_pid)
 
     env_file = str(_env_file_path().resolve())
 

--- a/inkbox_claude/setup_wizard.py
+++ b/inkbox_claude/setup_wizard.py
@@ -1616,9 +1616,22 @@ def _configure_autostart() -> None:
     print_info("  The bridge has to stay running to receive your messages and reply.")
 
     try:
-        from .daemon import install_autostart, start as daemon_start
+        from .daemon import install_autostart, restart as daemon_restart, running_pid
+        from .daemon import start as daemon_start
     except ImportError:  # pragma: no cover - direct local import/test fallback
-        from daemon import install_autostart, start as daemon_start
+        from daemon import install_autostart, restart as daemon_restart, running_pid
+        from daemon import start as daemon_start
+
+    def bring_up() -> None:
+        # `start` no-ops on a live PID, so a rerun would leave the bridge on
+        # the .env this wizard just replaced. Restart it instead.
+        pid = running_pid()
+        if pid:
+            print_info(f"  A background bridge is already running (pid {pid}) on the old config.")
+            print_info("  Restarting it so it picks up the new settings.")
+            daemon_restart()
+            return
+        daemon_start()
 
     env_file = str(_env_file_path().resolve())
 
@@ -1626,11 +1639,11 @@ def _configure_autostart() -> None:
         if install_autostart(env_file):
             return
         print_warning("  Couldn't set up boot autostart — starting in the background for now.")
-        daemon_start()
+        bring_up()
         return
 
     if prompt_yes_no("  Start it in the background now (until you reboot)?", True):
-        daemon_start()
+        bring_up()
         return
 
     print_info("  Start it yourself anytime with:  inkbox-claude start")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-code-plugin"
-version = "0.2.5"
+version = "0.2.6"
 description = "Inkbox bridge for Claude Code — talk to your coding agent over email, SMS, iMessage, and voice"
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from inkbox_claude import cli, daemon
 
@@ -199,3 +200,34 @@ def test_running_pid_mirrors_the_pid_probe(tmp_path, monkeypatch):
 
     daemon._pid_file().write_text(f"{os.getpid()}\n")
     assert daemon.running_pid() == os.getpid()
+
+
+def test_read_pid_does_not_report_a_zombie_child_as_alive(tmp_path, monkeypatch):
+    # `start` forks the gateway from the launching process, so a crashed bridge
+    # stays a zombie under it — and os.kill(pid, 0) succeeds on a zombie. This
+    # is what let a dead bridge print a "started successfully" banner.
+    monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
+
+    pid = os.fork()
+    if pid == 0:
+        os._exit(1)  # the bridge crashing on a bad bind
+    time.sleep(0.3)
+
+    daemon._pid_file().write_text(f"{pid}\n")
+    assert daemon._read_pid() is None
+    assert not daemon._pid_file().exists()
+
+
+def test_read_pid_still_reports_a_live_child(tmp_path, monkeypatch):
+    monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
+
+    pid = os.fork()
+    if pid == 0:
+        time.sleep(5)
+        os._exit(0)
+    try:
+        daemon._pid_file().write_text(f"{pid}\n")
+        assert daemon._read_pid() == pid
+    finally:
+        os.kill(pid, 9)
+        os.waitpid(pid, 0)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -231,3 +231,70 @@ def test_read_pid_still_reports_a_live_child(tmp_path, monkeypatch):
     finally:
         os.kill(pid, 9)
         os.waitpid(pid, 0)
+
+
+def test_start_spawns_a_fresh_interpreter_not_a_fork(tmp_path, monkeypatch):
+    # Forking a wizard that has already driven the SDK gives the child a
+    # half-initialised copy of httpx's pools; spawn the launcher instead, the
+    # same command the systemd/launchd units run.
+    monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
+    monkeypatch.setenv("INKBOX_API_KEY", "ApiKey_x")
+    monkeypatch.setenv("INKBOX_IDENTITY", "probe")
+    monkeypatch.setattr(daemon, "_launcher_path", lambda: "/opt/venv/bin/inkbox-claude")
+    monkeypatch.setattr(
+        daemon.os, "fork", lambda: (_ for _ in ()).throw(AssertionError("must not fork"))
+    )
+    monkeypatch.setattr(daemon.time, "sleep", lambda _s: None)
+
+    seen = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(argv, **kwargs):
+        seen["argv"] = argv
+        seen["kwargs"] = kwargs
+        return FakeProc()
+
+    monkeypatch.setattr(daemon.subprocess, "Popen", fake_popen)
+    pids = iter([None, 4242])  # not running, then the spawned pid
+    monkeypatch.setattr(daemon, "_read_pid", lambda: next(pids))
+
+    assert daemon.start() == 0
+
+    assert seen["argv"] == ["/opt/venv/bin/inkbox-claude", "run"]
+    # Detached into its own session so it survives the launching terminal.
+    assert seen["kwargs"]["start_new_session"] is True
+    assert daemon._pid_file().read_text().strip() == "4242"
+
+
+def test_start_reports_a_gateway_that_dies_immediately(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
+    monkeypatch.setenv("INKBOX_API_KEY", "ApiKey_x")
+    monkeypatch.setenv("INKBOX_IDENTITY", "probe")
+    monkeypatch.setattr(daemon, "_launcher_path", lambda: "/opt/venv/bin/inkbox-claude")
+    monkeypatch.setattr(daemon.time, "sleep", lambda _s: None)
+
+    class FakeProc:
+        pid = 4242
+
+    monkeypatch.setattr(daemon.subprocess, "Popen", lambda _argv, **_kw: FakeProc())
+    monkeypatch.setattr(daemon, "_read_pid", lambda: None)  # never came up
+
+    assert daemon.start() == 1
+    assert "exited right after starting" in capsys.readouterr().out
+
+
+def test_start_surfaces_a_missing_launcher(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
+    monkeypatch.setenv("INKBOX_API_KEY", "ApiKey_x")
+    monkeypatch.setenv("INKBOX_IDENTITY", "probe")
+    monkeypatch.setattr(daemon, "_launcher_path", lambda: "/nope/inkbox-claude")
+
+    def boom(_argv, **_kw):
+        raise OSError(2, "No such file or directory")
+
+    monkeypatch.setattr(daemon.subprocess, "Popen", boom)
+
+    assert daemon.start() == 1
+    assert "Could not start the gateway" in capsys.readouterr().out

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -191,3 +191,11 @@ def test_cli_routes_daemon_commands(monkeypatch):
     for cmd in ("run", "start", "stop", "restart", "status"):
         assert cli.main([cmd]) == 0
     assert calls == ["run", "start", "stop", "restart", "status"]
+
+
+def test_running_pid_mirrors_the_pid_probe(tmp_path, monkeypatch):
+    monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
+    assert daemon.running_pid() is None
+
+    daemon._pid_file().write_text(f"{os.getpid()}\n")
+    assert daemon.running_pid() == os.getpid()

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import types
 
@@ -827,6 +828,7 @@ def _patch_daemon(monkeypatch, *, pid, calls):
     daemon.start = lambda: (calls.append("start"), 0)[1]
     daemon.restart = lambda: (calls.append("restart"), 0)[1]
     daemon.install_autostart = lambda _env_file: calls.append("install_autostart") or False
+    daemon.state_dir = lambda: __import__("pathlib").Path(os.environ.get("INKBOX_CLAUDE_HOME", "/tmp"))
     monkeypatch.setitem(sys.modules, "inkbox_claude.daemon", daemon)
     monkeypatch.setattr(setup_wizard, "_confirm_bridge_running", lambda *_a, **_k: True)
     return daemon

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -824,8 +824,8 @@ def _patch_daemon(monkeypatch, *, pid, calls):
     """Stub the daemon module the autostart step imports lazily."""
     daemon = types.ModuleType("daemon")
     daemon.running_pid = lambda: pid
-    daemon.start = lambda: calls.append("start") or 0
-    daemon.restart = lambda: calls.append("restart") or 0
+    daemon.start = lambda: (calls.append("start"), 0)[1]
+    daemon.restart = lambda: (calls.append("restart"), 0)[1]
     daemon.install_autostart = lambda _env_file: calls.append("install_autostart") or False
     monkeypatch.setitem(sys.modules, "inkbox_claude.daemon", daemon)
     return daemon
@@ -877,3 +877,47 @@ def test_declining_both_offers_starts_nothing(monkeypatch, capsys):
 
     assert calls == []
     assert "inkbox-claude start" in capsys.readouterr().out
+
+
+def test_ready_banner_names_the_identity_and_the_health_command(capsys):
+    setup_wizard._print_ready_banner("dev-agent")
+
+    lines = [line for line in capsys.readouterr().out.splitlines() if line]
+    assert any("dev-agent" in line for line in lines)
+    assert any("inkbox-claude doctor" in line for line in lines)
+    # Every row is the same width, so the box closes cleanly.
+    assert len({len(line) for line in lines}) == 1
+
+
+def test_ready_banner_box_fits_a_long_handle(capsys):
+    setup_wizard._print_ready_banner("a-very-long-agent-handle-that-sets-the-width")
+
+    lines = [line for line in capsys.readouterr().out.splitlines() if line]
+    assert len({len(line) for line in lines}) == 1
+
+
+def test_autostart_reports_a_live_bridge(monkeypatch):
+    calls = []
+    _patch_daemon(monkeypatch, pid=None, calls=calls)
+    answers = iter([False, True])
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_a, **_k: next(answers))
+
+    assert setup_wizard._configure_autostart() is True
+
+
+def test_autostart_reports_no_bridge_when_both_offers_declined(monkeypatch):
+    calls = []
+    _patch_daemon(monkeypatch, pid=None, calls=calls)
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_a, **_k: False)
+
+    assert setup_wizard._configure_autostart() is False
+
+
+def test_autostart_reports_failure_when_the_daemon_will_not_start(monkeypatch):
+    calls = []
+    daemon = _patch_daemon(monkeypatch, pid=None, calls=calls)
+    daemon.start = lambda: 1  # e.g. bad config, or the port is taken
+    answers = iter([False, True])
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_a, **_k: next(answers))
+
+    assert setup_wizard._configure_autostart() is False

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,3 +1,4 @@
+import sys
 import types
 
 import pytest
@@ -812,3 +813,67 @@ def test_wizard_walks_imessage_before_dedicated_number(tmp_path, monkeypatch):
     # No number was provisioned this run, so the START wait never blocks.
     assert "sms_opt_in" not in order
     assert seen["imessage_enabled"] is True
+
+
+# ----------------------------------------------------------------------
+# Keeping the bridge running
+# ----------------------------------------------------------------------
+
+
+def _patch_daemon(monkeypatch, *, pid, calls):
+    """Stub the daemon module the autostart step imports lazily."""
+    daemon = types.ModuleType("daemon")
+    daemon.running_pid = lambda: pid
+    daemon.start = lambda: calls.append("start") or 0
+    daemon.restart = lambda: calls.append("restart") or 0
+    daemon.install_autostart = lambda _env_file: calls.append("install_autostart") or False
+    monkeypatch.setitem(sys.modules, "inkbox_claude.daemon", daemon)
+    return daemon
+
+
+def test_background_start_restarts_an_already_running_bridge(monkeypatch, capsys):
+    calls = []
+    _patch_daemon(monkeypatch, pid=4242, calls=calls)
+    # Decline boot autostart, accept the background start.
+    answers = iter([False, True])
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_a, **_k: next(answers))
+
+    setup_wizard._configure_autostart()
+
+    # A live bridge is still on the old .env — starting it again would no-op.
+    assert calls == ["restart"]
+    assert "pid 4242" in capsys.readouterr().out
+
+
+def test_background_start_starts_when_nothing_is_running(monkeypatch):
+    calls = []
+    _patch_daemon(monkeypatch, pid=None, calls=calls)
+    answers = iter([False, True])
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_a, **_k: next(answers))
+
+    setup_wizard._configure_autostart()
+
+    assert calls == ["start"]
+
+
+def test_autostart_fallback_also_restarts_a_live_bridge(monkeypatch):
+    # install_autostart() fails, so the step falls back to a background run —
+    # which must reload a bridge that is already up, not no-op on it.
+    calls = []
+    _patch_daemon(monkeypatch, pid=99, calls=calls)
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_a, **_k: True)
+
+    setup_wizard._configure_autostart()
+
+    assert calls == ["install_autostart", "restart"]
+
+
+def test_declining_both_offers_starts_nothing(monkeypatch, capsys):
+    calls = []
+    _patch_daemon(monkeypatch, pid=None, calls=calls)
+    monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_a, **_k: False)
+
+    setup_wizard._configure_autostart()
+
+    assert calls == []
+    assert "inkbox-claude start" in capsys.readouterr().out

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -828,6 +828,7 @@ def _patch_daemon(monkeypatch, *, pid, calls):
     daemon.restart = lambda: (calls.append("restart"), 0)[1]
     daemon.install_autostart = lambda _env_file: calls.append("install_autostart") or False
     monkeypatch.setitem(sys.modules, "inkbox_claude.daemon", daemon)
+    monkeypatch.setattr(setup_wizard, "_confirm_bridge_running", lambda *_a, **_k: True)
     return daemon
 
 
@@ -921,3 +922,47 @@ def test_autostart_reports_failure_when_the_daemon_will_not_start(monkeypatch):
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_a, **_k: next(answers))
 
     assert setup_wizard._configure_autostart() is False
+
+
+def test_confirm_bridge_running_reports_a_pid_that_stays_up(monkeypatch):
+    monkeypatch.setattr(setup_wizard.time, "sleep", lambda _s: None)
+
+    assert setup_wizard._confirm_bridge_running(lambda: 4242, timeout=0.0) is True
+
+
+def test_confirm_bridge_running_catches_a_bridge_that_dies(monkeypatch, capsys):
+    # daemon.start() only watches the child for ~1.5s; a bridge that exits on
+    # bad config just after that still leaves the operator a pid and a banner.
+    pids = iter([4242, 4242, None])
+    monkeypatch.setattr(setup_wizard.time, "sleep", lambda _s: None)
+
+    assert setup_wizard._confirm_bridge_running(lambda: next(pids), timeout=30.0) is False
+
+    out = capsys.readouterr().out
+    assert "exited right after starting" in out
+    assert "gateway.log" in out
+
+
+def test_env_file_prefers_an_existing_local_dotenv(monkeypatch, tmp_path):
+    monkeypatch.delenv("INKBOX_CLAUDE_ENV_FILE", raising=False)
+    (tmp_path / ".env").write_text("INKBOX_IDENTITY=local\n")
+    monkeypatch.chdir(tmp_path)
+
+    assert setup_wizard._env_file_path() == tmp_path / ".env"
+
+
+def test_env_file_falls_back_to_the_state_dir_not_cwd(monkeypatch, tmp_path):
+    # Running setup from a home directory used to drop an API key into ~/.env,
+    # which a globally installed bridge never reads.
+    monkeypatch.delenv("INKBOX_CLAUDE_ENV_FILE", raising=False)
+    state = tmp_path / "state"
+    monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(state))
+    monkeypatch.chdir(tmp_path)
+
+    assert setup_wizard._env_file_path() == state / ".env"
+
+
+def test_env_file_honours_the_explicit_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("INKBOX_CLAUDE_ENV_FILE", str(tmp_path / "custom.env"))
+
+    assert setup_wizard._env_file_path() == tmp_path / "custom.env"


### PR DESCRIPTION
## Summary

Setup could finish with a green sign-off over a bridge that was dead, stale, or reading a `.env` nobody wrote to. Five commits, four of them found by running this on a fresh macOS install rather than by reading the code.

The original ask was just the first one; the rest came out of testing it.

## 1. A rerun left the bridge on the old config

`_configure_autostart()`'s background path called `daemon.start()`, which bails on a live PID:

```python
existing = _read_pid()
if existing:
    print(f"Already running (pid {existing}). Logs: {_log_file()}")
    return 0
```

Returns **0**, so setup reported success while the bridge kept serving the `.env` it had just replaced — a rotated signing key or switched identity silently did not take effect.

The boot-autostart path already got this right, and its comment names the exact failure: *"`enable --now` is a no-op on an already-running service — which would leave a stale gateway holding the OLD .env (e.g. a rotated signing key) after a reconfigure."* This gives the background path the same property, and says which it did:

```
  A background bridge is already running (pid 4242) on the old config.
  Restarting it so it picks up the new settings.
```

Scoped to the fork-based daemon, which is what the PID file tracks; service-managed gateways were already handled by `install_autostart`.

## 2. The sign-off was identical whether or not anything was running

`Setup complete. / Check it anytime with: inkbox-claude doctor` printed in both cases, and never named the identity. So the one case where you *needed* a start command never mentioned one.

`_configure_autostart()` now returns liveness — read off exit codes `start`/`restart` were already returning and discarding. Live:

```
╭─────────────────────────────────────────────────────────╮
│ Your Claude Code agent is set up and running on Inkbox. │
│                                                         │
│   Inkbox identity:   claude-code-dima                   │
│   Check its health:  inkbox-claude doctor               │
╰─────────────────────────────────────────────────────────╯
```

Not live: the old sign-off, plus the `inkbox-claude start` line that was missing.

## 3. The wizard wrote a `.env` the bridge never reads

Pre-existing on `main`, not introduced here — but this branch made it look like a working install by asserting success on top of it.

`_env_file_path()` had two candidates, `daemon._maybe_load_env_file()` has three:

```python
# wizard:  override, cwd
# daemon:  override, cwd, state_dir   ← ~/.inkbox-claude/.env, the installer's target
```

Run `inkbox-claude setup` from a home directory and an API key and signing key land in `~/.env` — a file a globally installed bridge never reads, and the operator's own dotfile. Now mirrors the daemon's order exactly, with `daemon.state_dir()` as the single source so they cannot drift again.

## 4. `doctor` never loaded a `.env` at all

`run_doctor()` called `read_config()` directly, never `_maybe_load_env_file()` the way `start()` and `run_foreground()` do. It reported every credential `missing` while the bridge ran fine on them — which is what made #3 so hard to see. Verified with a smoke test against a state-dir `.env` it previously called missing.

## 5. A crashed bridge probed as alive

The one that matters most, and it is **not** a too-short health check — a longer wait cannot fix it.

`start()` single-forks, so whatever launched the gateway is its parent and never `wait()`s it. A crashed gateway becomes a **zombie**, and `os.kill(pid, 0)` succeeds on a zombie:

```
os.kill(4167140, 0) SUCCEEDED  -> _read_pid() reports it ALIVE
actual process state: Z (Z = zombie)
```

So a corpse probes as alive for as long as the launching process lives. `_read_pid()` now reaps first with `waitpid(WNOHANG)`; a pid that comes back reaped is a corpse. When the caller is not the parent — a separate `status` or `stop` — `waitpid` raises `ECHILD` and the signal probe stays authoritative.

Fixes every caller at once: `start()`'s own post-fork check, `status`, `stop`, and the wizard's confirmation. Verified end to end — a child that exits immediately now yields `running_pid() -> None` and `status() -> 1`.

## Notes for the reviewer

- **A stray `.env` in the repo root was hiding a test hole.** The suite passed only because it short-circuited `_env_file_path()` before the state-dir lookup; the codex twin, with no such file, failed immediately. `ec80999` gives the stubbed daemon a `state_dir` so neither passes by accident.
- The zombie tests **fork a real child** rather than mock the probe — mocking is exactly what would hide this.
- Version 0.2.5 → 0.2.6.

305 pass. The 14 `tests/test_sessions.py` failures are pre-existing on `main` (a `TypeError` from an SDK mismatch in this environment) and unrelated — confirmed against a clean checkout.

Fixes 3, 4 and 5 are mirrored in inkbox-ai/codex-plugin#29, which shared all of them.