### PR TITLE
Stop the voice test tripping answering-machine detection

### DIFF
--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -50,6 +50,12 @@ STATE_FILE = os.environ.get("VOICE_DRIVER_STATE", "/tmp/voice_driver_state.json"
 TIMEOUT_S = float(os.environ.get("LIVE_VOICE_TIMEOUT", "220"))
 POLL_EVERY_S = 6.0
 TERMINAL_FAILURE_STATUSES = {"canceled", "failed"}
+# A call can end normally and still never carry a conversation - answering-machine
+# detection hanging up on the driver ends it `completed`, hangup_reason=voicemail.
+# Transcript rows can still land during teardown, so allow a short grace period
+# before giving up rather than polling a finished call for the full timeout.
+ENDED_STATUSES = {"completed"}
+ENDED_GRACE_S = float(os.environ.get("LIVE_VOICE_ENDED_GRACE", "15"))
 
 pytestmark = pytest.mark.skipif(
     not (REMOTE_KEY and AUT_KEY and REAL),
@@ -106,6 +112,7 @@ def _wait_for_two_way_call(remote, number_id, call_id):
     """Block until the call transcript shows BOTH the agent and the driver spoke."""
     deadline = time.monotonic() + TIMEOUT_S
     last = ""
+    ended_at = None
     while time.monotonic() < deadline:
         transcript_state = ""
         try:
@@ -125,6 +132,11 @@ def _wait_for_two_way_call(remote, number_id, call_id):
         last = f"{progress}; {state}"
         if status in TERMINAL_FAILURE_STATUSES:
             pytest.fail(f"call ended before a two-way conversation ({last})")
+        if status in ENDED_STATUSES:
+            if ended_at is None:
+                ended_at = time.monotonic()
+            elif time.monotonic() - ended_at > ENDED_GRACE_S:
+                pytest.fail(f"call ended without a two-way conversation ({last})")
         time.sleep(POLL_EVERY_S)
     pytest.fail(f"agent never held a two-way call within {TIMEOUT_S:.0f}s ({last})")
 

--- a/tests/live/voice_driver.py
+++ b/tests/live/voice_driver.py
@@ -47,8 +47,12 @@ LINE = os.environ.get(
     "VOICE_DRIVER_LINE",
     "Hi, this is a quick test call. Please reply out loud with one short sentence, then say goodbye.",
 )
-# Speak shortly after the pipeline is ready so the agent's greeting lands first.
-SPEAK_AFTER_S = float(os.environ.get("VOICE_DRIVER_SPEAK_AFTER", "3"))
+# Answering-machine detection scores whoever answers: a greeting longer than the
+# carrier's `greeting_duration_millis` (3.5s) reads as a voicemail announcement
+# and the call is hung up before the agent ever speaks. Answer the way a person
+# does - one word, then silence - and hold the prompt until that window closes.
+GREETING = os.environ.get("VOICE_DRIVER_GREETING", "Hello?")
+SPEAK_AFTER_S = float(os.environ.get("VOICE_DRIVER_SPEAK_AFTER", "5"))
 # Then give the agent a turn and hang up — a dropped WS does NOT end the call, so we
 # must send an explicit stop or the leg lingers until the server max-duration cap.
 LISTEN_S = float(os.environ.get("VOICE_DRIVER_LISTEN", "12"))
@@ -75,16 +79,20 @@ async def phone_media_ws(ws: WebSocket) -> None:
     spoke = asyncio.Event()
     convo: asyncio.Task | None = None
 
-    async def _speak(text: str) -> None:
-        if spoke.is_set():
-            return
-        spoke.set()
+    async def _say(text: str) -> None:
         await ws.send_text(json.dumps({"event": "text", "delta": text}))
         await ws.send_text(json.dumps({"event": "text", "done": True}))
         log.info("spoke: %s", text)
 
+    async def _speak(text: str) -> None:
+        if spoke.is_set():
+            return
+        spoke.set()
+        await _say(text)
+
     async def _run_turn() -> None:
         # Speak one line, give the agent a turn, then hang up so the call ends fast.
+        await _say(GREETING)
         await asyncio.sleep(SPEAK_AFTER_S)
         await _speak(LINE)
         await asyncio.sleep(LISTEN_S)


### PR DESCRIPTION
## Summary

The live voice suite goes red intermittently with `two-way call transcript: nothing within 220s`. It is not the transport, and the 220s is a symptom rather than the cause.

Answering-machine detection scores whoever **answers** the call. The driver answered with a ~3s pause followed by ~7s of uninterrupted speech:

> "Hi, this is a quick test call. Please reply out loud with one short sentence, then say goodbye."

The carrier's threshold for a human greeting is `greeting_duration_millis` = **3500ms**. We were 2× over it, so the driver was classified `machine` and the call hung up about ten seconds in — before the agent said a word. It is *intermittent* rather than broken because the scoring is probabilistic near that boundary; the same commit passes on a re-run with no change.

Confirmed against a real incident (opencode-plugin, 2026-07-28):

```
16:21:58.836  call placed
16:22:01.517  call.answered
16:22:03.838  agent connected
16:22:08.620  AMD premium detection ended  result=machine
16:22:08.620  "Voicemail detected, hanging up"
16:22:09.645  hangup
```

`hangup_reason=voicemail`, `duration=10.160s`, `session_failed=false`, **0 transcript rows**. Not quota or concurrency — 2 calls and 66 voice-seconds in the window against limits of 300 calls / 300 minutes per 24h.

## Two changes

**1. The driver answers like a person.** One short word immediately, then silence, with the prompt held until the detection window has closed. A human says "Hello?" and stops; a voicemail greeting runs on. `VOICE_DRIVER_GREETING` overrides it.

**2. The test stops polling a dead call.** The terminal-status check only covered `canceled` and `failed`. A detection hangup ends the call **`completed`** with `hangup_reason=voicemail`, so the loop kept asking for a transcript that could never arrive and reported the timeout instead of the reason — which was sitting in the call record ten seconds in. It now stops shortly after the call ends, with the hangup reason already in the failure message.

The grace period (`LIVE_VOICE_ENDED_GRACE`, 15s) exists because transcript rows can still land while the call tears down.

## Scope

Test harness only. No plugin runtime, no gateway, no API change. No version bump.

## Not fixed here

The real fix is server-side: `answering_machine_detection="premium"` is hardcoded at all three dial sites in `servers`, with no per-call opt-out. AMD is meaningless when calling a known synthetic peer — and the same tax applies to any customer placing agent-to-agent calls. That is written up separately for the servers repo; this change makes CI honest in the meantime.
