### PR TITLE
Add dedicated-outbound iMessage group chats

### DIFF
--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -1382,6 +1382,39 @@ class InkboxGateway:
             )
             return None
 
+    async def _lookup_imessage_conversation_summary(self, conversation_id: str) -> Any:
+        """Group flags/participants for events that omit them (mirrors the SMS lookup)."""
+        if not conversation_id:
+            return None
+
+        def _lookup() -> Any:
+            identity = self._identity
+            if identity is None and self._inkbox is not None:
+                identity = self._inkbox.get_identity(self.cfg.identity)
+            if identity is None:
+                return None
+            method = getattr(identity, "list_imessage_conversations", None)
+            if callable(method):
+                try:
+                    conversations = method(limit=200, offset=0, include_groups=True)
+                except TypeError:
+                    conversations = method({"limit": 200, "offset": 0, "includeGroups": True})
+            else:
+                method = getattr(identity, "listImessageConversations", None)
+                if not callable(method):
+                    return None
+                conversations = method({"limit": 200, "offset": 0, "includeGroups": True})
+            for entry in conversations or []:
+                if str(self._field(entry, "id", "conversation_id", "conversationId") or "") == conversation_id:
+                    return entry
+            return None
+
+        try:
+            return await asyncio.to_thread(_lookup)
+        except Exception as exc:
+            logger.debug("[Inkbox] iMessage conversation lookup failed for %s: %s", conversation_id, exc)
+            return None
+
     @classmethod
     def _group_sms_prompt(
         cls,
@@ -1404,6 +1437,32 @@ class InkboxGateway:
         marker = " ".join(part for part in marker_parts if part)
         policy = "\n".join([
             "Group SMS response policy: you receive every message in this group so you can track context.",
+            "Reply only when the latest message clearly addresses this Inkbox agent, asks it to act, or a visible answer would be expected from the agent.",
+            "Treat ordinary group chatter as context only.",
+            "If no visible reply is warranted, return exactly [SILENT].",
+        ])
+        return "\n".join(part for part in [marker, policy, body] if part)
+
+    @classmethod
+    def _group_imessage_prompt(
+        cls,
+        body: str,
+        *,
+        sender: str,
+        conversation_id: str,
+        participants: List[str],
+        contact: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        marker_parts = [
+            f"[inkbox:group_imessage conversation_id={conversation_id or 'unknown'}",
+            f"from={sender}",
+            f"participants={','.join(participants)}" if participants else None,
+            "reply_mode=conversation_id",
+            f"| {contact_marker(contact)}]",
+        ]
+        marker = " ".join(part for part in marker_parts if part)
+        policy = "\n".join([
+            "Group iMessage response policy: you receive every message in this group so you can track context.",
             "Reply only when the latest message clearly addresses this Inkbox agent, asks it to act, or a visible answer would be expected from the agent.",
             "Treat ordinary group chatter as context only.",
             "If no visible reply is warranted, return exactly [SILENT].",
@@ -1566,28 +1625,59 @@ class InkboxGateway:
             return web.json_response({"ok": True, "ignored": "sender-not-allowed"})
 
         body = await self._with_media(text, media, prefix=f"imsg-{message.get('id', '')}")
-        conversation_id = str(message.get("conversation_id") or "").strip()
+        conversation_id = str(
+            message.get("conversation_id") or message.get("conversationId") or ""
+        ).strip()
+        conversation_summary = await self._lookup_imessage_conversation_summary(conversation_id)
+        participants: List[str] = []
+        for entry in (
+            self._string_list_field(conversation_summary, "participants")
+            + self._string_list_field(message, "participants")
+        ):
+            if entry not in participants:
+                participants.append(entry)
+        is_group = (
+            self._conversation_summary_is_group(conversation_summary)
+            or bool(self._field(message, "isGroup", "is_group"))
+            or len(participants) > 1
+        )
         contact = await self._resolve_contact_full(kind="phone", value=sender)
         # An address-book contact always wins over a resolved agent identity.
         agent_identity = (
             None
-            if contact
+            if (contact or is_group)
             else self._single_agent_identity(
                 self._webhook_list(data, "agent_identities", "agentIdentities", "identity_agents")
             )
         )
-        chat_id = self._chat_key(
-            data,
-            sender,
-            self._thread_key("imessage", conversation_id),
-            contact=contact,
-            allow_webhook_contact=False,
+        if is_group:
+            body = self._group_imessage_prompt(
+                body,
+                sender=sender,
+                conversation_id=conversation_id,
+                participants=participants,
+                contact=contact,
+            )
+        thread_key = self._thread_key("imessage", conversation_id)
+        # A group is one shared context for everyone in it, so the conversation -
+        # not the sender - is the chat. 1:1 keeps its per-contact chat.
+        chat_id = (
+            thread_key
+            if is_group
+            else self._chat_key(
+                data,
+                sender,
+                thread_key,
+                contact=contact,
+                allow_webhook_contact=False,
+            )
         )
         meta = {
             "conversation_id": conversation_id or None,
             "sender": sender,
             "contact": contact,
             "agent_identity": agent_identity,
+            "conversation_kind": "group" if is_group else "direct",
         }
         # A fresh inbound starts a fresh logical reply — reset its failed-send budget.
         self._clear_outbound_failures("imessage", conversation_id, sender, chat_id=chat_id)

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -52,6 +52,34 @@ logger = logging.getLogger(__name__)
 
 SMS_MAX_LENGTH = 1600
 IMESSAGE_MAX_LENGTH = 18995
+IMESSAGE_MAX_GROUP_RECIPIENTS = 8
+
+
+def _normalize_imessage_recipients(value: Any) -> Optional[List[str]]:
+    """`to` as a list of E.164 strings, or None when the caller omitted it."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        entry = value.strip()
+        return [entry] if entry else []
+    if isinstance(value, (list, tuple)):
+        return [str(v).strip() for v in value if str(v).strip()]
+    return []
+
+
+def _identity_can_start_imessage_conversations(identity: Any) -> bool:
+    """Whether the identity holds a dedicated outbound iMessage line."""
+    number = getattr(identity, "imessage_number", None) or getattr(identity, "imessageNumber", None)
+    if number is None:
+        return False
+    can_start = getattr(number, "can_start_conversations", None)
+    if can_start is None:
+        can_start = getattr(number, "canStartConversations", None)
+    if isinstance(can_start, bool):
+        return can_start
+    number_type = number.get("type") if isinstance(number, dict) else getattr(number, "type", None)
+    number_type = getattr(number_type, "value", number_type)
+    return str(number_type or "").strip().lower() == "dedicated_outbound"
 
 # The contact session whose turn is driving the current tool call. Each
 # session binds itself here right before its agent client connects, so the
@@ -376,16 +404,35 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
 
     @tool(
         "inkbox_send_imessage",
-        "Send an iMessage. Pass an existing conversation_id — get it from "
-        "inkbox_list_imessage_conversations (iMessage is recipient-first: a "
-        "conversation exists only after the person has messaged this agent). To "
-        "attach an image/file, pass media_path as a local file path (uploaded "
-        "automatically, max 10 MB). Text is limited to 18995 characters.",
-        {"conversation_id": str, "text": str, "media_path": str},
+        "Send an iMessage. Reply into an existing 1:1 or group chat with "
+        "conversation_id — get it from inkbox_list_imessage_conversations. A "
+        "dedicated outbound iMessage line may instead start a conversation with "
+        "to: one E.164 recipient, or 2-8 to open a group; shared and dedicated "
+        "inbound lines stay recipient-first. To attach an image/file, pass "
+        "media_path as a local file path (uploaded automatically, max 10 MB). "
+        "Text is limited to 18995 characters.",
+        {"conversation_id": str, "to": list, "text": str, "media_path": str},
     )
     async def inkbox_send_imessage(args: Dict[str, Any]) -> Dict[str, Any]:
         text = str(args.get("text") or "")
-        conversation_id = str(args["conversation_id"])
+        conversation_id = str(args.get("conversation_id") or "").strip()
+        to_list = _normalize_imessage_recipients(args.get("to"))
+        if bool(to_list) == bool(conversation_id):
+            return _error("Specify exactly one of `to` or `conversation_id`.")
+        if to_list is not None and not to_list:
+            return _error("`to` must include at least one recipient.")
+        if to_list and len(to_list) > IMESSAGE_MAX_GROUP_RECIPIENTS:
+            return _error(
+                f"Inkbox iMessage groups support at most {IMESSAGE_MAX_GROUP_RECIPIENTS} recipients."
+            )
+        if to_list and len(set(to_list)) != len(to_list):
+            return _error("iMessage recipients must be distinct.")
+        if len(to_list or []) > 1 and not _identity_can_start_imessage_conversations(_identity()):
+            return _error(
+                "Starting an iMessage group requires a dedicated outbound iMessage "
+                "line. Reply to an existing group with conversation_id.",
+                error_code="imessage_group_requires_dedicated_outbound",
+            )
         if len(text) > IMESSAGE_MAX_LENGTH:
             return _error(
                 _message_too_long_reason("iMessage", text, IMESSAGE_MAX_LENGTH),
@@ -396,10 +443,11 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
 
         def _run():
             identity = _identity()
-            kwargs: Dict[str, Any] = {
-                "conversation_id": conversation_id,
-                "text": text,
-            }
+            kwargs: Dict[str, Any] = {"text": text}
+            if conversation_id:
+                kwargs["conversation_id"] = conversation_id
+            else:
+                kwargs["to"] = to_list[0] if len(to_list) == 1 else to_list
             media_path = str(args.get("media_path") or "").strip()
             if media_path:
                 # One tool call for the agent; the upload→send two-step is internal.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-code-plugin"
-version = "0.2.6"
+version = "0.2.7"
 description = "Inkbox bridge for Claude Code — talk to your coding agent over email, SMS, iMessage, and voice"
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/test_gateway_inbound_media.py
+++ b/tests/test_gateway_inbound_media.py
@@ -368,3 +368,52 @@ def test_empty_message_no_text_no_media_is_ignored(monkeypatch):
     resp = asyncio.run(gw._on_text_received(envelope))
     assert json.loads(resp.text)["ignored"] == "empty"
     assert "+15550000001" not in gw.sessions.by_id
+
+
+def test_group_imessage_injects_silent_policy(monkeypatch):
+    gw = _gw(monkeypatch, [])
+    envelope = {"data": {
+        "message": {
+            "id": "im-group",
+            "direction": "inbound",
+            "remote_number": "+15550000000",
+            "conversation_id": "imconv-777",
+            "participants": ["+15550000000", "+15550000002"],
+            "content": "Dinner moved to 7.",
+        },
+    }}
+
+    asyncio.run(gw._on_imessage_received(envelope))
+
+    # The group is one shared context, so the conversation is the chat — not the sender.
+    session = gw.sessions.by_id["imessage:imconv-777"]
+    body, mode, meta = session.inbound[0]
+    assert mode == "imessage"
+    assert body.startswith("[inkbox:group_imessage conversation_id=imconv-777")
+    assert "participants=+15550000000,+15550000002" in body
+    assert "reply_mode=conversation_id" in body
+    assert "Group iMessage response policy" in body
+    assert "return exactly [SILENT]" in body
+    assert meta["conversation_id"] == "imconv-777"
+    assert meta["conversation_kind"] == "group"
+
+
+def test_one_to_one_imessage_keeps_per_contact_chat(monkeypatch):
+    gw = _gw(monkeypatch, [])
+    envelope = {"data": {
+        "message": {
+            "id": "im-dm",
+            "direction": "inbound",
+            "remote_number": "+15550000000",
+            "conversation_id": "imconv-778",
+            "content": "hey",
+        },
+    }}
+
+    asyncio.run(gw._on_imessage_received(envelope))
+
+    body, mode, meta = next(iter(gw.sessions.by_id.values())).inbound[0]
+    assert mode == "imessage"
+    assert "group_imessage" not in body
+    assert "Group iMessage response policy" not in body
+    assert meta["conversation_kind"] == "direct"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -575,3 +575,51 @@ def test_successful_message_tool_notifies_current_session():
         "attachments": None,
     }]
     assert deliveries == [("email", "ada@example.com")]
+
+
+def test_send_imessage_group_requires_dedicated_outbound_line():
+    client = _FakeClient()
+    data = _call(
+        client,
+        "inkbox_send_imessage",
+        {"to": ["+15550000001", "+15550000002"], "text": "hi both"},
+    )
+
+    assert data["error_code"] == "imessage_group_requires_dedicated_outbound"
+    assert client.identity.sent_imessages == []
+
+
+def test_send_imessage_rejects_both_target_and_conversation():
+    client = _FakeClient()
+    data = _call(
+        client,
+        "inkbox_send_imessage",
+        {"conversation_id": "imconv-1", "to": ["+15550000001"], "text": "hi"},
+    )
+
+    assert "exactly one" in data["error"]
+    assert client.identity.sent_imessages == []
+
+
+def test_send_imessage_rejects_too_many_recipients():
+    client = _FakeClient()
+    data = _call(
+        client,
+        "inkbox_send_imessage",
+        {"to": [f"+1555000000{i}" for i in range(9)], "text": "hi"},
+    )
+
+    assert "at most 8" in data["error"]
+    assert client.identity.sent_imessages == []
+
+
+def test_send_imessage_rejects_duplicate_recipients():
+    client = _FakeClient()
+    data = _call(
+        client,
+        "inkbox_send_imessage",
+        {"to": ["+15550000001", "+15550000001"], "text": "hi"},
+    )
+
+    assert "distinct" in data["error"]
+    assert client.identity.sent_imessages == []


### PR DESCRIPTION
## Summary

Ports the Hermes bridge's iMessage group-chat flow (inkbox-ai/hermes-agent-plugin#76) so the two behave the same on the wire.

## Inbound — a group is one shared context

A group conversation is a single context that everyone in it shares, so **the conversation is the chat, not the sender**. Every participant's message lands in the same session, which is what lets the agent follow a thread rather than seeing N disconnected 1:1s. One-to-one keeps its per-contact chat exactly as before.

The prompt gains a group marker and the response policy:

```
[inkbox:group_imessage conversation_id=… from=… participants=…,… reply_mode=conversation_id | contact=…]
Group iMessage response policy: you receive every message in this group so you can track context.
Reply only when the latest message clearly addresses this Inkbox agent, asks it to act, or a
visible answer would be expected from the agent.
Treat ordinary group chatter as context only.
If no visible reply is warranted, return exactly [SILENT].
```

That is the same policy this bridge already applies to group SMS — `_group_imessage_prompt` deliberately mirrors `_group_sms_prompt` rather than importing Hermes's internals, so it reads like the rest of the file.

Group flags and participants come from the event when present, falling back to a conversation lookup for events that omit them (mirroring `_lookup_text_conversation_summary`).

## Outbound — starting a group

`to` now accepts a single E.164 recipient or a list of 2–8 to open a group. **This bridge previously had no `to` at all** — the tool was conversation_id-only on the grounds that iMessage is recipient-first. That stays true for shared and dedicated *inbound* lines; a dedicated *outbound* line is the exception, and only it may initiate.

The tool checks for that line and returns a specific error code rather than letting the send fail at the API:

```
imessage_group_requires_dedicated_outbound
```

plus validation for exactly-one-of `to`/`conversation_id`, at least one recipient, at most 8, and distinct.

## Tests

6 new: group routing into the shared conversation chat with the policy and participants present; 1:1 keeping its per-contact chat with no policy injected; and the four outbound rejection paths (dedicated-line gate, both-targets, >8, duplicates).

**314 pass.** The 14 `tests/test_sessions.py` failures are pre-existing on `main` — a `TypeError` from an SDK mismatch in this environment, unrelated and confirmed against a clean checkout.

## Version

0.2.6 → **0.2.7**, matching the Hermes group-chat release so the fleet stays on one number.
