### PR TITLE
Use canonical webhook URLs and disable voicemail detection in CI

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install bridge + latest SDK
         run: |
           pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@a4dd76b534e33c0a8352148d8f0e9ab25199f05b#subdirectory=sdk/python" \
             -e . pytest
           pip install -U claude-agent-sdk
 

--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install bridge
         run: |
           pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@a4dd76b534e33c0a8352148d8f0e9ab25199f05b#subdirectory=sdk/python" \
             -e . pytest
 
       - name: Install Claude Code CLI

--- a/.github/workflows/live-external-events.yml
+++ b/.github/workflows/live-external-events.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install bridge
         run: |
           pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@a4dd76b534e33c0a8352148d8f0e9ab25199f05b#subdirectory=sdk/python" \
             -e . pytest
 
       - name: Install Claude Code CLI

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install bridge + driver deps
         run: |
           pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@a4dd76b534e33c0a8352148d8f0e9ab25199f05b#subdirectory=sdk/python" \
             -e . pytest fastapi 'uvicorn[standard]'
 
       - name: Install Claude Code CLI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install bridge + latest SDK
         run: |
           uv pip install --system \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@fdea6e55ac117f246624852aedeef0feabe08b9a#subdirectory=sdk/python" \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@a4dd76b534e33c0a8352148d8f0e9ab25199f05b#subdirectory=sdk/python" \
             -e . pytest
           uv pip install --system -U claude-agent-sdk
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The agent reaches you (or third parties) through an in-process MCP server:
 - `inkbox_list_a2a_tasks` · `inkbox_list_a2a_messages` — page and search this identity's inbound and outbound A2A history, with participant, task, context, role, state, and timestamp filters.
 - `inkbox_a2a_complete` · `inkbox_a2a_ask_caller` · `inkbox_a2a_fail` — commit the outcome of a verified inbound A2A task. These tools are rejected outside that task's isolated session.
 
-The bridge requires Inkbox SDK 0.5.6 or newer.
+The bridge requires Inkbox SDK 0.5.8 or newer.
 
 On a live call, the OpenAI Realtime voice agent additionally gets `consult_agent`, `register_post_call_action` / `edit_post_call_action` / `delete_post_call_action`, and `hang_up_call` — see [Voice](#voice).
 

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -704,7 +704,6 @@ class InkboxGateway:
             _reconcile(
                 {"agent_identity_id": identity.id},
                 A2A_EVENTS,
-                subscription_url=f"{webhook_url}?channel=a2a",
             )
         except Exception as exc:
             if not _is_unsupported_a2a_event_types(exc):

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -474,8 +474,16 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         "if they are connected to you over iMessage, otherwise the call is "
         "rejected). If origination is omitted it is resolved automatically. The "
         "call's audio bridges to the running gateway. Always pass purpose so the "
-        "live call opens with context; optionally pass opening_message and context.",
-        {"to_number": str, "purpose": str, "origination": str, "opening_message": str, "context": str},
+        "live call opens with context; optionally pass opening_message, context, "
+        "and voicemail_detection (enabled or disabled).",
+        {
+            "to_number": str,
+            "purpose": str,
+            "origination": str,
+            "opening_message": str,
+            "context": str,
+            "voicemail_detection": str,
+        },
     )
     async def inkbox_place_call(args: Dict[str, Any]) -> Dict[str, Any]:
         def _run():
@@ -486,6 +494,13 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
             if not purpose:
                 raise ValueError(
                     "purpose is required so the live call opens with context"
+                )
+            voicemail_detection = str(
+                args.get("voicemail_detection") or ""
+            ).strip().lower()
+            if voicemail_detection not in {"", "enabled", "disabled"}:
+                raise ValueError(
+                    "voicemail_detection must be enabled or disabled"
                 )
             identity = _identity()
 
@@ -519,13 +534,20 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
                 to_number=to_number,
             )
             ws_url = _append_query_param(ws_url, "context_token", token)
+            call_kwargs = {
+                "to_number": to_number,
+                "origination": origination,
+                "client_websocket_url": ws_url,
+            }
+            if voicemail_detection:
+                call_kwargs["voicemail_detection"] = voicemail_detection
             try:
-                call = identity.place_call(
-                    to_number=to_number,
-                    origination=origination,
-                    client_websocket_url=ws_url,
-                )
+                call = identity.place_call(**call_kwargs)
             except TypeError:
+                if voicemail_detection:
+                    raise RuntimeError(
+                        "voicemail_detection requires inkbox SDK 0.5.8 or newer"
+                    )
                 # Older SDK without ``origination`` support → dedicated only.
                 call = identity.place_call(to_number=to_number, client_websocket_url=ws_url)
             return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Inkbox bridge for Claude Code — talk to your coding agent over 
 requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.5.6,<1.0.0",
+  "inkbox>=0.5.8,<1.0.0",
   "claude-agent-sdk>=0.1.0",
   "segno>=1.5",  # terminal QR codes for the iMessage connect step
 ]

--- a/tests/live/test_cross_channel.py
+++ b/tests/live/test_cross_channel.py
@@ -214,7 +214,10 @@ def test_email_request_gets_call(xc):
     before = {c.id for c in _inbound_calls_from_aut(remote, remote_pid, aut_phone)}
     remote.messages.send(
         xc["remote_email"], to=[xc["aut_email"]], subject="please call me",
-        body_text="Please place a phone call to my number now — I'd rather talk than type.",
+        body_text=(
+            "Please place a phone call to my number now with "
+            "voicemail_detection disabled — I'd rather talk than type."
+        ),
     )
     _wait_for_new_call(remote, remote_pid, aut_phone, before)
 
@@ -231,6 +234,10 @@ def test_sms_request_gets_call(xc):
     # identical no-reply sends would trip the duplicate_body rule (422).
     remote.texts.send(
         remote_pid, to=aut_phone,
-        text=f"Please place a phone call to my number right now — actually call me, don't text back. (ref {_token()})",
+        text=(
+            "Please place a phone call to my number right now with "
+            "voicemail_detection disabled — actually call me, don't text back. "
+            f"(ref {_token()})"
+        ),
     )
     _wait_for_new_call(remote, remote_pid, aut_phone, before)

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -29,10 +29,10 @@ import pytest
 # cadence. Two identical no-reply sends to the same number trip the
 # duplicate_body rule (422), so every call request must carry a fresh body.
 _CALL_ME_PHRASINGS = (
-    "Please call me right now by phone — give me a ring.",
-    "Can you ring me on the phone right now?",
-    "Give me a call on my number now, please.",
-    "Please phone me right away — I'd rather talk than text.",
+    "Please call me right now by phone and set voicemail_detection to disabled.",
+    "Can you ring me now with voicemail_detection disabled?",
+    "Give me a call now, using disabled voicemail_detection.",
+    "Please phone me right away and disable voicemail_detection.",
 )
 
 
@@ -187,7 +187,10 @@ def test_inbound_call_inkbox_tts_stt():
 
     # Place the call to the agent, handing Inkbox the driver's own media WS.
     call = remote.calls.place(
-        from_number=st["number"], to_number=aut_phone, client_websocket_url=st["ws_url"],
+        from_number=st["number"],
+        to_number=aut_phone,
+        client_websocket_url=st["ws_url"],
+        voicemail_detection="disabled",
     )
     try:
         agent_said = _wait_for_two_way_call(remote, st["number_id"], call.id)

--- a/tests/test_gateway_call_config.py
+++ b/tests/test_gateway_call_config.py
@@ -177,7 +177,7 @@ def test_a2a_and_imessage_use_channel_coherent_subscriptions():
         gateway.IMESSAGE_EVENTS,
     ]
     assert [created["url"] for created in subscriptions.created] == [
-        "https://agent.example/webhook?channel=a2a",
+        "https://agent.example/webhook",
         "https://agent.example/webhook",
     ]
 
@@ -185,7 +185,7 @@ def test_a2a_and_imessage_use_channel_coherent_subscriptions():
 def test_imessage_reconcile_preserves_existing_a2a_channel_subscription():
     a2a = types.SimpleNamespace(
         id="sub-a2a",
-        url="https://agent.example/webhook?channel=a2a",
+        url="https://agent.example/webhook",
         event_types=gateway.A2A_EVENTS,
     )
     subscriptions = _FakeSubscriptions([a2a])
@@ -195,7 +195,11 @@ def test_imessage_reconcile_preserves_existing_a2a_channel_subscription():
     )
 
     assert subscriptions.deleted == []
-    assert subscriptions.created[-1]["event_types"] == gateway.IMESSAGE_EVENTS
+    assert subscriptions.created == [{
+        "agent_identity_id": "identity-1",
+        "url": "https://agent.example/webhook",
+        "event_types": gateway.IMESSAGE_EVENTS,
+    }]
 
 
 def test_a2a_only_subscription_is_skipped_on_older_api():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -414,6 +414,24 @@ def test_place_call_requires_purpose():
     assert "purpose is required" in data["error"]
 
 
+def test_place_call_forwards_disabled_voicemail_detection(tmp_path, monkeypatch):
+    monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
+    client = _FakeClient()
+
+    data = _call(
+        client,
+        "inkbox_place_call",
+        {
+            "to_number": "+15551112222",
+            "purpose": "run the CI voice check",
+            "voicemail_detection": "disabled",
+        },
+    )
+
+    assert data["placed"] is True
+    assert client.identity.place_call_kwargs["voicemail_detection"] == "disabled"
+
+
 def test_place_call_explicit_origination_wins():
     client = _FakeClient()
     client.identity.imessage_enabled = True


### PR DESCRIPTION
## Executive Summary

- Registers A2A and iMessage subscriptions on the canonical webhook URL.
- Disables voicemail detection for every CI voice call.

## Description

Gateway startup now configures A2A on the plain webhook URL. The outbound call tool accepts voicemail_detection, live CI requests disabled detection, and the minimum Inkbox SDK version is 0.5.8.

Related PRs:
- https://github.com/inkbox-ai/hermes-agent-plugin/pull/88
- https://github.com/inkbox-ai/claude-code-plugin/pull/51
- https://github.com/inkbox-ai/codex-plugin/pull/34
- https://github.com/inkbox-ai/openclaw-plugin/pull/51
- https://github.com/inkbox-ai/opencode-plugin/pull/15

## Reason

The query parameter is not used for webhook routing. CI calls also need voicemail detection disabled so the voice driver is not classified as an answering service.

## Decisions

- Keep webhook setup at gateway startup.
- Use the existing event-type reconciliation to keep same-URL channels independent.
- Limit disabled voicemail detection to CI voice scenarios; normal calls retain the SDK default.

## Testing

- uv run pytest -q tests/test_gateway_call_config.py tests/test_tools.py
- uv run ruff check inkbox_claude/gateway.py inkbox_claude/tools.py tests/test_gateway_call_config.py tests/test_tools.py tests/live/test_voice.py tests/live/test_cross_channel.py