### PR TITLE
feat: add selectable phone call voice stacks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.venv
+.pytest_cache
+**/__pycache__
+*.py[cod]
+.env
+.env.*
+!.env.example
+dist
+build
+*.egg-info

--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,12 @@ INKBOX_SIGNING_KEY=whsec_xxxxxxxxxxxx
 # INKBOX_WEBHOOK_SECRET_GITHUB=...                   # verification secret for a registered third-party source
 # INKBOX_BRIDGE_PORT=8767
 
-# --- Realtime voice (optional; requires INKBOX_REALTIME_ENABLED=true) ---
+# --- Phone call voice stack ---
+# INKBOX_VOICE_STACK=inkbox_tts_stt              # inkbox_voice_ai | openai_realtime | inkbox_tts_stt
+# INKBOX_VOICE_AI_AUTHORITY_MODE=contact_scoped   # local mirror for doctor; contact_scoped | yolo
+# INKBOX_VOICEMAIL_DETECTION=enabled              # enabled | disabled
+
+# --- Realtime voice (optional; select INKBOX_VOICE_STACK=openai_realtime) ---
 # INKBOX_REALTIME_ENABLED=true
 # INKBOX_REALTIME_API_KEY=sk-realtime
 # OPENAI_API_KEY=sk-openai-fallback

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install bridge + latest SDK
         run: |
           pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@a4dd76b534e33c0a8352148d8f0e9ab25199f05b#subdirectory=sdk/python" \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@73f18a2b8c0e9dc6887c5663e6e904d54869927e#subdirectory=sdk/python" \
             -e . pytest
           pip install -U claude-agent-sdk
 

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install bridge + latest SDK
         run: |
           pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@73f18a2b8c0e9dc6887c5663e6e904d54869927e#subdirectory=sdk/python" \
+            "inkbox==0.5.9" \
             -e . pytest
           pip install -U claude-agent-sdk
 

--- a/.github/workflows/live-a2a.yml
+++ b/.github/workflows/live-a2a.yml
@@ -46,6 +46,7 @@ jobs:
           - outbound-multi
     env:
       INKBOX_API_KEY: ${{ secrets.CLAUDE_CODE_INKBOX_API_KEY }}
+      INKBOX_VOICEMAIL_DETECTION: "disabled"
       INKBOX_SIGNING_KEY: ${{ secrets.CLAUDE_CODE_INKBOX_SIGNING_KEY }}
       CLAUDE_PROJECT_DIR: ${{ github.workspace }}
       INKBOX_PERMISSION_TIMEOUT_S: "30"

--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install bridge
         run: |
           pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@73f18a2b8c0e9dc6887c5663e6e904d54869927e#subdirectory=sdk/python" \
+            "inkbox==0.5.9" \
             -e . pytest
 
       - name: Install Claude Code CLI

--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -139,13 +139,13 @@ jobs:
 
       # Logs can carry live message content — surface them only when needed.
       - name: Dump logs on failure
-        if: failure()
+        if: failure() || cancelled()
         run: |
           echo "=== gateway.log ==="; tail -n 300 /tmp/gateway.log 2>/dev/null || true
           echo "=== mock_anthropic.log ==="; tail -n 100 /tmp/mock_anthropic.log 2>/dev/null || true
 
       - name: Upload logs on failure
-        if: failure()
+        if: failure() || cancelled()
         uses: actions/upload-artifact@v7
         with:
           name: live-channels-${{ matrix.leg }}-logs

--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -45,6 +45,7 @@ jobs:
         leg: [mock, real]
     env:
       INKBOX_API_KEY: ${{ secrets.CLAUDE_CODE_INKBOX_API_KEY }}
+      INKBOX_VOICEMAIL_DETECTION: "disabled"
       INKBOX_SIGNING_KEY: ${{ secrets.CLAUDE_CODE_INKBOX_SIGNING_KEY }}
       CLAUDE_PROJECT_DIR: ${{ github.workspace }}
       # A stray permission escalation should fail a test fast, not park the
@@ -67,7 +68,7 @@ jobs:
       - name: Install bridge
         run: |
           pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@a4dd76b534e33c0a8352148d8f0e9ab25199f05b#subdirectory=sdk/python" \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@73f18a2b8c0e9dc6887c5663e6e904d54869927e#subdirectory=sdk/python" \
             -e . pytest
 
       - name: Install Claude Code CLI

--- a/.github/workflows/live-channels.yml
+++ b/.github/workflows/live-channels.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           nohup python3 tests/live/mock_anthropic.py 8089 > /tmp/mock_anthropic.log 2>&1 &
           for i in $(seq 1 10); do
-            curl -fsS http://127.0.0.1:8089/ > /dev/null 2>&1 && exit 0
+            curl -fsS --connect-timeout 1 --max-time 3 http://127.0.0.1:8089/ > /dev/null 2>&1 && exit 0
             sleep 1
           done
           echo "mock model server never came up"; exit 1

--- a/.github/workflows/live-external-events.yml
+++ b/.github/workflows/live-external-events.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install bridge
         run: |
           pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@73f18a2b8c0e9dc6887c5663e6e904d54869927e#subdirectory=sdk/python" \
+            "inkbox==0.5.9" \
             -e . pytest
 
       - name: Install Claude Code CLI

--- a/.github/workflows/live-external-events.yml
+++ b/.github/workflows/live-external-events.yml
@@ -38,6 +38,7 @@ jobs:
     timeout-minutes: 12
     env:
       INKBOX_API_KEY: ${{ secrets.CLAUDE_CODE_INKBOX_API_KEY }}
+      INKBOX_VOICEMAIL_DETECTION: "disabled"
       INKBOX_SIGNING_KEY: ${{ secrets.CLAUDE_CODE_INKBOX_SIGNING_KEY }}
       CLAUDE_PROJECT_DIR: ${{ github.workspace }}
       # A stray permission escalation should fail a test fast, not park the
@@ -65,7 +66,7 @@ jobs:
       - name: Install bridge
         run: |
           pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@a4dd76b534e33c0a8352148d8f0e9ab25199f05b#subdirectory=sdk/python" \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@73f18a2b8c0e9dc6887c5663e6e904d54869927e#subdirectory=sdk/python" \
             -e . pytest
 
       - name: Install Claude Code CLI

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -132,6 +132,7 @@ jobs:
           CLAUDE_CODE_INKBOX_API_KEY: ${{ secrets.CLAUDE_CODE_INKBOX_API_KEY }}
           VOICE_SCENARIO: ${{ matrix.scenario }}
           LIVE_REAL_MODEL: "1"
+          GATEWAY_LOG: /tmp/gateway.log
         run: python3 -m pytest tests/live/test_voice.py -v
 
       # Logs can carry live call transcripts — surface them only when needed.

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install bridge + driver deps
         run: |
           pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@73f18a2b8c0e9dc6887c5663e6e904d54869927e#subdirectory=sdk/python" \
+            "inkbox==0.5.9" \
             -e . pytest fastapi 'uvicorn[standard]'
 
       - name: Install Claude Code CLI

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -106,7 +106,9 @@ jobs:
             echo "INKBOX_REALTIME_ENABLED=false" >> "$GITHUB_ENV"
             echo "HOSTED_POST_CALL_MARKER=$marker" >> "$GITHUB_ENV"
             echo "VOICE_DRIVER_LINE=After this call ends, send me one SMS containing exactly these words: $marker. Do not send it during the call." >> "$GITHUB_ENV"
-            echo "VOICE_DRIVER_LISTEN=45" >> "$GITHUB_ENV"
+            # Keep the media peer alive while the test waits for Voice AI to
+            # persist the open post-call action, then let the test hang up.
+            echo "VOICE_DRIVER_LISTEN=180" >> "$GITHUB_ENV"
           else
             echo "INKBOX_VOICE_STACK=inkbox_tts_stt" >> "$GITHUB_ENV"
             echo "INKBOX_REALTIME_ENABLED=false" >> "$GITHUB_ENV"

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -155,13 +155,13 @@ jobs:
 
       # Logs can carry live call transcripts — surface them only when needed.
       - name: Dump logs on failure
-        if: failure()
+        if: failure() || cancelled()
         run: |
           echo "=== gateway.log ==="; tail -n 300 /tmp/gateway.log 2>/dev/null || true
           echo "=== voice_driver.log ==="; tail -n 150 /tmp/voice_driver.log 2>/dev/null || true
 
       - name: Upload logs on failure
-        if: failure()
+        if: failure() || cancelled()
         uses: actions/upload-artifact@v7
         with:
           name: live-voice-${{ matrix.scenario }}-logs

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -105,7 +105,7 @@ jobs:
             echo "INKBOX_VOICE_STACK=inkbox_voice_ai" >> "$GITHUB_ENV"
             echo "INKBOX_REALTIME_ENABLED=false" >> "$GITHUB_ENV"
             echo "HOSTED_POST_CALL_MARKER=$marker" >> "$GITHUB_ENV"
-            echo "VOICE_DRIVER_LINE=After this call ends, send me one SMS containing exactly these words: $marker. Do not send it during the call." >> "$GITHUB_ENV"
+            echo "VOICE_DRIVER_LINE=After we hang up, send me one SMS. Create the post-call action now with this exact SMS body: $marker. Read those five words back to me after the action is saved. Do not send it during the call." >> "$GITHUB_ENV"
             # Keep the media peer alive while the test waits for Voice AI to
             # persist the open post-call action, then let the test hang up.
             echo "VOICE_DRIVER_LISTEN=180" >> "$GITHUB_ENV"

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -86,11 +86,27 @@ jobs:
             echo "INKBOX_REALTIME_MODEL=gpt-realtime-2" >> "$GITHUB_ENV"
             echo "INKBOX_REALTIME_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> "$GITHUB_ENV"
           elif [ "${{ matrix.scenario }}" = "outbound_hosted" ]; then
-            marker="hosted-post-call-$(openssl rand -hex 6)"
+            # The marker crosses TTS -> PSTN -> STT. Use ordinary phonetic
+            # words instead of punctuation and long digit strings so the live
+            # assertion proves the current request without depending on exact
+            # ASR formatting.
+            RADIO_WORDS=(
+              alpha bravo charlie delta echo foxtrot golf hotel india juliet
+              kilo lima mike november oscar papa quebec romeo sierra tango
+              uniform victor whiskey xray yankee zulu
+            )
+            marker_value=$((GITHUB_RUN_ID * 10 + GITHUB_RUN_ATTEMPT))
+            marker="claude"
+            for _ in 1 2 3 4 5; do
+              marker_index=$((marker_value % ${#RADIO_WORDS[@]}))
+              marker="$marker ${RADIO_WORDS[$marker_index]}"
+              marker_value=$((marker_value / ${#RADIO_WORDS[@]}))
+            done
             echo "INKBOX_VOICE_STACK=inkbox_voice_ai" >> "$GITHUB_ENV"
             echo "INKBOX_REALTIME_ENABLED=false" >> "$GITHUB_ENV"
             echo "HOSTED_POST_CALL_MARKER=$marker" >> "$GITHUB_ENV"
-            echo "VOICE_DRIVER_LINE=After this call ends, send me an SMS containing exactly: $marker" >> "$GITHUB_ENV"
+            echo "VOICE_DRIVER_LINE=After this call ends, send me one SMS containing exactly these words: $marker. Do not send it during the call." >> "$GITHUB_ENV"
+            echo "VOICE_DRIVER_LISTEN=45" >> "$GITHUB_ENV"
           else
             echo "INKBOX_VOICE_STACK=inkbox_tts_stt" >> "$GITHUB_ENV"
             echo "INKBOX_REALTIME_ENABLED=false" >> "$GITHUB_ENV"

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -96,10 +96,10 @@ jobs:
               uniform victor whiskey xray yankee zulu
             )
             marker_value=$((GITHUB_RUN_ID * 10 + GITHUB_RUN_ATTEMPT))
-            marker="claude"
+            marker=""
             for _ in 1 2 3 4 5; do
               marker_index=$((marker_value % ${#RADIO_WORDS[@]}))
-              marker="$marker ${RADIO_WORDS[$marker_index]}"
+              marker="${marker:+$marker }${RADIO_WORDS[$marker_index]}"
               marker_value=$((marker_value / ${#RADIO_WORDS[@]}))
             done
             echo "INKBOX_VOICE_STACK=inkbox_voice_ai" >> "$GITHUB_ENV"

--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -4,6 +4,7 @@ name: Live voice e2e
 #   * inbound_inkbox    — driver calls the agent; Inkbox STT/TTS answers.
 #   * outbound_realtime — driver texts "call me"; the agent dials back powered
 #                         by the realtime voice API.
+#   * outbound_hosted   — Voice AI runs the call and call.ended wakes Claude.
 # A driver process (tests/live/voice_driver.py) is the peer on the other end
 # of the call, bridged over the driver identity's own Inkbox tunnel.
 
@@ -31,9 +32,10 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        scenario: [inbound_inkbox, outbound_realtime]
+        scenario: [inbound_inkbox, outbound_realtime, outbound_hosted]
     env:
       INKBOX_API_KEY: ${{ secrets.CLAUDE_CODE_INKBOX_API_KEY }}
+      INKBOX_VOICEMAIL_DETECTION: "disabled"
       INKBOX_SIGNING_KEY: ${{ secrets.CLAUDE_CODE_INKBOX_SIGNING_KEY }}
       CLAUDE_PROJECT_DIR: ${{ github.workspace }}
       INKBOX_PERMISSION_TIMEOUT_S: "30"
@@ -58,7 +60,7 @@ jobs:
       - name: Install bridge + driver deps
         run: |
           pip install \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@a4dd76b534e33c0a8352148d8f0e9ab25199f05b#subdirectory=sdk/python" \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@73f18a2b8c0e9dc6887c5663e6e904d54869927e#subdirectory=sdk/python" \
             -e . pytest fastapi 'uvicorn[standard]'
 
       - name: Install Claude Code CLI
@@ -79,10 +81,18 @@ jobs:
       - name: Configure speech mode (${{ matrix.scenario }})
         run: |
           if [ "${{ matrix.scenario }}" = "outbound_realtime" ]; then
+            echo "INKBOX_VOICE_STACK=openai_realtime" >> "$GITHUB_ENV"
             echo "INKBOX_REALTIME_ENABLED=true" >> "$GITHUB_ENV"
             echo "INKBOX_REALTIME_MODEL=gpt-realtime-2" >> "$GITHUB_ENV"
             echo "INKBOX_REALTIME_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> "$GITHUB_ENV"
+          elif [ "${{ matrix.scenario }}" = "outbound_hosted" ]; then
+            marker="hosted-post-call-$(openssl rand -hex 6)"
+            echo "INKBOX_VOICE_STACK=inkbox_voice_ai" >> "$GITHUB_ENV"
+            echo "INKBOX_REALTIME_ENABLED=false" >> "$GITHUB_ENV"
+            echo "HOSTED_POST_CALL_MARKER=$marker" >> "$GITHUB_ENV"
+            echo "VOICE_DRIVER_LINE=After this call ends, send me an SMS containing exactly: $marker" >> "$GITHUB_ENV"
           else
+            echo "INKBOX_VOICE_STACK=inkbox_tts_stt" >> "$GITHUB_ENV"
             echo "INKBOX_REALTIME_ENABLED=false" >> "$GITHUB_ENV"
           fi
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install bridge + latest SDK
         run: |
           uv pip install --system \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@a4dd76b534e33c0a8352148d8f0e9ab25199f05b#subdirectory=sdk/python" \
+            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@73f18a2b8c0e9dc6887c5663e6e904d54869927e#subdirectory=sdk/python" \
             -e . pytest
           uv pip install --system -U claude-agent-sdk
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install bridge + latest SDK
         run: |
           uv pip install --system \
-            "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@73f18a2b8c0e9dc6887c5663e6e904d54869927e#subdirectory=sdk/python" \
+            "inkbox==0.5.9" \
             -e . pytest
           uv pip install --system -U claude-agent-sdk
 

--- a/Dockerfile.manual-test
+++ b/Dockerfile.manual-test
@@ -1,0 +1,26 @@
+FROM node:22-bookworm
+
+ARG INKBOX_SDK_SHA=73f18a2b8c0e9dc6887c5663e6e904d54869927e
+
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git python3 python3-venv \
+    && rm -rf /var/lib/apt/lists/* \
+    && python3 -m venv /opt/inkbox-claude \
+    && /opt/inkbox-claude/bin/pip install --no-cache-dir --upgrade pip \
+    && npm install --global @anthropic-ai/claude-code
+
+WORKDIR /src/claude-code-plugin
+COPY . .
+RUN /opt/inkbox-claude/bin/pip install --no-cache-dir \
+      "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@${INKBOX_SDK_SHA}#subdirectory=sdk/python" \
+    && /opt/inkbox-claude/bin/pip install --no-cache-dir .
+
+ENV PATH="/opt/inkbox-claude/bin:${PATH}" \
+    INKBOX_CLAUDE_HOME=/home/node/.inkbox-claude
+RUN mkdir -p /home/node/.inkbox-claude /workspace \
+    && chown -R node:node /home/node/.inkbox-claude /workspace
+
+USER node
+WORKDIR /workspace
+CMD ["sleep", "infinity"]

--- a/Dockerfile.manual-test
+++ b/Dockerfile.manual-test
@@ -1,7 +1,5 @@
 FROM node:22-bookworm
 
-ARG INKBOX_SDK_SHA=73f18a2b8c0e9dc6887c5663e6e904d54869927e
-
 USER root
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git python3 python3-venv \
@@ -13,7 +11,7 @@ RUN apt-get update \
 WORKDIR /src/claude-code-plugin
 COPY . .
 RUN /opt/inkbox-claude/bin/pip install --no-cache-dir \
-      "inkbox @ git+https://github.com/inkbox-ai/inkbox.git@${INKBOX_SDK_SHA}#subdirectory=sdk/python" \
+      "inkbox==0.5.9" \
     && /opt/inkbox-claude/bin/pip install --no-cache-dir .
 
 ENV PATH="/opt/inkbox-claude/bin:${PATH}" \

--- a/README.md
+++ b/README.md
@@ -163,7 +163,12 @@ These match only when the whole message is exactly the command, so "please /clea
 
 ## Voice
 
-Calls have two modes, chosen per call:
+The configured phone voice stack applies to inbound and outbound calls:
+
+- **Inkbox Voice AI:** Inkbox handles the conversation on the agent's behalf.
+  When the call ends, a signed `call.ended` event wakes the same contact-keyed
+  Claude Code session once to execute remaining commitments. Plain model text
+  from that synthetic turn is suppressed; explicit tool side effects still run.
 
 - **OpenAI Realtime** (when configured): the bridge pre-opens an OpenAI Realtime session and accepts the call in raw-media mode, so a natural, low-latency voice handles the conversation. It runs the call itself and has these tools:
   - `consult_agent` — do real work *now* in the project; runs in the *same* contact-keyed session as your SMS/iMessage and its answer is spoken back.
@@ -180,7 +185,7 @@ Calls — inbound and outbound — can run over either of two lines, and the age
 - **The dedicated phone number.** The agent's own number (the same line SMS uses). Outbound calls present this number; inbound calls to it ring the agent.
 - **The shared Inkbox iMessage line.** The agent can also place and receive voice calls with a person it's connected to over iMessage, over the same shared line that person already messages. The underlying number is never surfaced — Inkbox resolves it from the iMessage connection — and it only works for people already connected over iMessage (an unknown caller is rejected; an outbound call with no connection is refused).
 
-Inbound answering is configured once per identity (`auto_accept` → open the call bridge WebSocket), so a single setting governs both lines. Outbound, the agent sets `origination` on `inkbox_place_call` (`dedicated_number` / `shared_imessage_number`), or omits it — then it resolves to the only line available, or, when both are, to the line matching the current conversation's channel (an iMessage turn calls over the shared line; an SMS/phone turn over the dedicated number).
+Inbound answering is configured once per identity (`hosted_agent` for Inkbox Voice AI, otherwise `auto_accept` to the call bridge WebSocket), so a single setting governs both lines. Outbound, the agent sets `origination` on `inkbox_place_call` (`dedicated_number` / `shared_imessage_number`), or omits it — then it resolves to the only line available, or, when both are, to the line matching the current conversation's channel (an iMessage turn calls over the shared line; an SMS/phone turn over the dedicated number).
 
 ## External webhooks
 
@@ -219,6 +224,9 @@ Beyond Inkbox's own events, the `/webhook` endpoint can wake the agent for event
 | `INKBOX_BRIDGE_PORT` | no | `8767` | Local webhook server port. |
 | `INKBOX_PERMISSION_TIMEOUT_S` | no | `600` | Seconds to wait for a permission/poll reply. |
 | `INKBOX_AUTO_ALLOWED_TOOLS` | no | read-only set | Tools that never need a permission text. |
+| `INKBOX_VOICE_STACK` | no | `inkbox_tts_stt` | `inkbox_voice_ai`, `openai_realtime`, or `inkbox_tts_stt`. |
+| `INKBOX_VOICE_AI_AUTHORITY_MODE` | no | `contact_scoped` | Local mirror used by doctor for the saved Voice AI authority. |
+| `INKBOX_VOICEMAIL_DETECTION` | no | `enabled` | Default outbound policy: `enabled` or `disabled`. |
 | `INKBOX_REALTIME_ENABLED` | no | `false` | Use OpenAI Realtime for calls. Needs a key; off → Inkbox STT/TTS. |
 | `INKBOX_REALTIME_API_KEY` | realtime | `OPENAI_API_KEY` | OpenAI key with `/v1/realtime` access. |
 | `INKBOX_REALTIME_MODEL` | no | `gpt-realtime-2` | Realtime model id. |
@@ -243,7 +251,49 @@ The agent reaches you (or third parties) through an in-process MCP server:
 - `inkbox_list_a2a_tasks` · `inkbox_list_a2a_messages` — page and search this identity's inbound and outbound A2A history, with participant, task, context, role, state, and timestamp filters.
 - `inkbox_a2a_complete` · `inkbox_a2a_ask_caller` · `inkbox_a2a_fail` — commit the outcome of a verified inbound A2A task. These tools are rejected outside that task's isolated session.
 
-The bridge requires Inkbox SDK 0.5.8 or newer.
+The bridge requires Inkbox SDK 0.5.9 or newer.
+
+### Phone call voice stack
+
+`inkbox-claude setup` presents a **Phone call voice stack** section with three
+choices:
+
+1. **Inkbox Voice AI** handles the call and wakes Claude Code after it ends.
+   Choose contact-scoped or YOLO authority during setup. Authority changes
+   require an admin API key, but that credential is used only in memory and is
+   never written to the plugin `.env`.
+2. **OpenAI Realtime API** uses a separately validated Realtime API key for
+   low-latency call audio while Claude Code handles complex work.
+3. **Inkbox TTS/STT** keeps the full agent turn in Claude Code and uses Inkbox
+   speech services, with higher latency.
+
+The canonical selection is `INKBOX_VOICE_STACK` (`inkbox_voice_ai`,
+`openai_realtime`, or `inkbox_tts_stt`). `INKBOX_VOICEMAIL_DETECTION` accepts
+`enabled` or `disabled` and applies to outbound calls unless the tool call
+explicitly overrides it. Voice AI outbound calls send a reason and use the
+saved server-side authority default; the plugin does not elevate authority per
+call.
+
+### Local/manual Docker test environment
+
+This image is for interactive local testing. It installs Claude Code, this
+plugin, and the pinned Inkbox SDK, but contains no credentials. It uses your
+native Claude login; an Anthropic or OpenAI API key is not embedded in the
+image. An OpenAI key is only needed if you select OpenAI Realtime for calls.
+
+```bash
+docker build -f Dockerfile.manual-test -t inkbox-claude-manual .
+docker run -d --name inkbox-claude-manual \
+  -v "$HOME/.claude:/home/node/.claude" \
+  -v inkbox-claude-state:/home/node/.inkbox-claude \
+  -v "$PWD:/workspace" \
+  inkbox-claude-manual
+docker exec -it inkbox-claude-manual bash
+claude --version
+inkbox-claude setup
+inkbox-claude doctor
+inkbox-claude run
+```
 
 On a live call, the OpenAI Realtime voice agent additionally gets `consult_agent`, `register_post_call_action` / `edit_post_call_action` / `delete_post_call_action`, and `hang_up_call` — see [Voice](#voice).
 

--- a/docs/live-ci.md
+++ b/docs/live-ci.md
@@ -1,0 +1,163 @@
+# Live CI coverage
+
+## Full stack e2e
+
+### Channels suite
+
+**Proves:** Both channel-model legs complete successfully. **Flow:** 1. Run the channels action. 2. Require success before continuing.
+
+### Agent2Agent suite
+
+**Proves:** All four Agent2Agent scenarios complete successfully. **Flow:** 1. Run the scenarios serially. 2. Require success before continuing.
+
+### Voice suite
+
+**Proves:** Each configured voice stack completes its matching live scenario. **Flow:** 1. Run the voice matrix serially. 2. Require success before continuing.
+
+### External-events suite
+
+**Proves:** Authenticated external-event acceptance and invalid-event rejection complete successfully. **Flow:** 1. Run the external-event action. 2. Require success before continuing.
+
+### Aggregate gate
+
+**Proves:** No delegated live suite failed, skipped, or was cancelled. **Flow:** 1. Read every suite result. 2. Pass only when all results are successful.
+
+## Live — Agent2Agent
+
+### Inbound single-turn
+
+**Proves:** The agent completes a remotely opened task with the requested result. **Flow:** 1. Open a task. 2. Wait for completion. 3. Check its unique result marker.
+
+### Inbound multi-turn
+
+**Proves:** The agent requests caller input before completing the task. **Flow:** 1. Open a task. 2. Answer its input request. 3. Check the final history and result.
+
+### Outbound single-turn
+
+**Proves:** The agent delegates work and waits for the worker before completing. **Flow:** 1. Request delegation. 2. Complete the worker task. 3. Check the outer result.
+
+### Outbound multi-turn
+
+**Proves:** The agent handles worker-requested input during delegation. **Flow:** 1. Request delegation. 2. Answer the worker. 3. Complete it. 4. Check the outer result.
+
+## Live channels e2e
+
+### Email reachability
+
+**Proves:** The deterministic model receives email and sends a correlated reply. **Flow:** 1. Send unique email. 2. Wait for its reply marker. 3. Mock leg only; real leg skips it.
+
+### Email basic reply
+
+**Proves:** The real model returns a non-empty email reply. **Flow:** 1. Send an acknowledgement request. 2. Wait for a correlated response. 3. Real leg only.
+
+### Email reports own identity
+
+**Proves:** The real model can report its configured identity fields. **Flow:** 1. Ask for identity details. 2. Compare the response with current API data. 3. Real leg only.
+
+### Email reports sender details
+
+**Proves:** The real model can use the sender's contact record. **Flow:** 1. Ensure a contact exists. 2. Ask who sent the email. 3. Compare returned contact fields. 4. Real leg only.
+
+### Email names available tools
+
+**Proves:** The real model sees the expected contact-tool surface. **Flow:** 1. Ask for tool names. 2. Require the contact tools and several available tools. 3. Real leg only.
+
+### Email contact lifecycle
+
+**Proves:** The real model can create, update, and delete a contact through tools. **Flow:** 1. Create a unique contact. 2. Verify and update it. 3. Delete and verify removal. 4. Real opt-in enabled by this action.
+
+### SMS reachability
+
+**Proves:** The deterministic model receives SMS and returns the expected marker. **Flow:** 1. Send a unique prompt. 2. Wait for the correlated reply. 3. Mock leg only; real leg skips it.
+
+### SMS basic reply
+
+**Proves:** The real model returns a non-empty SMS reply. **Flow:** 1. Send an acknowledgement request. 2. Wait for the correlated response. 3. Real leg only.
+
+### SMS reports own identity
+
+**Proves:** The real model can report its configured email identity. **Flow:** 1. Ask for identity details. 2. Require the current email in the reply. 3. Real leg only.
+
+### SMS reports sender details
+
+**Proves:** The real model can report a known sender's contact name. **Flow:** 1. Look up the sender. 2. Ask who sent the SMS. 3. Require the stored name when present. 4. Real leg only; skips without a contact match.
+
+### SMS names available tools
+
+**Proves:** The real model sees multiple plugin tools. **Flow:** 1. Ask for exact tool names. 2. Compare the response with the registered surface. 3. Real leg only.
+
+### SMS recovery after asynchronous failure
+
+**Proves:** An authenticated delivery-failure event wakes the agent and produces a fresh follow-up. **Flow:** 1. Establish the conversation. 2. Submit the failure event. 3. Observe a new inbound SMS and the recovery marker. 4. Real leg only.
+
+### SMS synchronous block feedback
+
+**Proves:** A synchronous content rejection reaches the agent's turn. **Flow:** 1. Request content expected to be rejected. 2. Accept either supported send path. 3. Require rejection feedback evidence. 4. Real leg only; a follow-up is optional.
+
+### Email-to-SMS
+
+**Proves:** An email request can produce an SMS containing the run marker. **Flow:** 1. Send email with a unique marker. 2. Wait for a new SMS carrying it. 3. Real leg only.
+
+### SMS-to-email
+
+**Proves:** An SMS request can produce an email containing the run marker. **Flow:** 1. Send SMS with a unique marker. 2. Wait for a new email carrying it. 3. Real leg only.
+
+### Email-to-call
+
+**Proves:** An email request creates paired call records with voicemail detection disabled. **Flow:** 1. Snapshot both call owners. 2. Request a call by email. 3. Correlate the fresh pair and inspect the outbound policy. 4. Real leg only.
+
+### SMS-to-call
+
+**Proves:** An SMS request creates paired call records with voicemail detection disabled. **Flow:** 1. Snapshot both call owners. 2. Request a call by SMS. 3. Correlate the fresh pair and inspect the outbound policy. 4. Real leg only.
+
+### Inbound TTS/STT voice test
+
+**Proves:** Nothing in the channels action; this scenario belongs to the voice matrix. **Flow:** 1. Collect the test. 2. Skip it because no voice scenario is selected.
+
+### Outbound realtime voice test
+
+**Proves:** Nothing in the channels action; this scenario belongs to the voice matrix. **Flow:** 1. Collect the test. 2. Skip it because no voice scenario is selected.
+
+### Outbound hosted voice test
+
+**Proves:** Nothing in the channels action; this scenario belongs to the voice matrix. **Flow:** 1. Collect the test. 2. Skip it because no voice scenario is selected.
+
+### Authenticated product external event
+
+**Proves:** Nothing in the channels action; external-event opt-in is absent. **Flow:** 1. Collect the test. 2. Skip it in both channel legs.
+
+### Invalid external authentication
+
+**Proves:** Nothing in the channels action; external-event opt-in is absent. **Flow:** 1. Collect the test. 2. Skip it in both channel legs.
+
+### Valid external authentication
+
+**Proves:** Nothing in the channels action; external-event opt-in is absent. **Flow:** 1. Collect the test. 2. Skip it in both channel legs.
+
+## Live voice e2e
+
+### Inbound TTS/STT
+
+**Proves:** The TTS/STT stack holds a two-way call and persists disabled voicemail detection. **Flow:** 1. Place an inbound call. 2. Require speech from both parties. 3. Inspect call policy and speech mode.
+
+### Outbound realtime
+
+**Proves:** The realtime stack places a callback, holds a two-way call, and persists disabled voicemail detection. **Flow:** 1. Request a callback by SMS. 2. Correlate both call records. 3. Check conversation and speech mode.
+
+### Outbound hosted
+
+**Proves:** Voice AI records the request and open action, emits completion evidence, and creates a current marker-bearing SMS to the caller. **Flow:** 1. Request a hosted callback. 2. Check mode, reason, authority, and voicemail policy. 3. Wait for transcript, action, completion, and matching SMS evidence.
+
+## Live external events e2e
+
+### Authenticated product external event
+
+**Proves:** A valid authenticated event completes a real-model agent turn. **Flow:** 1. Submit a uniquely identified event. 2. Require acceptance. 3. Wait for its completion marker.
+
+### Invalid external authentication
+
+**Proves:** Invalid external authentication is rejected without starting a session. **Flow:** 1. Submit an invalid event. 2. Require rejection. 3. Confirm no matching session starts.
+
+### Valid external authentication
+
+**Proves:** Valid external authentication reaches the session layer. **Flow:** 1. Submit a valid event. 2. Require acceptance. 3. Wait for the matching session marker.

--- a/inkbox_claude/__init__.py
+++ b/inkbox_claude/__init__.py
@@ -1,3 +1,3 @@
 """Inkbox bridge for Claude Code — email, SMS, iMessage, and voice."""
 
-__version__ = "0.2.7"
+__version__ = "0.2.8"

--- a/inkbox_claude/config.py
+++ b/inkbox_claude/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.metadata
 import os
 from dataclasses import dataclass, field
+from enum import Enum
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List
@@ -24,6 +25,14 @@ DISTRIBUTION_NAME = "claude-code-plugin"
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8767
 DEFAULT_WEBHOOK_PATH = "/webhook"
+
+
+class VoiceStack(str, Enum):
+    """Supported phone-call voice stacks."""
+
+    INKBOX_VOICE_AI = "inkbox_voice_ai"
+    OPENAI_REALTIME = "openai_realtime"
+    INKBOX_TTS_STT = "inkbox_tts_stt"
 
 # Tools Claude Code may run without texting the human first. Everything
 # else (Bash, Write, Edit, ...) escalates over the active channel.
@@ -82,6 +91,10 @@ class BridgeConfig:
     claude_model: str = ""
     permission_timeout_s: float = 600.0
     auto_allowed_tools: List[str] = field(default_factory=lambda: list(DEFAULT_AUTO_ALLOWED_TOOLS))
+    voice_stack: VoiceStack = VoiceStack.INKBOX_TTS_STT
+    voice_stack_invalid_value: str = ""
+    voice_ai_authority_mode: str = "contact_scoped"
+    voicemail_detection: str = "enabled"
     # OpenAI Realtime voice (off unless the wizard validated a key)
     realtime: RealtimeConfig = field(default_factory=RealtimeConfig)
 
@@ -130,8 +143,36 @@ def _read_realtime_config() -> RealtimeConfig:
     )
 
 
+def resolve_voice_stack(
+    value: Any,
+    *,
+    realtime_enabled: Any = None,
+    realtime_api_key: str = "",
+) -> tuple[VoiceStack, str]:
+    """Resolve the canonical stack while preserving pre-selector installs."""
+    normalized = str(value or "").strip().lower()
+    if normalized:
+        try:
+            return VoiceStack(normalized), ""
+        except ValueError:
+            return VoiceStack.INKBOX_TTS_STT, normalized
+    if realtime_enabled is not None:
+        enabled = str(realtime_enabled).strip().lower() in {"auto", "1", "true", "yes", "on"}
+        if not enabled:
+            return VoiceStack.INKBOX_TTS_STT, ""
+    if realtime_api_key:
+        return VoiceStack.OPENAI_REALTIME, ""
+    return VoiceStack.INKBOX_TTS_STT, ""
+
+
 def read_config(extra: Dict[str, Any] | None = None) -> BridgeConfig:
     extra = extra or {}
+    realtime = _read_realtime_config()
+    voice_stack, invalid_voice_stack = resolve_voice_stack(
+        extra.get("voice_stack") or os.getenv("INKBOX_VOICE_STACK"),
+        realtime_enabled=os.getenv("INKBOX_REALTIME_ENABLED"),
+        realtime_api_key=realtime.api_key,
+    )
     return BridgeConfig(
         api_key=str(extra.get("api_key") or os.getenv("INKBOX_API_KEY") or "").strip(),
         identity=str(extra.get("identity") or os.getenv("INKBOX_IDENTITY") or "").strip(),
@@ -151,5 +192,17 @@ def read_config(extra: Dict[str, Any] | None = None) -> BridgeConfig:
         claude_model=str(os.getenv("CLAUDE_MODEL") or extra.get("claude_model") or "").strip(),
         permission_timeout_s=float(os.getenv("INKBOX_PERMISSION_TIMEOUT_S") or 600.0),
         auto_allowed_tools=_csv_env("INKBOX_AUTO_ALLOWED_TOOLS") or list(DEFAULT_AUTO_ALLOWED_TOOLS),
-        realtime=_read_realtime_config(),
+        voice_stack=voice_stack,
+        voice_stack_invalid_value=invalid_voice_stack,
+        voice_ai_authority_mode=str(
+            extra.get("voice_ai_authority_mode")
+            or os.getenv("INKBOX_VOICE_AI_AUTHORITY_MODE")
+            or "contact_scoped"
+        ).strip().lower(),
+        voicemail_detection=str(
+            extra.get("voicemail_detection")
+            or os.getenv("INKBOX_VOICEMAIL_DETECTION")
+            or "enabled"
+        ).strip().lower(),
+        realtime=realtime,
     )

--- a/inkbox_claude/delivery_policy.py
+++ b/inkbox_claude/delivery_policy.py
@@ -16,9 +16,6 @@ _TERMINAL_CODES = frozenset({
     "sender_registration_required",
     "messaging_profile_disabled",
     "toll_free_sms_unsupported",
-    "unauthorized",
-    "forbidden",
-    "insufficient_authority",
 })
 _TERMINAL_MARKERS = (
     "opted out",
@@ -29,9 +26,6 @@ _TERMINAL_MARKERS = (
     "unreachable",
     "unknown subscriber",
     "cannot receive",
-    "not authorized",
-    "unauthorized",
-    "forbidden",
     "unsafe",
     "harmful",
     "abusive",
@@ -49,13 +43,19 @@ _RETRY_MARKERS = (
     "emoji",
     "profanity",
     "temporar",
-    "rate_limit",
-    "rate limit",
-    "duplicate_body",
-    "carrier_backoff",
     "carrier_unavailable",
 )
 _TRANSIENT_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504})
+_HOSTED_TERMINAL_CODES = frozenset({
+    "unauthorized",
+    "forbidden",
+    "insufficient_authority",
+})
+_HOSTED_RECOVERABLE_CODES = frozenset({
+    "carrier_rate_limit",
+    "inkbox_duplicate_body",
+    "inkbox_carrier_backoff",
+})
 
 
 def sms_delivery_failure_policy(
@@ -101,10 +101,17 @@ def sms_tool_failure_kind(error: Any) -> str:
 
     stable_code = f"{code} rule={rule}" if code and rule else (code or rule)
     fallback = str(error or "")
+    normalized_code = code.lower()
+    if normalized_code in _HOSTED_TERMINAL_CODES:
+        return "terminal"
     policy = sms_delivery_failure_policy(stable_code, message or fallback)
     if policy == "stop":
         return "terminal"
-    if policy == "retry" or status in _TRANSIENT_STATUSES:
+    if (
+        policy == "retry"
+        or normalized_code in _HOSTED_RECOVERABLE_CODES
+        or status in _TRANSIENT_STATUSES
+    ):
         return "recoverable"
     if status in {401, 403}:
         return "terminal"

--- a/inkbox_claude/delivery_policy.py
+++ b/inkbox_claude/delivery_policy.py
@@ -45,17 +45,53 @@ _RETRY_MARKERS = (
     "temporar",
     "carrier_unavailable",
 )
-_TRANSIENT_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504})
 _HOSTED_TERMINAL_CODES = frozenset({
+    *_TERMINAL_CODES,
     "unauthorized",
     "forbidden",
     "insufficient_authority",
-})
-_HOSTED_RECOVERABLE_CODES = frozenset({
     "carrier_rate_limit",
+    "carrier_unavailable",
+    "carrier_temporarily_unavailable",
     "inkbox_duplicate_body",
     "inkbox_carrier_backoff",
 })
+_HOSTED_RECOVERABLE_CODES = frozenset({
+    "sms_too_long",
+    "message_too_long",
+    "message_blocked_spam_filter",
+    "content_flagged_as_spam",
+    "content_rejected_by_carrier",
+    "content_blocked_by_policy",
+})
+_HOSTED_TERMINAL_MARKERS = (
+    *_TERMINAL_MARKERS,
+    "duplicate_body",
+    "carrier_backoff",
+    "carrier_unavailable",
+    "carrier temporarily unavailable",
+    "rate limit",
+    "timed out",
+    "timeout",
+)
+_HOSTED_RECOVERABLE_MARKERS = (
+    "invalid argument",
+    "invalid params",
+    "required property",
+    "missing required",
+    "schema",
+    "format",
+    "e.164",
+    "maximum is",
+    "too long",
+    "must be",
+    "specify exactly one",
+    "message_blocked_spam_filter",
+    "content_flagged_as_spam",
+    "content_rejected_by_carrier",
+    "content_blocked_by_policy",
+)
+_COMMIT_AMBIGUOUS_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504})
 
 
 def sms_delivery_failure_policy(
@@ -99,18 +135,20 @@ def sms_tool_failure_kind(error: Any) -> str:
     elif detail is not None:
         message = str(detail)
 
-    stable_code = f"{code} rule={rule}" if code and rule else (code or rule)
     fallback = str(error or "")
     normalized_code = code.lower()
-    if normalized_code in _HOSTED_TERMINAL_CODES:
-        return "terminal"
-    policy = sms_delivery_failure_policy(stable_code, message or fallback)
-    if policy == "stop":
+    combined = " ".join(
+        value.lower() for value in (code, rule, message, fallback) if value
+    )
+    if (
+        normalized_code in _HOSTED_TERMINAL_CODES
+        or status in _COMMIT_AMBIGUOUS_STATUSES
+        or any(marker in combined for marker in _HOSTED_TERMINAL_MARKERS)
+    ):
         return "terminal"
     if (
-        policy == "retry"
-        or normalized_code in _HOSTED_RECOVERABLE_CODES
-        or status in _TRANSIENT_STATUSES
+        normalized_code in _HOSTED_RECOVERABLE_CODES
+        or any(marker in combined for marker in _HOSTED_RECOVERABLE_MARKERS)
     ):
         return "recoverable"
     if status in {401, 403}:

--- a/inkbox_claude/delivery_policy.py
+++ b/inkbox_claude/delivery_policy.py
@@ -1,0 +1,111 @@
+"""Shared SMS failure classification for replies and hosted-call tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_TERMINAL_CODES = frozenset({
+    "recipient_not_opted_in",
+    "recipient_opted_out",
+    "recipient_blocked",
+    "invalid_phone_number",
+    "carrier_rejected",
+    "sender_sms_pending",
+    "sender_sms_assignment_failed",
+    "sender_not_registered",
+    "sender_registration_required",
+    "messaging_profile_disabled",
+    "toll_free_sms_unsupported",
+    "unauthorized",
+    "forbidden",
+    "insufficient_authority",
+})
+_TERMINAL_MARKERS = (
+    "opted out",
+    "opt-out",
+    "not opted in",
+    "invalid number",
+    "invalid phone",
+    "unreachable",
+    "unknown subscriber",
+    "cannot receive",
+    "not authorized",
+    "unauthorized",
+    "forbidden",
+    "unsafe",
+    "harmful",
+    "abusive",
+    "harassment",
+    "threatening",
+    "illegal content",
+)
+_RETRY_MARKERS = (
+    "40002",
+    "spam",
+    "content",
+    "too_long",
+    "too long",
+    "markdown",
+    "emoji",
+    "profanity",
+    "temporar",
+    "rate_limit",
+    "rate limit",
+    "duplicate_body",
+    "carrier_backoff",
+    "carrier_unavailable",
+)
+_TRANSIENT_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504})
+
+
+def sms_delivery_failure_policy(
+    error_code: str | None,
+    error_detail: str | None,
+) -> str:
+    """Classify an SMS failure as retry, stop, or conditional."""
+    code = str(error_code or "").strip().lower()
+    detail = str(error_detail or "").strip().lower()
+    combined = f"{code} {detail}"
+    if code in _TERMINAL_CODES or any(
+        marker in combined for marker in _TERMINAL_MARKERS
+    ):
+        return "stop"
+    if any(marker in combined for marker in _RETRY_MARKERS):
+        return "retry"
+    return "conditional"
+
+
+def sms_tool_failure_kind(error: Any) -> str:
+    """Classify one SDK/local SMS failure without returning sensitive detail."""
+    status = getattr(error, "status_code", None)
+    try:
+        status = int(status) if status is not None else None
+    except (TypeError, ValueError):
+        status = None
+
+    detail = getattr(error, "detail", None)
+    code = str(getattr(error, "error_code", "") or "").strip()
+    rule = ""
+    message = ""
+    if isinstance(detail, dict):
+        code = str(
+            detail.get("error")
+            or detail.get("error_code")
+            or detail.get("code")
+            or code
+        ).strip()
+        rule = str(detail.get("rule") or "").strip()
+        message = str(detail.get("message") or detail.get("reason") or "").strip()
+    elif detail is not None:
+        message = str(detail)
+
+    stable_code = f"{code} rule={rule}" if code and rule else (code or rule)
+    fallback = str(error or "")
+    policy = sms_delivery_failure_policy(stable_code, message or fallback)
+    if policy == "stop":
+        return "terminal"
+    if policy == "retry" or status in _TRANSIENT_STATUSES:
+        return "recoverable"
+    if status in {401, 403}:
+        return "terminal"
+    return "unknown"

--- a/inkbox_claude/doctor.py
+++ b/inkbox_claude/doctor.py
@@ -99,6 +99,28 @@ def run_doctor() -> List[Tuple[str, bool, str]]:
                 "imessage" if getattr(identity, "imessage_enabled", False) else None,
             ])) or "no channels provisioned"
             checks.append(("identity reachable", True, detail))
+            expected_action = (
+                "hosted_agent"
+                if cfg.voice_stack is VoiceStack.INKBOX_VOICE_AI
+                else "auto_accept"
+            )
+            try:
+                incoming = identity.get_incoming_call_action()
+                actual_action = str(
+                    getattr(
+                        getattr(incoming, "incoming_call_action", ""),
+                        "value",
+                        getattr(incoming, "incoming_call_action", ""),
+                    )
+                )
+            except Exception as exc:
+                checks.append(("incoming call action", False, str(exc)))
+            else:
+                checks.append((
+                    "incoming call action",
+                    actual_action == expected_action,
+                    f"{actual_action or 'unset'} (expected {expected_action})",
+                ))
             if cfg.voice_stack is VoiceStack.INKBOX_VOICE_AI:
                 try:
                     hosted = identity.get_hosted_agent_config()

--- a/inkbox_claude/doctor.py
+++ b/inkbox_claude/doctor.py
@@ -7,9 +7,9 @@ import shutil
 from typing import List, Tuple
 
 try:
-    from .config import inkbox_client_kwargs, read_config
+    from .config import VoiceStack, inkbox_client_kwargs, read_config
 except ImportError:  # pragma: no cover - direct local import/test fallback
-    from config import inkbox_client_kwargs, read_config
+    from config import VoiceStack, inkbox_client_kwargs, read_config
 
 
 def run_doctor() -> List[Tuple[str, bool, str]]:
@@ -37,12 +37,28 @@ def run_doctor() -> List[Tuple[str, bool, str]]:
         bool(cfg.signing_key) or not cfg.require_signature,
         "set" if cfg.signing_key else "missing (required for signed inbound webhooks)",
     ))
+    checks.append((
+        "phone voice stack",
+        not bool(cfg.voice_stack_invalid_value),
+        cfg.voice_stack_invalid_value or cfg.voice_stack.value,
+    ))
+    checks.append((
+        "voicemail detection",
+        cfg.voicemail_detection in {"enabled", "disabled"},
+        cfg.voicemail_detection,
+    ))
+    if cfg.voice_stack is VoiceStack.OPENAI_REALTIME:
+        checks.append((
+            "OpenAI Realtime key",
+            bool(cfg.realtime.api_key),
+            "set" if cfg.realtime.api_key else "missing",
+        ))
 
     try:
         import inkbox  # noqa: F401
         checks.append(("inkbox SDK", True, "installed"))
     except ImportError:
-        checks.append(("inkbox SDK", False, "pip install 'inkbox>=0.5.6,<1.0.0'"))
+        checks.append(("inkbox SDK", False, "pip install 'inkbox>=0.5.9,<1.0.0'"))
 
     try:
         import claude_agent_sdk  # noqa: F401
@@ -83,6 +99,24 @@ def run_doctor() -> List[Tuple[str, bool, str]]:
                 "imessage" if getattr(identity, "imessage_enabled", False) else None,
             ])) or "no channels provisioned"
             checks.append(("identity reachable", True, detail))
+            if cfg.voice_stack is VoiceStack.INKBOX_VOICE_AI:
+                try:
+                    hosted = identity.get_hosted_agent_config()
+                    remote = str(
+                        getattr(
+                            getattr(hosted, "authority_mode", ""),
+                            "value",
+                            getattr(hosted, "authority_mode", ""),
+                        )
+                        or "contact_scoped"
+                    )
+                    checks.append((
+                        "Voice AI authority",
+                        remote == cfg.voice_ai_authority_mode,
+                        remote,
+                    ))
+                except Exception as exc:
+                    checks.append(("Voice AI authority", False, str(exc)))
         except Exception as exc:
             checks.append(("identity reachable", False, str(exc)))
 

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -124,21 +124,35 @@ class _HostedToolSettlementError(RuntimeError):
 
 
 _TRANSCRIPT_POST_CALL_TIMING = (
-    r"(?:after|when|once)\s+(?:(?:we|you)\s+hang\s*up|"
+    r"(?:after|when|once)\s+(?:(?:i|we|you)\s+hang\s*up|"
     r"(?:this|the)\s+call\s+(?:ends?|is\s+over))"
 )
-_TRANSCRIPT_SMS_ACTION = (
-    r"(?:text\s+(?!messages?\b|history\b|thread\b|yesterday\b|earlier\b|from\b)"
-    r"[\w@][\w@.'’+-]*\b|"
-    r"send\b.{0,80}\b(?:an?\s+)?(?:sms|text\s+message)\b)"
+_TRANSCRIPT_TEXT_VERB = (
+    r"text\s+(?!conversation\b|messages?\b|history\b|thread\b|"
+    r"yesterday\b|earlier\b|from\b)[\w@][\w@.'’+-]*\b"
 )
+_TRANSCRIPT_TEXT_CLAUSE_PREFIX = (
+    r"(?:please\s+|then\s+|(?:(?:can|could|would|will)\s+you|"
+    r"(?:i|we)\s*(?:will|'ll|’ll|am\s+going\s+to|are\s+going\s+to))\s+)?"
+)
+_TRANSCRIPT_SEND_SMS = r"send\b.{0,80}\b(?:an?\s+)?(?:sms|text\s+message)\b"
 _TRANSCRIPT_SMS_COMMITMENT_PATTERNS = (
     re.compile(
-        rf"\b{_TRANSCRIPT_POST_CALL_TIMING}\b.{{0,160}}{_TRANSCRIPT_SMS_ACTION}",
+        rf"\b{_TRANSCRIPT_POST_CALL_TIMING}\b[\s,;:!—-]*"
+        rf"{_TRANSCRIPT_TEXT_CLAUSE_PREFIX}{_TRANSCRIPT_TEXT_VERB}",
         re.IGNORECASE,
     ),
     re.compile(
-        rf"\b{_TRANSCRIPT_SMS_ACTION}.{{0,160}}\b{_TRANSCRIPT_POST_CALL_TIMING}\b",
+        rf"(?:^|[.!?]\s+|\b{_TRANSCRIPT_TEXT_CLAUSE_PREFIX})"
+        rf"{_TRANSCRIPT_TEXT_VERB}.{{0,160}}\b{_TRANSCRIPT_POST_CALL_TIMING}\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\b{_TRANSCRIPT_POST_CALL_TIMING}\b.{{0,160}}{_TRANSCRIPT_SEND_SMS}",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\b{_TRANSCRIPT_SEND_SMS}.{{0,160}}\b{_TRANSCRIPT_POST_CALL_TIMING}\b",
         re.IGNORECASE,
     ),
 )

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -956,6 +956,7 @@ class InkboxGateway:
         )
         try:
             transcript: List[Tuple[str, str]] = []
+            transcript_fetch_failed = False
             try:
                 identity = await asyncio.to_thread(self._inkbox.get_identity, self.cfg.identity)
                 list_transcripts = getattr(identity, "list_transcripts", None)
@@ -970,6 +971,7 @@ class InkboxGateway:
                         if str(getattr(row, "text", "") or "").strip()
                     ]
             except Exception as exc:
+                transcript_fetch_failed = True
                 logger.warning(
                     "[bridge] full transcript unavailable for hosted call %s: %s; using webhook transcript",
                     call_id,
@@ -985,6 +987,10 @@ class InkboxGateway:
                     and "marker" not in row
                     and str(row.get("text") or "").strip()
                 ]
+                if transcript_fetch_failed and not isinstance(inline, dict):
+                    raise RuntimeError(
+                        "authoritative transcript unavailable for recovered hosted call"
+                    )
             contacts = data.get("contacts") if isinstance(data.get("contacts"), list) else []
             contact = contacts[0] if contacts and isinstance(contacts[0], dict) else {}
             remote = str(call.get("remote_phone_number") or "").strip()

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -58,6 +58,7 @@ except ImportError:  # pragma: no cover
     INKBOX_TUNNEL_AVAILABLE = False
 
 try:
+    from .a2a_delegations import find_by_task as find_a2a_delegation
     from .config import (
         DEFAULT_WEBHOOK_PATH,
         INKBOX_WS_PATH,
@@ -66,32 +67,110 @@ try:
         call_contexts_dir,
         inkbox_client_kwargs,
     )
-    from .a2a_delegations import find_by_task as find_a2a_delegation
+    from .delivery_policy import (
+        sms_delivery_failure_policy as _sms_delivery_failure_policy,
+    )
     from .media import download_media, inbound_media_note
-    from .prompts import contact_marker, contact_memories_block, frame_inbound, normalize_contact_memories, strip_markdown
+    from .prompts import (
+        contact_marker,
+        contact_memories_block,
+        frame_inbound,
+        normalize_contact_memories,
+        strip_markdown,
+    )
     from .realtime import (
         RealtimeBridgeConnectError,
         RealtimeCallMeta,
         open_inkbox_realtime_bridge,
     )
-    from .sessions import SessionManager
+    from .sessions import CapturedTurnResult, SessionManager
     from .tools import build_inkbox_mcp_server
     from .webhook_providers import match_provider
 except ImportError:  # pragma: no cover - direct local import/test fallback
-    from config import DEFAULT_WEBHOOK_PATH, INKBOX_WS_PATH, BridgeConfig, VoiceStack, call_contexts_dir, inkbox_client_kwargs
     from a2a_delegations import find_by_task as find_a2a_delegation
+    from config import (
+        DEFAULT_WEBHOOK_PATH,
+        INKBOX_WS_PATH,
+        BridgeConfig,
+        VoiceStack,
+        call_contexts_dir,
+        inkbox_client_kwargs,
+    )
+    from delivery_policy import (
+        sms_delivery_failure_policy as _sms_delivery_failure_policy,
+    )
     from media import download_media, inbound_media_note
-    from prompts import contact_marker, contact_memories_block, frame_inbound, normalize_contact_memories, strip_markdown
+    from prompts import (
+        contact_marker,
+        contact_memories_block,
+        frame_inbound,
+        normalize_contact_memories,
+        strip_markdown,
+    )
     from realtime import (
         RealtimeBridgeConnectError,
         RealtimeCallMeta,
         open_inkbox_realtime_bridge,
     )
-    from sessions import SessionManager
+    from sessions import CapturedTurnResult, SessionManager
     from tools import build_inkbox_mcp_server
     from webhook_providers import match_provider
 
 logger = logging.getLogger(__name__)
+
+
+class _HostedToolSettlementError(RuntimeError):
+    """A required hosted-call side effect reached a bounded terminal state."""
+
+
+def _hosted_requires_sms(actions: List[Dict[str, Any]]) -> bool:
+    """Return true when an open server-recorded action explicitly requires SMS."""
+    text = " ".join(
+        str(action.get(field) or "")
+        for action in actions
+        if str(action.get("status") or "open").strip().lower() == "open"
+        for field in ("action", "description", "details")
+    ).lower()
+    return bool(re.search(r"\b(?:sms|text|texted|texting)\b", text))
+
+
+def _hosted_sms_settlement(
+    result: CapturedTurnResult,
+    remote_phone: str,
+) -> str:
+    """Classify a required host-native SMS side effect."""
+    if result.aborted:
+        return "aborted"
+    attempts = [item for item in result.tool_deliveries if item.mode == "sms"]
+    if not attempts:
+        return "missing"
+    if len(attempts) != 1:
+        return "terminal"
+    attempt = attempts[0]
+    if attempt.sent:
+        if attempt.target != remote_phone:
+            return "terminal"
+        return "success"
+    if attempt.error_kind == "recoverable":
+        return "recoverable"
+    return "terminal"
+
+
+def _hosted_sms_correction_prompt(remote_phone: str, *, missing: bool) -> str:
+    reason = (
+        "The required SMS tool was not called"
+        if missing
+        else "The required SMS tool had a recoverable argument or format error"
+    )
+    return "\n".join([
+        "[hosted_post_call_sms_correction]",
+        f"{reason}. This is the only correction attempt.",
+        "Call inkbox_send_sms exactly once now with `to` set to the exact "
+        f"authoritative remote number {remote_phone} and `text` set to the "
+        "still-needed message from the prior hosted-call reconciliation.",
+        "Do not use another recipient, do not repeat any completed action, and "
+        "do not answer with prose. Stop after the tool result.",
+    ])
 
 
 def _webhook_mail_body(message: Dict[str, Any]) -> str:
@@ -191,66 +270,6 @@ _DELIVERY_FAILURE_CHANNEL_GUIDANCE: Dict[str, str] = {
         "deliver."
     ),
 }
-
-_DELIVERY_FAILURE_TERMINAL_CODES = frozenset({
-    "recipient_not_opted_in",
-    "recipient_opted_out",
-    "recipient_blocked",
-    "invalid_phone_number",
-    "carrier_rejected",
-    "sender_sms_pending",
-    "sender_sms_assignment_failed",
-    "sender_not_registered",
-    "sender_registration_required",
-    "messaging_profile_disabled",
-    "toll_free_sms_unsupported",
-})
-_DELIVERY_FAILURE_TERMINAL_MARKERS = (
-    "opted out",
-    "opt-out",
-    "not opted in",
-    "invalid number",
-    "invalid phone",
-    "unreachable",
-    "unknown subscriber",
-    "cannot receive",
-    "unsafe",
-    "harmful",
-    "abusive",
-    "harassment",
-    "threatening",
-    "illegal content",
-)
-_DELIVERY_FAILURE_RETRY_MARKERS = (
-    "40002",
-    "spam",
-    "content",
-    "too_long",
-    "too long",
-    "markdown",
-    "emoji",
-    "profanity",
-    "temporar",
-    "carrier_unavailable",
-)
-
-
-def _sms_delivery_failure_policy(
-    error_code: Optional[str],
-    error_detail: Optional[str],
-) -> str:
-    """Classify whether an SMS failure requires retry, stop, or judgment."""
-    code = str(error_code or "").strip().lower()
-    detail = str(error_detail or "").strip().lower()
-    combined = f"{code} {detail}"
-    if code in _DELIVERY_FAILURE_TERMINAL_CODES or any(
-        marker in combined for marker in _DELIVERY_FAILURE_TERMINAL_MARKERS
-    ):
-        return "stop"
-    if any(marker in combined for marker in _DELIVERY_FAILURE_RETRY_MARKERS):
-        return "retry"
-    return "conditional"
-
 
 def _delivery_failure_reply_instruction(
     *,
@@ -863,6 +882,7 @@ class InkboxGateway:
         state: str,
         payload: Optional[Dict[str, Any]] = None,
         outcome: str = "",
+        retryable: bool = True,
     ) -> None:
         """Atomically persist completion work before acknowledging a webhook."""
         now = time.time()
@@ -889,6 +909,8 @@ class InkboxGateway:
             "owner_id": self._hosted_call_registry_owner,
             "updated_at": now,
         }
+        if state == "failed":
+            entry["retryable"] = retryable
         # Only unfinished/retryable work needs replay data. Completed receipts
         # retain dedupe metadata but immediately discard call content.
         if state in {"queued", "running", "failed"} and replay_payload is not None:
@@ -1005,6 +1027,8 @@ class InkboxGateway:
         for call_id, entry in self._read_hosted_call_registry().items():
             if not isinstance(entry, dict) or entry.get("state") == "completed":
                 continue
+            if entry.get("state") == "failed" and entry.get("retryable") is False:
+                continue
             payload = entry.get("payload")
             if not isinstance(payload, dict) or call_id in self._hosted_call_jobs:
                 continue
@@ -1034,7 +1058,12 @@ class InkboxGateway:
             and state in {"queued", "running"}
             and existing.get("owner_id") == self._hosted_call_registry_owner
         )
-        if state == "completed" or current_inflight:
+        terminal_failure = (
+            state == "failed"
+            and isinstance(existing, dict)
+            and existing.get("retryable") is False
+        )
+        if state == "completed" or terminal_failure or current_inflight:
             return web.json_response({"ok": True, "deduped": True})
         event_id = str(envelope.get("id") or "").strip()
         self._write_hosted_call_registry(
@@ -1103,7 +1132,8 @@ class InkboxGateway:
             chat_id = str(contact.get("id") or remote or f"call:{call_id}")
             actions = [
                 item for item in (data.get("post_call_action_items") or [])
-                if isinstance(item, dict) and str(item.get("status") or "open") == "open"
+                if isinstance(item, dict)
+                and str(item.get("status") or "open").strip().lower() == "open"
             ]
             lines = [
                 f"[inkbox:voice_call call_id={call_id}]",
@@ -1136,10 +1166,12 @@ class InkboxGateway:
                 lines.append("  (no transcript captured)")
             if actions:
                 lines.extend(["", "Open post-call actions:"])
-                lines.extend(
-                    f"  - {item.get('action') or item.get('description') or item}"
-                    for item in actions
-                )
+                for item in actions:
+                    label = str(
+                        item.get("action") or item.get("description") or item
+                    ).strip()
+                    details = str(item.get("details") or "").strip()
+                    lines.append(f"  - {label}" + (f" — {details}" if details else ""))
             lines.extend([
                 "",
                 "Review the outcome, transcript, and open actions once. Use tools "
@@ -1155,16 +1187,42 @@ class InkboxGateway:
             ])
             if self.sessions is None:
                 raise RuntimeError("session manager is not ready")
-            await self.sessions.get(chat_id).run_consult("\n".join(lines))
+            session = self.sessions.get(chat_id)
+            prompt = "\n".join(lines)
+            if remote and _hosted_requires_sms(actions):
+                result = await session.run_consult_detailed(prompt)
+                settlement = _hosted_sms_settlement(result, remote)
+                if settlement in {"missing", "recoverable"}:
+                    correction = _hosted_sms_correction_prompt(
+                        remote,
+                        missing=settlement == "missing",
+                    )
+                    corrected = await session.run_consult_detailed(correction)
+                    settlement = _hosted_sms_settlement(corrected, remote)
+                if settlement != "success":
+                    raise _HostedToolSettlementError(
+                        "required hosted SMS did not reach a confirmed safe completion"
+                    )
+                logger.info(
+                    "[bridge] confirmed hosted call SMS tool completion call_id=%s",
+                    call_id,
+                )
+            else:
+                await session.run_consult(prompt)
             self._write_hosted_call_registry(
                 call_id, event_id=event_id, state="completed", outcome=outcome
             )
             logger.info("[bridge] completed hosted call completion call_id=%s", call_id)
         except asyncio.CancelledError:
             raise
-        except Exception:
+        except Exception as exc:
             self._write_hosted_call_registry(
-                call_id, event_id=event_id, state="failed", payload=envelope, outcome=outcome
+                call_id,
+                event_id=event_id,
+                state="failed",
+                payload=envelope,
+                outcome=outcome,
+                retryable=not isinstance(exc, _HostedToolSettlementError),
             )
             logger.exception("[bridge] hosted call completion failed call_id=%s", call_id)
 

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -794,8 +794,22 @@ class InkboxGateway:
             raise RuntimeError(
                 f"invalid INKBOX_VOICE_STACK={self.cfg.voice_stack_invalid_value!r}; rerun setup"
             )
+        if (
+            self.cfg.voice_stack is VoiceStack.OPENAI_REALTIME
+            and not self.cfg.realtime.enabled
+        ):
+            raise RuntimeError(
+                "INKBOX_VOICE_STACK=openai_realtime requires INKBOX_REALTIME_API_KEY"
+            )
         if self.cfg.voicemail_detection not in {"enabled", "disabled"}:
             raise RuntimeError("INKBOX_VOICEMAIL_DETECTION must be enabled or disabled")
+        if (
+            self.cfg.voice_stack is VoiceStack.INKBOX_VOICE_AI
+            and self.cfg.voice_ai_authority_mode not in {"contact_scoped", "yolo"}
+        ):
+            raise RuntimeError(
+                "INKBOX_VOICE_AI_AUTHORITY_MODE must be contact_scoped or yolo"
+            )
         if not self.cfg.api_key or not self.cfg.identity:
             raise RuntimeError("INKBOX_API_KEY and INKBOX_IDENTITY must be set (see README)")
 

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -123,15 +123,70 @@ class _HostedToolSettlementError(RuntimeError):
     """A required hosted-call side effect reached a bounded terminal state."""
 
 
-def _hosted_requires_sms(actions: List[Dict[str, Any]]) -> bool:
-    """Return true when an open server-recorded action explicitly requires SMS."""
+_TRANSCRIPT_SMS_COMMITMENT_PATTERNS = (
+    # Direct text requests: "text me" / "could you text her".  Bare "send
+    # me" is channel-ambiguous and must not force an SMS side effect.
+    re.compile(r"\btext\s+(?:me|us|them|him|her)\b", re.IGNORECASE),
+    # A clear imperative/request may use a named recipient rather than a
+    # pronoun: "Text Alex" / "please text Dima" / "could you text Pat".
+    re.compile(
+        r"(?:^|[.!?]\s+|\b(?:please|can\s+you|could\s+you|would\s+you|will\s+you)\s+)"
+        r"text\s+(?!messages?\b|history\b|thread\b)[\w@][\w@.'’+-]*\b",
+        re.IGNORECASE,
+    ),
+    # Explicit channel requests that name the medium even when the recipient
+    # is a proper noun: "send Alex an SMS" / "send a text message".
+    re.compile(
+        r"\bsend\b.{0,80}\b(?:an?\s+)?(?:sms|text\s+message)\b",
+        re.IGNORECASE,
+    ),
+    # A bounded after-call promise/request.  Bare "send" is not enough: it
+    # must identify the SMS/text-message medium inside the same turn.
+    re.compile(
+        r"\b(?:after|once|when)\s+(?:we\s+|you\s+)?"
+        r"(?:hang\s*up|the\s+call\s+(?:ends?|is\s+over))\b.{0,160}"
+        r"(?:\btext\b|\bsend\b.{0,80}\b(?:sms|text\s+message))",
+        re.IGNORECASE,
+    ),
+    # The hosted agent's own unambiguous future commitment.
+    re.compile(
+        r"\b(?:i|we)\s*(?:will|'ll|’ll|am\s+going\s+to|are\s+going\s+to)\s+"
+        r"(?:text\s+(?:you|me|us|them|him|her)\b|"
+        r"send\b.{0,80}\b(?:sms|text\s+message)\b)",
+        re.IGNORECASE,
+    ),
+)
+
+
+def _transcript_requires_sms_commitment(transcript: Any) -> bool:
+    """Detect a clear future SMS commitment without matching past references."""
+    turns = []
+    for row in transcript or []:
+        if isinstance(row, dict):
+            value = row.get("text")
+        elif isinstance(row, (tuple, list)) and len(row) > 1:
+            value = row[1]
+        else:
+            value = getattr(row, "text", "")
+        text = str(value or "").strip()
+        if text:
+            turns.append(text)
+    return any(pattern.search(turn) for turn in turns for pattern in _TRANSCRIPT_SMS_COMMITMENT_PATTERNS)
+
+
+def _hosted_requires_sms(
+    actions: List[Dict[str, Any]], transcript: Any = None,
+) -> bool:
+    """Return true for an open SMS action or explicit transcript commitment."""
     text = " ".join(
         str(action.get(field) or "")
         for action in actions
         if str(action.get("status") or "open").strip().lower() == "open"
         for field in ("action", "description", "details")
     ).lower()
-    return bool(re.search(r"\b(?:sms|text|texted|texting)\b", text))
+    return bool(re.search(r"\b(?:sms|text|texted|texting)\b", text)) or (
+        _transcript_requires_sms_commitment(transcript)
+    )
 
 
 def _hosted_sms_settlement(
@@ -1189,7 +1244,7 @@ class InkboxGateway:
                 raise RuntimeError("session manager is not ready")
             session = self.sessions.get(chat_id)
             prompt = "\n".join(lines)
-            if remote and _hosted_requires_sms(actions):
+            if remote and _hosted_requires_sms(actions, transcript):
                 result = await session.run_consult_detailed(prompt)
                 settlement = _hosted_sms_settlement(result, remote)
                 if settlement in {"missing", "recoverable"}:

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -755,7 +755,7 @@ class InkboxGateway:
         *,
         event_id: str,
         state: str,
-        payload: Dict[str, Any],
+        payload: Optional[Dict[str, Any]] = None,
         outcome: str = "",
     ) -> None:
         """Atomically persist completion work before acknowledging a webhook."""
@@ -766,14 +766,28 @@ class InkboxGateway:
             if isinstance(value, dict)
             and now - float(value.get("updated_at") or 0) < 30 * 24 * 60 * 60
         }
-        current[call_id] = {
+        previous = current.get(call_id)
+        replay_payload = (
+            self._hosted_call_replay_payload(payload)
+            if payload is not None
+            else (
+                previous.get("payload")
+                if isinstance(previous, dict)
+                else None
+            )
+        )
+        entry = {
             "event_id": event_id,
             "state": state,
             "outcome": outcome,
             "owner_id": self._hosted_call_registry_owner,
-            "payload": payload,
             "updated_at": now,
         }
+        # Only unfinished/retryable work needs replay data. Completed receipts
+        # retain dedupe metadata but immediately discard call content.
+        if state in {"queued", "running", "failed"} and replay_payload is not None:
+            entry["payload"] = replay_payload
+        current[call_id] = entry
         if len(current) > 1_000:
             current = dict(sorted(
                 current.items(),
@@ -785,6 +799,87 @@ class InkboxGateway:
         tmp.chmod(0o600)
         os.replace(tmp, self._hosted_call_registry_path)
         self._hosted_call_registry_path.chmod(0o600)
+
+    @staticmethod
+    def _hosted_call_replay_payload(
+        payload: Optional[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        """Keep only bounded fields required to retry post-call work.
+
+        The authenticated event can include a transcript and contact memories.
+        Recovery fetches the authoritative transcript from Inkbox, so neither
+        belongs in the durable receipt. Open actions remain because they are
+        the work the recovered Claude turn must reconcile.
+        """
+        if not isinstance(payload, dict):
+            return None
+        data = payload.get("data")
+        call = data.get("call") if isinstance(data, dict) else None
+        if not isinstance(call, dict):
+            return None
+
+        def bounded(value: Any, limit: int) -> str:
+            return str(value or "")[:limit]
+
+        call_snapshot = {
+            key: bounded(call.get(key), limit)
+            for key, limit in (
+                ("id", 128),
+                ("mode", 64),
+                ("direction", 32),
+                ("status", 64),
+                ("hangup_reason", 512),
+                ("remote_phone_number", 128),
+                ("reason", 4_000),
+            )
+            if call.get(key) is not None
+        }
+        contacts = data.get("contacts") if isinstance(data, dict) else None
+        contact_snapshot: List[Dict[str, str]] = []
+        if isinstance(contacts, list) and contacts and isinstance(contacts[0], dict):
+            contact = contacts[0]
+            contact_snapshot.append({
+                key: bounded(contact.get(key), limit)
+                for key, limit in (
+                    ("id", 128),
+                    ("name", 1_000),
+                    ("preferred_name", 1_000),
+                )
+                if contact.get(key) is not None
+            })
+
+        action_snapshot: List[Dict[str, str]] = []
+        raw_actions = (
+            data.get("post_call_action_items")
+            if isinstance(data, dict)
+            else None
+        )
+        for action in raw_actions[:100] if isinstance(raw_actions, list) else []:
+            if not isinstance(action, dict):
+                continue
+            action_snapshot.append({
+                key: bounded(action.get(key), limit)
+                for key, limit in (
+                    ("id", 128),
+                    ("seq", 32),
+                    ("action", 4_000),
+                    ("description", 4_000),
+                    ("details", 8_000),
+                    ("status", 64),
+                )
+                if action.get(key) is not None
+            })
+
+        return {
+            "id": bounded(payload.get("id"), 128),
+            "event_type": "call.ended",
+            "data": {
+                "call": call_snapshot,
+                "contacts": contact_snapshot,
+                "outcome": bounded(data.get("outcome"), 128),
+                "post_call_action_items": action_snapshot,
+            },
+        }
 
     def _schedule_hosted_call_completion(
         self,
@@ -943,7 +1038,7 @@ class InkboxGateway:
                 raise RuntimeError("session manager is not ready")
             await self.sessions.get(chat_id).run_consult("\n".join(lines))
             self._write_hosted_call_registry(
-                call_id, event_id=event_id, state="completed", payload=envelope, outcome=outcome
+                call_id, event_id=event_id, state="completed", outcome=outcome
             )
             logger.info("[bridge] completed hosted call completion call_id=%s", call_id)
         except asyncio.CancelledError:

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -133,13 +133,13 @@ _TRANSCRIPT_TEXT_VERB = (
 )
 _TRANSCRIPT_TEXT_CLAUSE_PREFIX = (
     r"(?:please\s+|then\s+|(?:(?:can|could|would|will)\s+you|"
-    r"(?:i|we)\s*(?:will|'ll|’ll|am\s+going\s+to|are\s+going\s+to))\s+)?"
+    r"(?:i|we)\s*(?:will|'ll|’ll|am\s+going\s+to|are\s+going\s+to))\s+)"
 )
 _TRANSCRIPT_SEND_SMS = r"send\b.{0,80}\b(?:an?\s+)?(?:sms|text\s+message)\b"
 _TRANSCRIPT_SMS_COMMITMENT_PATTERNS = (
     re.compile(
         rf"\b{_TRANSCRIPT_POST_CALL_TIMING}\b[\s,;:!—-]*"
-        rf"{_TRANSCRIPT_TEXT_CLAUSE_PREFIX}{_TRANSCRIPT_TEXT_VERB}",
+        rf"(?:{_TRANSCRIPT_TEXT_CLAUSE_PREFIX})?{_TRANSCRIPT_TEXT_VERB}",
         re.IGNORECASE,
     ),
     re.compile(

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -1125,6 +1125,8 @@ class InkboxGateway:
                     f"Remote party phone number: {remote}",
                     "For callbacks or phone follow-up, use that exact number. "
                     "Contact memories are background only and must not override it.",
+                    "For an SMS follow-up, call inkbox_send_sms with `to` set to "
+                    "that exact remote number and `text` set to the requested message.",
                 ])
             if reason:
                 lines.append(f"Outbound task: {reason}")
@@ -1143,6 +1145,9 @@ class InkboxGateway:
                 "Review the outcome, transcript, and open actions once. Use tools "
                 "to execute every still-needed commitment; do not repeat completed, "
                 "canceled, superseded, or already-performed work.",
+                "Do not finish until each required tool reports success. If a tool "
+                "rejects a recoverable argument or format mistake, correct it and "
+                "try once more.",
                 "If nothing remains, do nothing. Plain text from this turn is "
                 "suppressed because the call has ended; side effects require tools.",
             ])

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -71,6 +71,7 @@ try:
         sms_delivery_failure_policy as _sms_delivery_failure_policy,
     )
     from .media import download_media, inbound_media_note
+    from .hosted_sms_guard import hosted_sms_attempt_state
     from .prompts import (
         contact_marker,
         contact_memories_block,
@@ -100,6 +101,7 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
         sms_delivery_failure_policy as _sms_delivery_failure_policy,
     )
     from media import download_media, inbound_media_note
+    from hosted_sms_guard import hosted_sms_attempt_state
     from prompts import (
         contact_marker,
         contact_memories_block,
@@ -129,7 +131,7 @@ _TRANSCRIPT_POST_CALL_TIMING = (
 )
 _TRANSCRIPT_TEXT_VERB = (
     r"text\s+(?!conversation\b|messages?\b|history\b|thread\b|"
-    r"yesterday\b|earlier\b|from\b)[\w@][\w@.'’+-]*\b"
+    r"exchange\b|yesterday\b|earlier\b|from\b)[\w@][\w@.'’+-]*\b"
 )
 _TRANSCRIPT_TEXT_CLAUSE_PREFIX = (
     r"(?:please\s+|then\s+|(?:(?:can|could|would|will)\s+you|"
@@ -160,6 +162,10 @@ _TRANSCRIPT_SMS_COMMITMENT_PATTERNS = (
         rf"\b{_TRANSCRIPT_SEND_SMS}.{{0,160}}\b{_TRANSCRIPT_POST_CALL_TIMING}\b",
         re.IGNORECASE,
     ),
+)
+_OPEN_ACTION_SMS_COMMITMENT_PATTERNS = (
+    re.compile(rf"\b{_TRANSCRIPT_TEXT_VERB}", re.IGNORECASE),
+    re.compile(rf"\b{_TRANSCRIPT_SEND_SMS}", re.IGNORECASE),
 )
 
 
@@ -197,8 +203,11 @@ def _hosted_requires_sms(
         if str(action.get("status") or "open").strip().lower() == "open"
     )
     action_requires_sms = any(
-        re.search(r"\b(?:sms|text|texted|texting)\b", text, re.IGNORECASE)
-        and not _TRANSCRIPT_NEGATED_SMS_ACTION.search(text)
+        not _TRANSCRIPT_NEGATED_SMS_ACTION.search(text)
+        and any(
+            pattern.search(text)
+            for pattern in _OPEN_ACTION_SMS_COMMITMENT_PATTERNS
+        )
         for text in open_action_texts
     )
     return action_requires_sms or _transcript_requires_sms_commitment(transcript)
@@ -1099,6 +1108,24 @@ class InkboxGateway:
                 continue
             if entry.get("state") == "failed" and entry.get("retryable") is False:
                 continue
+            if any(
+                hosted_sms_attempt_state(str(call_id), attempt) is not None
+                for attempt in (1, 2)
+            ):
+                self._write_hosted_call_registry(
+                    str(call_id),
+                    event_id=str(entry.get("event_id") or ""),
+                    state="failed",
+                    payload=entry.get("payload"),
+                    outcome=str(entry.get("outcome") or ""),
+                    retryable=False,
+                )
+                logger.warning(
+                    "[bridge] hosted SMS attempt was commit-ambiguous after restart; "
+                    "replay blocked call_id=%s",
+                    call_id,
+                )
+                continue
             payload = entry.get("payload")
             if not isinstance(payload, dict) or call_id in self._hosted_call_jobs:
                 continue
@@ -1265,14 +1292,28 @@ class InkboxGateway:
                 # commit-ambiguous: the host may have completed a send before
                 # the model/transport failed to return the detailed result.
                 required_sms_turn_started = True
-                result = await session.run_consult_detailed(prompt)
+                result = await session.run_consult_detailed(
+                    prompt,
+                    hosted_sms_context={
+                        "call_id": call_id,
+                        "attempt": 1,
+                        "remote_phone": remote,
+                    },
+                )
                 settlement = _hosted_sms_settlement(result, remote)
                 if settlement in {"missing", "recoverable"}:
                     correction = _hosted_sms_correction_prompt(
                         remote,
                         missing=settlement == "missing",
                     )
-                    corrected = await session.run_consult_detailed(correction)
+                    corrected = await session.run_consult_detailed(
+                        correction,
+                        hosted_sms_context={
+                            "call_id": call_id,
+                            "attempt": 2,
+                            "remote_phone": remote,
+                        },
+                    )
                     settlement = _hosted_sms_settlement(corrected, remote)
                 if settlement != "success":
                     raise _HostedToolSettlementError(

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -233,22 +233,67 @@ def _hosted_sms_settlement(
     return "terminal"
 
 
-def _hosted_sms_correction_prompt(remote_phone: str, *, missing: bool) -> str:
+def _hosted_sms_recovery_evidence(transcript: Any, actions: Any) -> str:
+    """Render only trusted SMS commitments needed by a fresh recovery session."""
+    lines: List[str] = []
+    for row in transcript or []:
+        if isinstance(row, dict):
+            role, text = row.get("party"), row.get("text")
+        elif isinstance(row, (tuple, list)) and len(row) > 1:
+            role, text = row[0], row[1]
+        else:
+            role, text = getattr(row, "party", "unknown"), getattr(row, "text", "")
+        text = str(text or "").strip()
+        if text and _clause_requires_sms(text, _TRANSCRIPT_SMS_COMMITMENT_PATTERNS):
+            lines.append(f"Transcript SMS commitment ({role or 'unknown'}): {text}")
+    for action in actions or []:
+        if not isinstance(action, dict):
+            continue
+        if str(action.get("status") or "open").strip().lower() != "open":
+            continue
+        text = " ".join(
+            str(action.get(field) or "")
+            for field in ("action", "description", "details")
+        ).strip()
+        if text and _clause_requires_sms(text, _OPEN_ACTION_SMS_COMMITMENT_PATTERNS):
+            lines.append(f"Open SMS action: {text}")
+    return "\n".join(lines)
+
+
+def _hosted_sms_correction_prompt(
+    remote_phone: str,
+    *,
+    missing: bool,
+    evidence: str = "",
+) -> str:
     reason = (
         "The required SMS tool was not called"
         if missing
         else "The required SMS tool had a recoverable argument or format error"
     )
-    return "\n".join([
+    lines = [
         "[hosted_post_call_sms_correction]",
         f"{reason}. This is the only correction attempt.",
+    ]
+    if evidence:
+        lines.extend([
+            "Trusted SMS-only recovery context:",
+            evidence,
+        ])
+    message_source = (
+        "the trusted SMS context above"
+        if evidence
+        else "the prior hosted-call reconciliation"
+    )
+    lines.extend([
         "Call inkbox_send_sms exactly once now with `to` set to the exact "
         f"authoritative remote number {remote_phone} and `text` set to the "
-        "still-needed message from the prior hosted-call reconciliation.",
+        f"still-needed message in {message_source}.",
         "Do not use another recipient, do not repeat any completed action, and "
         "do not answer with prose. Do not return [SILENT], skip, or defer. "
         "Stop after the tool result.",
     ])
+    return "\n".join(lines)
 
 
 def _webhook_mail_body(message: Dict[str, Any]) -> str:
@@ -1141,9 +1186,38 @@ class InkboxGateway:
             contact = contacts[0] if contacts and isinstance(contacts[0], dict) else {}
             if not remote or self.sessions is None:
                 raise _HostedToolSettlementError("hosted SMS correction context is unavailable")
+            transcript: List[Tuple[str, str]] = []
+            try:
+                identity = await asyncio.to_thread(
+                    self._inkbox.get_identity, self.cfg.identity
+                )
+                rows = await asyncio.to_thread(identity.list_transcripts, call_id)
+                transcript = [
+                    (
+                        str(getattr(row, "party", "unknown") or "unknown"),
+                        str(getattr(row, "text", "") or ""),
+                    )
+                    for row in (rows or [])
+                ]
+            except Exception:
+                logger.warning(
+                    "[bridge] hosted SMS recovery transcript unavailable: %s",
+                    call_id,
+                    exc_info=True,
+                )
+            actions = data.get("post_call_action_items") or []
+            evidence = _hosted_sms_recovery_evidence(transcript, actions)
+            if not evidence:
+                raise _HostedToolSettlementError(
+                    "hosted SMS correction lacks authoritative SMS context"
+                )
             session = self.sessions.get(str(contact.get("id") or remote))
             corrected = await session.run_consult_detailed(
-                _hosted_sms_correction_prompt(remote, missing=False),
+                _hosted_sms_correction_prompt(
+                    remote,
+                    missing=False,
+                    evidence=evidence,
+                ),
                 hosted_sms_context={
                     "call_id": call_id,
                     "attempt": 2,

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -29,6 +29,7 @@ import re
 import shutil
 import threading
 import time
+import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -61,12 +62,13 @@ try:
         DEFAULT_WEBHOOK_PATH,
         INKBOX_WS_PATH,
         BridgeConfig,
+        VoiceStack,
         call_contexts_dir,
         inkbox_client_kwargs,
     )
     from .a2a_delegations import find_by_task as find_a2a_delegation
     from .media import download_media, inbound_media_note
-    from .prompts import contact_marker, frame_inbound, normalize_contact_memories, strip_markdown
+    from .prompts import contact_marker, contact_memories_block, frame_inbound, normalize_contact_memories, strip_markdown
     from .realtime import (
         RealtimeBridgeConnectError,
         RealtimeCallMeta,
@@ -76,10 +78,10 @@ try:
     from .tools import build_inkbox_mcp_server
     from .webhook_providers import match_provider
 except ImportError:  # pragma: no cover - direct local import/test fallback
-    from config import DEFAULT_WEBHOOK_PATH, INKBOX_WS_PATH, BridgeConfig, call_contexts_dir, inkbox_client_kwargs
+    from config import DEFAULT_WEBHOOK_PATH, INKBOX_WS_PATH, BridgeConfig, VoiceStack, call_contexts_dir, inkbox_client_kwargs
     from a2a_delegations import find_by_task as find_a2a_delegation
     from media import download_media, inbound_media_note
-    from prompts import contact_marker, frame_inbound, normalize_contact_memories, strip_markdown
+    from prompts import contact_marker, contact_memories_block, frame_inbound, normalize_contact_memories, strip_markdown
     from realtime import (
         RealtimeBridgeConnectError,
         RealtimeCallMeta,
@@ -417,6 +419,7 @@ A2A_EVENTS = [
     "a2a.task.canceled",
     "a2a.sent_task.updated",
 ]
+CALL_EVENTS = ["call.ended"]
 A2A_TERMINAL_STATES = {"completed", "failed", "canceled", "rejected"}
 
 
@@ -519,6 +522,11 @@ class InkboxGateway:
             Path.home() / ".inkbox-claude" / "a2a_tasks.json"
         )
         self._a2a_jobs: Dict[str, set[asyncio.Task[Any]]] = {}
+        state_root = Path(os.getenv("INKBOX_CLAUDE_HOME") or (Path.home() / ".inkbox-claude"))
+        state_root.mkdir(parents=True, exist_ok=True)
+        self._hosted_call_registry_path = state_root / "hosted_call_completions.json"
+        self._hosted_call_registry_owner = uuid.uuid4().hex
+        self._hosted_call_jobs: Dict[str, asyncio.Task[Any]] = {}
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -533,7 +541,13 @@ class InkboxGateway:
         if not AIOHTTP_AVAILABLE:
             raise RuntimeError("aiohttp is not installed; run: pip install aiohttp")
         if not INKBOX_AVAILABLE:
-            raise RuntimeError("inkbox SDK is not installed; run: pip install 'inkbox>=0.5.6,<1.0.0'")
+            raise RuntimeError("inkbox SDK is not installed; run: pip install 'inkbox>=0.5.9,<1.0.0'")
+        if self.cfg.voice_stack_invalid_value:
+            raise RuntimeError(
+                f"invalid INKBOX_VOICE_STACK={self.cfg.voice_stack_invalid_value!r}; rerun setup"
+            )
+        if self.cfg.voicemail_detection not in {"enabled", "disabled"}:
+            raise RuntimeError("INKBOX_VOICEMAIL_DETECTION must be enabled or disabled")
         if not self.cfg.api_key or not self.cfg.identity:
             raise RuntimeError("INKBOX_API_KEY and INKBOX_IDENTITY must be set (see README)")
 
@@ -562,7 +576,7 @@ class InkboxGateway:
         await asyncio.to_thread(self._patch_identity_objects)
 
         # Sessions get the Inkbox tools so Claude can message proactively.
-        server, tool_names = build_inkbox_mcp_server(self._inkbox, self.cfg.identity)
+        server, tool_names = build_inkbox_mcp_server(self._inkbox, self.cfg.identity, self.cfg)
         self.sessions = SessionManager(
             cfg=self.cfg,
             send_fn=self.send_to_contact,
@@ -574,6 +588,7 @@ class InkboxGateway:
             health_fn=self.health_report,
         )
         await self._catch_up_a2a_tasks()
+        await self._recover_hosted_call_completions()
 
         logger.info(
             "[bridge] ready — %s / %s / %s → Claude Code in %s",
@@ -682,11 +697,18 @@ class InkboxGateway:
         )
         if can_receive_calls:
             if hasattr(identity, "set_incoming_call_action"):
-                identity.set_incoming_call_action(
-                    incoming_call_action="auto_accept",
-                    client_websocket_url=ws_url,
-                    incoming_call_webhook_url=webhook_url,
-                )
+                if self.cfg.voice_stack is VoiceStack.INKBOX_VOICE_AI:
+                    identity.set_incoming_call_action(
+                        incoming_call_action="hosted_agent",
+                        client_websocket_url=None,
+                        incoming_call_webhook_url=None,
+                    )
+                else:
+                    identity.set_incoming_call_action(
+                        incoming_call_action="auto_accept",
+                        client_websocket_url=ws_url,
+                        incoming_call_webhook_url=webhook_url,
+                    )
             elif identity.phone_number is not None:
                 # Legacy SDKs (<0.4.15) only expose the number-scoped shim,
                 # which cannot configure a shared-iMessage-only identity.
@@ -712,11 +734,232 @@ class InkboxGateway:
                 "[bridge] Inkbox API does not support A2A webhook events yet; "
                 "continuing without A2A delivery until the backend is upgraded"
             )
+        _reconcile({"agent_identity_id": identity.id}, CALL_EVENTS)
         if getattr(identity, "imessage_enabled", False):
             _reconcile({"agent_identity_id": identity.id}, IMESSAGE_EVENTS)
         logger.info("[bridge] identity events for %s → %s", self.cfg.identity, webhook_url)
 
+    def _read_hosted_call_registry(self) -> Dict[str, Any]:
+        if not self._hosted_call_registry_path.exists():
+            return {}
+        try:
+            loaded = json.loads(self._hosted_call_registry_path.read_text())
+        except Exception:
+            logger.exception("[bridge] hosted-call completion registry is unreadable")
+            return {}
+        return loaded if isinstance(loaded, dict) else {}
+
+    def _write_hosted_call_registry(
+        self,
+        call_id: str,
+        *,
+        event_id: str,
+        state: str,
+        payload: Dict[str, Any],
+        outcome: str = "",
+    ) -> None:
+        """Atomically persist completion work before acknowledging a webhook."""
+        now = time.time()
+        current = {
+            key: value
+            for key, value in self._read_hosted_call_registry().items()
+            if isinstance(value, dict)
+            and now - float(value.get("updated_at") or 0) < 30 * 24 * 60 * 60
+        }
+        current[call_id] = {
+            "event_id": event_id,
+            "state": state,
+            "outcome": outcome,
+            "owner_id": self._hosted_call_registry_owner,
+            "payload": payload,
+            "updated_at": now,
+        }
+        if len(current) > 1_000:
+            current = dict(sorted(
+                current.items(),
+                key=lambda item: float(item[1].get("updated_at") or 0),
+                reverse=True,
+            )[:1_000])
+        tmp = self._hosted_call_registry_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n")
+        tmp.chmod(0o600)
+        os.replace(tmp, self._hosted_call_registry_path)
+        self._hosted_call_registry_path.chmod(0o600)
+
+    def _schedule_hosted_call_completion(
+        self,
+        call_id: str,
+        event_id: str,
+        payload: Dict[str, Any],
+    ) -> None:
+        task = asyncio.create_task(
+            self._run_hosted_call_completion(call_id, event_id, payload),
+            name=f"hosted-call-completion:{call_id}",
+        )
+        self._hosted_call_jobs[call_id] = task
+        task.add_done_callback(lambda _task, key=call_id: self._hosted_call_jobs.pop(key, None))
+
+    async def _recover_hosted_call_completions(self) -> None:
+        """Requeue work left queued/running/failed by a previous process."""
+        for call_id, entry in self._read_hosted_call_registry().items():
+            if not isinstance(entry, dict) or entry.get("state") == "completed":
+                continue
+            payload = entry.get("payload")
+            if not isinstance(payload, dict) or call_id in self._hosted_call_jobs:
+                continue
+            self._write_hosted_call_registry(
+                call_id,
+                event_id=str(entry.get("event_id") or ""),
+                state="queued",
+                payload=payload,
+                outcome=str(entry.get("outcome") or ""),
+            )
+            self._schedule_hosted_call_completion(
+                call_id, str(entry.get("event_id") or ""), payload
+            )
+
+    async def _on_hosted_call_ended(self, envelope: Dict[str, Any]) -> "web.Response":
+        data = envelope.get("data")
+        call = data.get("call") if isinstance(data, dict) else None
+        if not isinstance(call, dict) or str(call.get("mode") or "") != "hosted_agent":
+            return web.json_response({"ok": True, "ignored": "non-hosted-call"})
+        call_id = str(call.get("id") or "").strip()
+        if not call_id:
+            return web.json_response({"ok": True, "ignored": "missing-call-id"})
+        existing = self._read_hosted_call_registry().get(call_id)
+        state = str(existing.get("state") or "") if isinstance(existing, dict) else ""
+        current_inflight = (
+            isinstance(existing, dict)
+            and state in {"queued", "running"}
+            and existing.get("owner_id") == self._hosted_call_registry_owner
+        )
+        if state == "completed" or current_inflight:
+            return web.json_response({"ok": True, "deduped": True})
+        event_id = str(envelope.get("id") or "").strip()
+        self._write_hosted_call_registry(
+            call_id,
+            event_id=event_id,
+            state="queued",
+            payload=envelope,
+            outcome=str(data.get("outcome") or call.get("status") or ""),
+        )
+        self._schedule_hosted_call_completion(call_id, event_id, envelope)
+        logger.info("[bridge] enqueued hosted call completion call_id=%s", call_id)
+        return web.json_response({"ok": True})
+
+    async def _run_hosted_call_completion(
+        self,
+        call_id: str,
+        event_id: str,
+        envelope: Dict[str, Any],
+    ) -> None:
+        data = envelope.get("data") if isinstance(envelope.get("data"), dict) else {}
+        call = data.get("call") if isinstance(data.get("call"), dict) else {}
+        outcome = str(data.get("outcome") or call.get("status") or "unknown")
+        self._write_hosted_call_registry(
+            call_id, event_id=event_id, state="running", payload=envelope, outcome=outcome
+        )
+        try:
+            transcript: List[Tuple[str, str]] = []
+            try:
+                identity = await asyncio.to_thread(self._inkbox.get_identity, self.cfg.identity)
+                list_transcripts = getattr(identity, "list_transcripts", None)
+                if callable(list_transcripts):
+                    rows = await asyncio.to_thread(list_transcripts, call_id)
+                    transcript = [
+                        (
+                            str(getattr(getattr(row, "party", ""), "value", getattr(row, "party", "")) or "unknown"),
+                            str(getattr(row, "text", "") or ""),
+                        )
+                        for row in (rows or [])
+                        if str(getattr(row, "text", "") or "").strip()
+                    ]
+            except Exception as exc:
+                logger.warning(
+                    "[bridge] full transcript unavailable for hosted call %s: %s; using webhook transcript",
+                    call_id,
+                    exc,
+                )
+            if not transcript:
+                inline = data.get("transcript")
+                entries = inline.get("entries") if isinstance(inline, dict) else []
+                transcript = [
+                    (str(row.get("party") or "unknown"), str(row.get("text") or ""))
+                    for row in (entries or [])
+                    if isinstance(row, dict)
+                    and "marker" not in row
+                    and str(row.get("text") or "").strip()
+                ]
+            contacts = data.get("contacts") if isinstance(data.get("contacts"), list) else []
+            contact = contacts[0] if contacts and isinstance(contacts[0], dict) else {}
+            remote = str(call.get("remote_phone_number") or "").strip()
+            chat_id = str(contact.get("id") or remote or f"call:{call_id}")
+            actions = [
+                item for item in (data.get("post_call_action_items") or [])
+                if isinstance(item, dict) and str(item.get("status") or "open") == "open"
+            ]
+            lines = [
+                f"[inkbox:voice_call call_id={call_id}]",
+            ]
+            memories = contact_memories_block(contact.get("memories") or [])
+            if memories:
+                lines.append(memories)
+            lines.extend([
+                "[call_ended] Inkbox Voice AI finished this phone call.",
+                f"Direction: {call.get('direction') or 'unknown'}",
+                f"Outcome: {outcome}",
+            ])
+            hangup = str(call.get("hangup_reason") or "").strip()
+            reason = str(call.get("reason") or "").strip()
+            if hangup:
+                lines.append(f"Hangup reason: {hangup}")
+            if remote:
+                lines.extend([
+                    f"Remote party phone number: {remote}",
+                    "For callbacks or phone follow-up, use that exact number. "
+                    "Contact memories are background only and must not override it.",
+                ])
+            if reason:
+                lines.append(f"Outbound task: {reason}")
+            lines.extend(["", "Call transcript:"])
+            lines.extend(f"  - {role}: {text}" for role, text in transcript)
+            if not transcript:
+                lines.append("  (no transcript captured)")
+            if actions:
+                lines.extend(["", "Open post-call actions:"])
+                lines.extend(
+                    f"  - {item.get('action') or item.get('description') or item}"
+                    for item in actions
+                )
+            lines.extend([
+                "",
+                "Review the outcome, transcript, and open actions once. Use tools "
+                "to execute every still-needed commitment; do not repeat completed, "
+                "canceled, superseded, or already-performed work.",
+                "If nothing remains, do nothing. Plain text from this turn is "
+                "suppressed because the call has ended; side effects require tools.",
+            ])
+            if self.sessions is None:
+                raise RuntimeError("session manager is not ready")
+            await self.sessions.get(chat_id).run_consult("\n".join(lines))
+            self._write_hosted_call_registry(
+                call_id, event_id=event_id, state="completed", payload=envelope, outcome=outcome
+            )
+            logger.info("[bridge] completed hosted call completion call_id=%s", call_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self._write_hosted_call_registry(
+                call_id, event_id=event_id, state="failed", payload=envelope, outcome=outcome
+            )
+            logger.exception("[bridge] hosted call completion failed call_id=%s", call_id)
+
     async def _cleanup(self) -> None:
+        jobs = list(self._hosted_call_jobs.values())
+        for task in jobs:
+            task.cancel()
+        if jobs:
+            await asyncio.gather(*jobs, return_exceptions=True)
         if self.sessions is not None:
             await self.sessions.close_all()
         if self._runner is not None:
@@ -863,6 +1106,8 @@ class InkboxGateway:
                     response = await self._on_imessage_received(envelope)
                 elif event_type == "imessage.reaction_received":
                     response = await self._on_imessage_reaction_received(envelope)
+                elif event_type == "call.ended":
+                    response = await self._on_hosted_call_ended(envelope)
                 elif event_type.startswith("a2a."):
                     response = await self._on_a2a_event(envelope)
                 # Outbound delivery failures: tell the agent its message didn't
@@ -935,7 +1180,7 @@ class InkboxGateway:
             bool: True for a recognised Inkbox event shape.
         """
         if event_type and event_type.startswith(
-            ("message.", "text.", "imessage.", "a2a.")
+            ("message.", "text.", "imessage.", "a2a.", "call.")
         ):
             return True
         # ``id`` by itself is not a call discriminator: generic external

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -167,6 +167,20 @@ _OPEN_ACTION_SMS_COMMITMENT_PATTERNS = (
     re.compile(rf"\b{_TRANSCRIPT_TEXT_VERB}", re.IGNORECASE),
     re.compile(rf"\b{_TRANSCRIPT_SEND_SMS}", re.IGNORECASE),
 )
+_SMS_CLAUSE_SPLIT = re.compile(
+    r"(?:[.!?;]+|\s+—\s+|\b(?:but|however)\b)",
+    re.IGNORECASE,
+)
+
+
+def _clause_requires_sms(text: str, patterns: Any) -> bool:
+    """Match one positive SMS clause without letting another clause negate it."""
+    clauses = [part.strip() for part in _SMS_CLAUSE_SPLIT.split(text) if part.strip()]
+    return any(
+        not _TRANSCRIPT_NEGATED_SMS_ACTION.search(clause)
+        and any(pattern.search(clause) for pattern in patterns)
+        for clause in clauses
+    )
 
 
 def _transcript_requires_sms_commitment(transcript: Any) -> bool:
@@ -183,10 +197,8 @@ def _transcript_requires_sms_commitment(transcript: Any) -> bool:
         if text:
             turns.append(text)
     return any(
-        not _TRANSCRIPT_NEGATED_SMS_ACTION.search(turn)
-        and pattern.search(turn)
+        _clause_requires_sms(turn, _TRANSCRIPT_SMS_COMMITMENT_PATTERNS)
         for turn in turns
-        for pattern in _TRANSCRIPT_SMS_COMMITMENT_PATTERNS
     )
 
 
@@ -203,11 +215,7 @@ def _hosted_requires_sms(
         if str(action.get("status") or "open").strip().lower() == "open"
     )
     action_requires_sms = any(
-        not _TRANSCRIPT_NEGATED_SMS_ACTION.search(text)
-        and any(
-            pattern.search(text)
-            for pattern in _OPEN_ACTION_SMS_COMMITMENT_PATTERNS
-        )
+        _clause_requires_sms(text, _OPEN_ACTION_SMS_COMMITMENT_PATTERNS)
         for text in open_action_texts
     )
     return action_requires_sms or _transcript_requires_sms_commitment(transcript)
@@ -248,7 +256,8 @@ def _hosted_sms_correction_prompt(remote_phone: str, *, missing: bool) -> str:
         f"authoritative remote number {remote_phone} and `text` set to the "
         "still-needed message from the prior hosted-call reconciliation.",
         "Do not use another recipient, do not repeat any completed action, and "
-        "do not answer with prose. Stop after the tool result.",
+        "do not answer with prose. Do not return [SILENT], skip, or defer. "
+        "Stop after the tool result.",
     ])
 
 

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -136,6 +136,11 @@ _TRANSCRIPT_TEXT_CLAUSE_PREFIX = (
     r"(?:i|we)\s*(?:will|'ll|’ll|am\s+going\s+to|are\s+going\s+to))\s+)"
 )
 _TRANSCRIPT_SEND_SMS = r"send\b.{0,80}\b(?:an?\s+)?(?:sms|text\s+message)\b"
+_TRANSCRIPT_NEGATED_SMS_ACTION = re.compile(
+    r"\b(?:do\s+not|don['’]?t|never)\s+(?:(?:ever|again)\s+)?"
+    r"(?:text\b|send\b.{0,80}\b(?:sms|text\s+message)\b)",
+    re.IGNORECASE,
+)
 _TRANSCRIPT_SMS_COMMITMENT_PATTERNS = (
     re.compile(
         rf"\b{_TRANSCRIPT_POST_CALL_TIMING}\b[\s,;:!—-]*"
@@ -172,7 +177,8 @@ def _transcript_requires_sms_commitment(transcript: Any) -> bool:
         if text:
             turns.append(text)
     return any(
-        pattern.search(turn)
+        not _TRANSCRIPT_NEGATED_SMS_ACTION.search(turn)
+        and pattern.search(turn)
         for turn in turns
         for pattern in _TRANSCRIPT_SMS_COMMITMENT_PATTERNS
     )
@@ -182,15 +188,20 @@ def _hosted_requires_sms(
     actions: List[Dict[str, Any]], transcript: Any = None,
 ) -> bool:
     """Return true for an open SMS action or explicit transcript commitment."""
-    text = " ".join(
-        str(action.get(field) or "")
+    open_action_texts = (
+        " ".join(
+            str(action.get(field) or "")
+            for field in ("action", "description", "details")
+        )
         for action in actions
         if str(action.get("status") or "open").strip().lower() == "open"
-        for field in ("action", "description", "details")
-    ).lower()
-    return bool(re.search(r"\b(?:sms|text|texted|texting)\b", text)) or (
-        _transcript_requires_sms_commitment(transcript)
     )
+    action_requires_sms = any(
+        re.search(r"\b(?:sms|text|texted|texting)\b", text, re.IGNORECASE)
+        and not _TRANSCRIPT_NEGATED_SMS_ACTION.search(text)
+        for text in open_action_texts
+    )
+    return action_requires_sms or _transcript_requires_sms_commitment(transcript)
 
 
 def _hosted_sms_settlement(
@@ -1148,6 +1159,7 @@ class InkboxGateway:
         self._write_hosted_call_registry(
             call_id, event_id=event_id, state="running", payload=envelope, outcome=outcome
         )
+        required_sms_turn_started = False
         try:
             transcript: List[Tuple[str, str]] = []
             transcript_fetch_failed = False
@@ -1249,6 +1261,10 @@ class InkboxGateway:
             session = self.sessions.get(chat_id)
             prompt = "\n".join(lines)
             if remote and _hosted_requires_sms(actions, transcript):
+                # Once this capture turn starts, an exception is
+                # commit-ambiguous: the host may have completed a send before
+                # the model/transport failed to return the detailed result.
+                required_sms_turn_started = True
                 result = await session.run_consult_detailed(prompt)
                 settlement = _hosted_sms_settlement(result, remote)
                 if settlement in {"missing", "recoverable"}:
@@ -1273,6 +1289,15 @@ class InkboxGateway:
             )
             logger.info("[bridge] completed hosted call completion call_id=%s", call_id)
         except asyncio.CancelledError:
+            if required_sms_turn_started:
+                self._write_hosted_call_registry(
+                    call_id,
+                    event_id=event_id,
+                    state="failed",
+                    payload=envelope,
+                    outcome=outcome,
+                    retryable=False,
+                )
             raise
         except Exception as exc:
             self._write_hosted_call_registry(
@@ -1281,7 +1306,10 @@ class InkboxGateway:
                 state="failed",
                 payload=envelope,
                 outcome=outcome,
-                retryable=not isinstance(exc, _HostedToolSettlementError),
+                retryable=(
+                    not required_sms_turn_started
+                    and not isinstance(exc, _HostedToolSettlementError)
+                ),
             )
             logger.exception("[bridge] hosted call completion failed call_id=%s", call_id)
 

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -173,8 +173,7 @@ _DELIVERY_FAILURE_CHANNEL_GUIDANCE: Dict[str, str] = {
         "Rewrite the message so it no longer trips the stated rule and it "
         "reads like a human text: plain conversational prose, no markdown "
         "(**bold**, # headers, ``` fences), at most one emoji, no profanity, "
-        "no test/probe phrasing. Then send the corrected reply with your "
-        "Inkbox SMS tool now."
+        "no test/probe phrasing."
     ),
     "imessage": (
         "Rewrite the message so it no longer trips the stated rule and it "
@@ -192,6 +191,106 @@ _DELIVERY_FAILURE_CHANNEL_GUIDANCE: Dict[str, str] = {
         "deliver."
     ),
 }
+
+_DELIVERY_FAILURE_TERMINAL_CODES = frozenset({
+    "recipient_not_opted_in",
+    "recipient_opted_out",
+    "recipient_blocked",
+    "invalid_phone_number",
+    "carrier_rejected",
+    "sender_sms_pending",
+    "sender_sms_assignment_failed",
+    "sender_not_registered",
+    "sender_registration_required",
+    "messaging_profile_disabled",
+    "toll_free_sms_unsupported",
+})
+_DELIVERY_FAILURE_TERMINAL_MARKERS = (
+    "opted out",
+    "opt-out",
+    "not opted in",
+    "invalid number",
+    "invalid phone",
+    "unreachable",
+    "unknown subscriber",
+    "cannot receive",
+    "unsafe",
+    "harmful",
+    "abusive",
+    "harassment",
+    "threatening",
+    "illegal content",
+)
+_DELIVERY_FAILURE_RETRY_MARKERS = (
+    "40002",
+    "spam",
+    "content",
+    "too_long",
+    "too long",
+    "markdown",
+    "emoji",
+    "profanity",
+    "temporar",
+    "carrier_unavailable",
+)
+
+
+def _sms_delivery_failure_policy(
+    error_code: Optional[str],
+    error_detail: Optional[str],
+) -> str:
+    """Classify whether an SMS failure requires retry, stop, or judgment."""
+    code = str(error_code or "").strip().lower()
+    detail = str(error_detail or "").strip().lower()
+    combined = f"{code} {detail}"
+    if code in _DELIVERY_FAILURE_TERMINAL_CODES or any(
+        marker in combined for marker in _DELIVERY_FAILURE_TERMINAL_MARKERS
+    ):
+        return "stop"
+    if any(marker in combined for marker in _DELIVERY_FAILURE_RETRY_MARKERS):
+        return "retry"
+    return "conditional"
+
+
+def _delivery_failure_reply_instruction(
+    *,
+    mode: str,
+    error_code: Optional[str],
+    error_detail: Optional[str],
+    attempt: int,
+) -> str:
+    """Give the model one non-contradictory action for this failure class."""
+    if mode != "sms":
+        return (
+            "Send a corrected message only when it is safe, permitted, and likely "
+            "to deliver. Otherwise reply exactly [SILENT]."
+        )
+    policy = _sms_delivery_failure_policy(error_code, error_detail)
+    if policy == "retry":
+        if attempt == 1:
+            return (
+                "SMS failure classification: FIRST SAFE RETRY REQUIRED. This "
+                "is the first failure and it is retryable. You MUST now send "
+                "exactly one safe, materially rephrased SMS in plain "
+                "conversational prose; do not reuse the failed wording."
+            )
+        return (
+            "SMS failure classification: RETRY OPTIONAL. A safe, materially "
+            "rephrased SMS may use the remaining retry budget, but the first "
+            "retry has already failed. You may instead reply exactly [SILENT]."
+        )
+    if policy == "stop":
+        return (
+            "SMS failure classification: DO NOT RETRY. The recipient has not "
+            "consented, the destination is invalid or unreachable, or the "
+            "content is unsafe or harmful. Do not resend this message; reply "
+            "exactly [SILENT]."
+        )
+    return (
+        "SMS failure classification: REVIEW BEFORE RETRY. Send one corrected "
+        "SMS only if it is safe, permitted, and likely to deliver. Otherwise "
+        "reply exactly [SILENT]."
+    )
 
 
 def _outbound_failure_keys(
@@ -286,6 +385,12 @@ def _delivery_failure_prompt(
     guidance = _DELIVERY_FAILURE_CHANNEL_GUIDANCE.get(
         mode, _DELIVERY_FAILURE_CHANNEL_GUIDANCE["sms"],
     )
+    reply_instruction = _delivery_failure_reply_instruction(
+        mode=mode,
+        error_code=error_code,
+        error_detail=error_detail,
+        attempt=attempts,
+    )
     remaining = max_attempts - attempts
     target_part = f" to {target}" if target else ""
     conversation_part = f" conversation_id={conversation_id}" if conversation_id else ""
@@ -301,11 +406,12 @@ def _delivery_failure_prompt(
         f"Reason: {reason}{quoted}",
         "",
         guidance,
+        reply_instruction,
         f"This reply has failed {attempts} of {max_attempts} allowed sends; "
         f"{remaining} left before the thread goes quiet.",
-        "Act NOW via your Inkbox messaging tools — do not just reply here, the "
-        "original channel may be the dead one. Do not mention this delivery "
-        "problem to the recipient. If there is nothing sensible to send, do nothing.",
+        "If retrying, act via your Inkbox messaging tools — do not just reply "
+        "here, because the original channel may be the dead one. Do not mention "
+        "this delivery problem to the recipient.",
     ])
 
 

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -1145,9 +1145,11 @@ class InkboxGateway:
                 "Review the outcome, transcript, and open actions once. Use tools "
                 "to execute every still-needed commitment; do not repeat completed, "
                 "canceled, superseded, or already-performed work.",
-                "Do not finish until each required tool reports success. If a tool "
-                "rejects a recoverable argument or format mistake, correct it and "
-                "try once more.",
+                "Every safe, still-needed commitment must be attempted. Mark it "
+                "complete only after the required tool reports success. If the "
+                "first tool call rejects a recoverable argument or format mistake, "
+                "correct it and try once more. After a terminal error or a failed "
+                "second attempt, stop without claiming success or duplicating the send.",
                 "If nothing remains, do nothing. Plain text from this turn is "
                 "suppressed because the call has ended; side effects require tools.",
             ])

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -123,36 +123,22 @@ class _HostedToolSettlementError(RuntimeError):
     """A required hosted-call side effect reached a bounded terminal state."""
 
 
+_TRANSCRIPT_POST_CALL_TIMING = (
+    r"(?:after|when|once)\s+(?:(?:we|you)\s+hang\s*up|"
+    r"(?:this|the)\s+call\s+(?:ends?|is\s+over))"
+)
+_TRANSCRIPT_SMS_ACTION = (
+    r"(?:text\s+(?!messages?\b|history\b|thread\b|yesterday\b|earlier\b|from\b)"
+    r"[\w@][\w@.'’+-]*\b|"
+    r"send\b.{0,80}\b(?:an?\s+)?(?:sms|text\s+message)\b)"
+)
 _TRANSCRIPT_SMS_COMMITMENT_PATTERNS = (
-    # Direct text requests: "text me" / "could you text her".  Bare "send
-    # me" is channel-ambiguous and must not force an SMS side effect.
-    re.compile(r"\btext\s+(?:me|us|them|him|her)\b", re.IGNORECASE),
-    # A clear imperative/request may use a named recipient rather than a
-    # pronoun: "Text Alex" / "please text Dima" / "could you text Pat".
     re.compile(
-        r"(?:^|[.!?]\s+|\b(?:please|can\s+you|could\s+you|would\s+you|will\s+you)\s+)"
-        r"text\s+(?!messages?\b|history\b|thread\b)[\w@][\w@.'’+-]*\b",
+        rf"\b{_TRANSCRIPT_POST_CALL_TIMING}\b.{{0,160}}{_TRANSCRIPT_SMS_ACTION}",
         re.IGNORECASE,
     ),
-    # Explicit channel requests that name the medium even when the recipient
-    # is a proper noun: "send Alex an SMS" / "send a text message".
     re.compile(
-        r"\bsend\b.{0,80}\b(?:an?\s+)?(?:sms|text\s+message)\b",
-        re.IGNORECASE,
-    ),
-    # A bounded after-call promise/request.  Bare "send" is not enough: it
-    # must identify the SMS/text-message medium inside the same turn.
-    re.compile(
-        r"\b(?:after|once|when)\s+(?:we\s+|you\s+)?"
-        r"(?:hang\s*up|the\s+call\s+(?:ends?|is\s+over))\b.{0,160}"
-        r"(?:\btext\b|\bsend\b.{0,80}\b(?:sms|text\s+message))",
-        re.IGNORECASE,
-    ),
-    # The hosted agent's own unambiguous future commitment.
-    re.compile(
-        r"\b(?:i|we)\s*(?:will|'ll|’ll|am\s+going\s+to|are\s+going\s+to)\s+"
-        r"(?:text\s+(?:you|me|us|them|him|her)\b|"
-        r"send\b.{0,80}\b(?:sms|text\s+message)\b)",
+        rf"\b{_TRANSCRIPT_SMS_ACTION}.{{0,160}}\b{_TRANSCRIPT_POST_CALL_TIMING}\b",
         re.IGNORECASE,
     ),
 )
@@ -171,7 +157,11 @@ def _transcript_requires_sms_commitment(transcript: Any) -> bool:
         text = str(value or "").strip()
         if text:
             turns.append(text)
-    return any(pattern.search(turn) for turn in turns for pattern in _TRANSCRIPT_SMS_COMMITMENT_PATTERNS)
+    return any(
+        pattern.search(turn)
+        for turn in turns
+        for pattern in _TRANSCRIPT_SMS_COMMITMENT_PATTERNS
+    )
 
 
 def _hosted_requires_sms(

--- a/inkbox_claude/gateway.py
+++ b/inkbox_claude/gateway.py
@@ -167,20 +167,10 @@ _OPEN_ACTION_SMS_COMMITMENT_PATTERNS = (
     re.compile(rf"\b{_TRANSCRIPT_TEXT_VERB}", re.IGNORECASE),
     re.compile(rf"\b{_TRANSCRIPT_SEND_SMS}", re.IGNORECASE),
 )
-_SMS_CLAUSE_SPLIT = re.compile(
-    r"(?:[.!?;]+|\s+—\s+|\b(?:but|however)\b)",
-    re.IGNORECASE,
-)
-
-
 def _clause_requires_sms(text: str, patterns: Any) -> bool:
-    """Match one positive SMS clause without letting another clause negate it."""
-    clauses = [part.strip() for part in _SMS_CLAUSE_SPLIT.split(text) if part.strip()]
-    return any(
-        not _TRANSCRIPT_NEGATED_SMS_ACTION.search(clause)
-        and any(pattern.search(clause) for pattern in patterns)
-        for clause in clauses
-    )
+    """Match positive SMS intent after removing only negated action candidates."""
+    candidate = _TRANSCRIPT_NEGATED_SMS_ACTION.sub("", text)
+    return any(pattern.search(candidate) for pattern in patterns)
 
 
 def _transcript_requires_sms_commitment(transcript: Any) -> bool:
@@ -999,9 +989,12 @@ class InkboxGateway:
         }
         if state == "failed":
             entry["retryable"] = retryable
-        # Only unfinished/retryable work needs replay data. Completed receipts
-        # retain dedupe metadata but immediately discard call content.
-        if state in {"queued", "running", "failed"} and replay_payload is not None:
+        # Only unfinished/retryable work needs replay data. Completed and
+        # terminal-failed receipts retain dedupe metadata but discard content.
+        replayable = state in {"queued", "running"} or (
+            state == "failed" and retryable
+        )
+        if replayable and replay_payload is not None:
             entry["payload"] = replay_payload
         current[call_id] = entry
         if len(current) > 1_000:
@@ -1110,6 +1103,82 @@ class InkboxGateway:
         self._hosted_call_jobs[call_id] = task
         task.add_done_callback(lambda _task, key=call_id: self._hosted_call_jobs.pop(key, None))
 
+    def _schedule_hosted_sms_correction_recovery(
+        self,
+        call_id: str,
+        event_id: str,
+        payload: Dict[str, Any],
+    ) -> None:
+        task = asyncio.create_task(
+            self._run_hosted_sms_correction_recovery(call_id, event_id, payload),
+            name=f"hosted-sms-correction:{call_id}",
+        )
+        self._hosted_call_jobs[call_id] = task
+        task.add_done_callback(
+            lambda _task, key=call_id: self._hosted_call_jobs.pop(key, None)
+        )
+
+    async def _run_hosted_sms_correction_recovery(
+        self,
+        call_id: str,
+        event_id: str,
+        payload: Dict[str, Any],
+    ) -> None:
+        """Resume only the one safe SMS correction after a known rejection."""
+        data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+        call = data.get("call") if isinstance(data.get("call"), dict) else {}
+        outcome = str(data.get("outcome") or call.get("status") or "unknown")
+        self._write_hosted_call_registry(
+            call_id,
+            event_id=event_id,
+            state="running",
+            payload=payload,
+            outcome=outcome,
+        )
+        try:
+            remote = str(call.get("remote_phone_number") or "").strip()
+            contacts = data.get("contacts") if isinstance(data.get("contacts"), list) else []
+            contact = contacts[0] if contacts and isinstance(contacts[0], dict) else {}
+            if not remote or self.sessions is None:
+                raise _HostedToolSettlementError("hosted SMS correction context is unavailable")
+            session = self.sessions.get(str(contact.get("id") or remote))
+            corrected = await session.run_consult_detailed(
+                _hosted_sms_correction_prompt(remote, missing=False),
+                hosted_sms_context={
+                    "call_id": call_id,
+                    "attempt": 2,
+                    "remote_phone": remote,
+                },
+            )
+            if _hosted_sms_settlement(corrected, remote) != "success":
+                raise _HostedToolSettlementError(
+                    "recovered hosted SMS correction did not complete safely"
+                )
+            self._write_hosted_call_registry(
+                call_id,
+                event_id=event_id,
+                state="completed",
+                outcome=outcome,
+            )
+        except asyncio.CancelledError:
+            self._write_hosted_call_registry(
+                call_id,
+                event_id=event_id,
+                state="failed",
+                outcome=outcome,
+                retryable=False,
+            )
+            raise
+        except Exception:
+            self._write_hosted_call_registry(
+                call_id,
+                event_id=event_id,
+                state="failed",
+                outcome=outcome,
+                retryable=False,
+            )
+            logger.exception("[bridge] hosted SMS correction recovery failed: %s", call_id)
+
     async def _recover_hosted_call_completions(self) -> None:
         """Requeue work left queued/running/failed by a previous process."""
         for call_id, entry in self._read_hosted_call_registry().items():
@@ -1117,10 +1186,20 @@ class InkboxGateway:
                 continue
             if entry.get("state") == "failed" and entry.get("retryable") is False:
                 continue
-            if any(
-                hosted_sms_attempt_state(str(call_id), attempt) is not None
-                for attempt in (1, 2)
+            attempt_one = hosted_sms_attempt_state(str(call_id), 1)
+            attempt_two = hosted_sms_attempt_state(str(call_id), 2)
+            payload = entry.get("payload")
+            if (
+                attempt_one == "recoverable"
+                and attempt_two is None
+                and isinstance(payload, dict)
+                and call_id not in self._hosted_call_jobs
             ):
+                self._schedule_hosted_sms_correction_recovery(
+                    str(call_id), str(entry.get("event_id") or ""), payload
+                )
+                continue
+            if attempt_one is not None or attempt_two is not None:
                 self._write_hosted_call_registry(
                     str(call_id),
                     event_id=str(entry.get("event_id") or ""),
@@ -1135,7 +1214,6 @@ class InkboxGateway:
                     call_id,
                 )
                 continue
-            payload = entry.get("payload")
             if not isinstance(payload, dict) or call_id in self._hosted_call_jobs:
                 continue
             self._write_hosted_call_registry(

--- a/inkbox_claude/hosted_sms_guard.py
+++ b/inkbox_claude/hosted_sms_guard.py
@@ -1,0 +1,98 @@
+"""Durable pre-send guard for hosted-call SMS commitments."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def _root() -> Path:
+    home = Path(os.getenv("INKBOX_CLAUDE_HOME") or (Path.home() / ".inkbox-claude"))
+    root = home / "hosted_sms_attempts"
+    root.mkdir(parents=True, exist_ok=True)
+    root.chmod(0o700)
+    return root
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _path(call_id: str, attempt: int) -> Path:
+    return _root() / f"{_digest(call_id)}-{attempt}.json"
+
+
+def _atomic_replace(path: Path, value: Dict[str, Any]) -> None:
+    tmp = path.with_suffix(f"{path.suffix}.tmp")
+    tmp.unlink(missing_ok=True)
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(value, sort_keys=True) + "\n")
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
+    os.replace(tmp, path)
+    path.chmod(0o600)
+
+
+def reserve_hosted_sms_attempt(
+    call_id: str,
+    attempt: int,
+    target: str,
+) -> bool:
+    """Atomically reserve one provider attempt before any external side effect."""
+    path = _path(call_id, attempt)
+    value = {
+        "state": "pending",
+        "target_digest": _digest(target),
+        "updated_at": time.time(),
+    }
+    encoded = json.dumps(value, sort_keys=True) + "\n"
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        return False
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(encoded)
+    except Exception:
+        # Keep the reservation file even if writing fails. Its existence is
+        # the fail-closed signal that a provider call may have started.
+        raise
+    path.chmod(0o600)
+    return True
+
+
+def settle_hosted_sms_attempt(call_id: str, attempt: int, state: str) -> None:
+    """Persist the sanitized synchronous result for a reserved attempt."""
+    path = _path(call_id, attempt)
+    try:
+        current = json.loads(path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        current = {}
+    value = current if isinstance(current, dict) else {}
+    value = {
+        "state": state,
+        "target_digest": str(value.get("target_digest") or ""),
+        "updated_at": time.time(),
+    }
+    _atomic_replace(path, value)
+
+
+def hosted_sms_attempt_state(call_id: str, attempt: int) -> Optional[str]:
+    """Read one attempt state; an unreadable reservation is commit-ambiguous."""
+    path = _path(call_id, attempt)
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return "pending"
+    if not isinstance(value, dict):
+        return "pending"
+    return str(value.get("state") or "pending")

--- a/inkbox_claude/prompts.py
+++ b/inkbox_claude/prompts.py
@@ -75,6 +75,11 @@ The shared line only works for people connected to you over iMessage
 first, or fall back to your dedicated number), and its number is managed
 by Inkbox: never state a number for it. If you omit origination it
 follows the current conversation's channel, or the only line available.
+Always provide a concrete purpose for a call. In Inkbox Voice AI mode that
+purpose becomes the hosted agent's task, so include enough context for it to
+know what outcome it should achieve. Voice AI authority comes from the saved
+agent configuration unless an administrator changes it; never guess or request
+a per-call authority elevation.
 
 # Inkbox contacts
 

--- a/inkbox_claude/sessions.py
+++ b/inkbox_claude/sessions.py
@@ -21,6 +21,11 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, Optional
 
 try:
+    from .delivery_policy import sms_tool_failure_kind
+except ImportError:  # pragma: no cover - direct local import/test fallback
+    from delivery_policy import sms_tool_failure_kind
+
+try:
     from claude_agent_sdk import (
         AssistantMessage,
         ClaudeAgentOptions,
@@ -87,8 +92,28 @@ class _Turn:
     """
 
     text: str
-    future: Optional["asyncio.Future[str]"] = None
+    future: Optional["asyncio.Future[Any]"] = None
     a2a_context: Optional[Dict[str, Any]] = None
+    capture_tools: bool = False
+
+
+@dataclass(frozen=True)
+class ToolDeliveryResult:
+    """Sanitized host-native outcome for one messaging tool attempt."""
+
+    mode: str
+    target: str
+    sent: bool
+    error_kind: str
+
+
+@dataclass(frozen=True)
+class CapturedTurnResult:
+    """Capture-turn text plus host-native messaging-tool outcomes."""
+
+    text: str
+    tool_deliveries: tuple[ToolDeliveryResult, ...]
+    aborted: bool = False
 
 # Leading slash-commands the human can text to steer the conversation itself.
 # The bridge acts on these locally — they never reach Claude as a turn.
@@ -353,6 +378,7 @@ class ContactSession:
         # and recipient as the inbound turn. The tool's message is the reply;
         # do not follow it with Claude's usually-redundant "sent it" result.
         self._current_channel_tool_delivery = False
+        self._current_tool_deliveries: list[ToolDeliveryResult] = []
 
     # ------------------------------------------------------------------
     # Inbound routing
@@ -504,7 +530,14 @@ class ContactSession:
             except asyncio.QueueEmpty:
                 break
             if turn.future is not None and not turn.future.done():
-                turn.future.set_result("")
+                if turn.capture_tools:
+                    turn.future.set_result(CapturedTurnResult(
+                        text="",
+                        tool_deliveries=(),
+                        aborted=True,
+                    ))
+                else:
+                    turn.future.set_result("")
 
     async def _begin_resume(self) -> None:
         """List recent sessions and let the human pick one to reopen.
@@ -611,10 +644,19 @@ class ContactSession:
         Cross-channel sends and sends to third parties still need the normal
         automatic reply so the human hears that the action completed.
         """
-        if not self._turn_active or str(mode or "").strip().lower() != self.mode:
+        if not self._turn_active:
             return
 
+        normalized_mode = str(mode or "").strip().lower()
         target = str(target or "").strip()
+        self._current_tool_deliveries.append(ToolDeliveryResult(
+            mode=normalized_mode,
+            target=target,
+            sent=True,
+            error_kind="none",
+        ))
+        if normalized_mode != self.mode:
+            return
         matched = False
         if self.mode == "email":
             current = str(
@@ -642,9 +684,21 @@ class ContactSession:
                 self.mode,
             )
 
+    def mark_tool_failure(self, mode: str, target: str, error: Any) -> None:
+        """Record a failed host-native tool attempt without retaining its payload."""
+        if not self._turn_active:
+            return
+        self._current_tool_deliveries.append(ToolDeliveryResult(
+            mode=str(mode or "").strip().lower(),
+            target=str(target or "").strip(),
+            sent=False,
+            error_kind=sms_tool_failure_kind(error),
+        ))
+
     async def _run_turn(self, turn: _Turn) -> None:
         self._interrupting = False  # fresh turn starts un-interrupted
         self._current_channel_tool_delivery = False
+        self._current_tool_deliveries: list[ToolDeliveryResult] = []
         self._current_turn = turn
         typing_task: Optional[asyncio.Task] = None
         retried_missing_resume = False
@@ -701,7 +755,14 @@ class ContactSession:
             # A capture turn must always settle its waiter — surface the error
             # there. A normal turn re-raises so _drain shows the human a notice.
             if turn.future is not None and not turn.future.done():
-                turn.future.set_exception(exc)
+                if turn.capture_tools and self._interrupting:
+                    turn.future.set_result(CapturedTurnResult(
+                        text="",
+                        tool_deliveries=tuple(self._current_tool_deliveries),
+                        aborted=True,
+                    ))
+                else:
+                    turn.future.set_exception(exc)
                 return
             raise
         finally:
@@ -722,7 +783,16 @@ class ContactSession:
         # interrupted this one, in which case the partial answer is dropped.
         if turn.future is not None:
             if not turn.future.done():
-                turn.future.set_result(reply or "I finished that, but didn't have anything to say back.")
+                if turn.capture_tools:
+                    turn.future.set_result(CapturedTurnResult(
+                        text=reply,
+                        tool_deliveries=tuple(self._current_tool_deliveries),
+                        aborted=self._interrupting,
+                    ))
+                else:
+                    turn.future.set_result(
+                        reply or "I finished that, but didn't have anything to say back."
+                    )
             return
         if self._interrupting:
             return
@@ -804,6 +874,15 @@ class ContactSession:
         await self._queue.put(
             _Turn(text=query, future=future, a2a_context=a2a_context)
         )
+        if self._worker is None or self._worker.done():
+            self._worker = asyncio.create_task(self._drain())
+        return await future
+
+    async def run_consult_detailed(self, query: str) -> CapturedTurnResult:
+        """Run a capture turn and return sanitized host-native tool outcomes."""
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[CapturedTurnResult] = loop.create_future()
+        await self._queue.put(_Turn(text=query, future=future, capture_tools=True))
         if self._worker is None or self._worker.done():
             self._worker = asyncio.create_task(self._drain())
         return await future

--- a/inkbox_claude/sessions.py
+++ b/inkbox_claude/sessions.py
@@ -22,8 +22,16 @@ from typing import Any, Awaitable, Callable, Dict, Optional
 
 try:
     from .delivery_policy import sms_tool_failure_kind
+    from .hosted_sms_guard import (
+        reserve_hosted_sms_attempt,
+        settle_hosted_sms_attempt,
+    )
 except ImportError:  # pragma: no cover - direct local import/test fallback
     from delivery_policy import sms_tool_failure_kind
+    from hosted_sms_guard import (
+        reserve_hosted_sms_attempt,
+        settle_hosted_sms_attempt,
+    )
 
 try:
     from claude_agent_sdk import (
@@ -95,6 +103,7 @@ class _Turn:
     future: Optional["asyncio.Future[Any]"] = None
     a2a_context: Optional[Dict[str, Any]] = None
     capture_tools: bool = False
+    hosted_sms_context: Optional[Dict[str, Any]] = None
 
 
 @dataclass(frozen=True)
@@ -379,6 +388,7 @@ class ContactSession:
         # do not follow it with Claude's usually-redundant "sent it" result.
         self._current_channel_tool_delivery = False
         self._current_tool_deliveries: list[ToolDeliveryResult] = []
+        self._current_hosted_sms_context: Optional[Dict[str, Any]] = None
 
     # ------------------------------------------------------------------
     # Inbound routing
@@ -655,6 +665,8 @@ class ContactSession:
             sent=True,
             error_kind="none",
         ))
+        if normalized_mode == "sms":
+            self._settle_hosted_sms_attempt("success")
         if normalized_mode != self.mode:
             return
         matched = False
@@ -688,17 +700,80 @@ class ContactSession:
         """Record a failed host-native tool attempt without retaining its payload."""
         if not self._turn_active:
             return
+        error_kind = sms_tool_failure_kind(error)
         self._current_tool_deliveries.append(ToolDeliveryResult(
             mode=str(mode or "").strip().lower(),
             target=str(target or "").strip(),
             sent=False,
-            error_kind=sms_tool_failure_kind(error),
+            error_kind=error_kind,
         ))
+        if str(mode or "").strip().lower() == "sms":
+            self._settle_hosted_sms_attempt(error_kind)
+
+    def preflight_hosted_sms(self, target: str) -> Optional[Dict[str, str]]:
+        """Reserve a trusted hosted SMS attempt before the provider is called."""
+        context = self._current_hosted_sms_context
+        if not self._turn_active or not isinstance(context, dict):
+            return None
+        expected = str(context.get("remote_phone") or "").strip()
+        if not expected or str(target or "").strip() != expected:
+            return {
+                "kind": "terminal",
+                "message": (
+                    "Hosted-call SMS target does not match the authoritative "
+                    "caller; send blocked."
+                ),
+            }
+        try:
+            reserved = reserve_hosted_sms_attempt(
+                str(context.get("call_id") or ""),
+                int(context.get("attempt") or 1),
+                expected,
+            )
+        except Exception:
+            logger.exception(
+                "[session %s] hosted SMS reservation failed; send blocked",
+                self.chat_id,
+            )
+            return {
+                "kind": "terminal",
+                "message": "Hosted-call SMS safety state is unavailable; send blocked.",
+            }
+        if not reserved:
+            return {
+                "kind": "duplicate",
+                "message": (
+                    "This hosted-call SMS attempt was already used; duplicate "
+                    "send blocked."
+                ),
+            }
+        return None
+
+    def _settle_hosted_sms_attempt(self, state: str) -> None:
+        context = self._current_hosted_sms_context
+        if not isinstance(context, dict):
+            return
+        try:
+            settle_hosted_sms_attempt(
+                str(context.get("call_id") or ""),
+                int(context.get("attempt") or 1),
+                state,
+            )
+        except Exception:
+            logger.exception(
+                "[session %s] hosted SMS settlement journal failed",
+                self.chat_id,
+            )
 
     async def _run_turn(self, turn: _Turn) -> None:
         self._interrupting = False  # fresh turn starts un-interrupted
         self._current_channel_tool_delivery = False
         self._current_tool_deliveries: list[ToolDeliveryResult] = []
+        self._current_hosted_sms_context = (
+            dict(turn.hosted_sms_context)
+            if isinstance(turn.hosted_sms_context, dict)
+            else None
+        )
         self._current_turn = turn
         typing_task: Optional[asyncio.Task] = None
         retried_missing_resume = False
@@ -770,6 +845,7 @@ class ContactSession:
                 A2A_TURN_CONTEXT.reset(a2a_token)
             self._turn_active = False
             self._current_turn = None
+            self._current_hosted_sms_context = None
             if typing_task is not None:
                 typing_task.cancel()
                 try:
@@ -878,11 +954,21 @@ class ContactSession:
             self._worker = asyncio.create_task(self._drain())
         return await future
 
-    async def run_consult_detailed(self, query: str) -> CapturedTurnResult:
+    async def run_consult_detailed(
+        self,
+        query: str,
+        *,
+        hosted_sms_context: Optional[Dict[str, Any]] = None,
+    ) -> CapturedTurnResult:
         """Run a capture turn and return sanitized host-native tool outcomes."""
         loop = asyncio.get_running_loop()
         future: asyncio.Future[CapturedTurnResult] = loop.create_future()
-        await self._queue.put(_Turn(text=query, future=future, capture_tools=True))
+        await self._queue.put(_Turn(
+            text=query,
+            future=future,
+            capture_tools=True,
+            hosted_sms_context=hosted_sms_context,
+        ))
         if self._worker is None or self._worker.done():
             self._worker = asyncio.create_task(self._drain())
         return await future

--- a/inkbox_claude/setup_wizard.py
+++ b/inkbox_claude/setup_wizard.py
@@ -952,7 +952,13 @@ def _local_call_ws_url(identity: Any) -> str:
     if public_url:
         scheme, _, host = public_url.partition("://")
         return f"{'wss' if scheme == 'https' else 'ws'}://{host}{INKBOX_WS_PATH}"
-    return ""
+    handle = str(getattr(identity, "agent_handle", "") or "").strip()
+    tunnel_name = _env("INKBOX_TUNNEL_NAME").strip() or handle
+    return (
+        f"wss://{tunnel_name}.inkboxwire.com{INKBOX_WS_PATH}"
+        if tunnel_name
+        else ""
+    )
 
 
 def _set_local_incoming_call_action(identity: Any) -> None:
@@ -1105,9 +1111,15 @@ def _configure_voice_ai(
     authority_changed = False
     incoming_changed = False
     try:
-        # Hosted instructions intentionally remain server-owned for now.
+        # Hosted prompt/model configuration remains server-owned. Re-submit
+        # the authoritative values so setup never clears an existing server
+        # configuration while changing only routing/authority.
         hosted_changed = True
-        identity.set_hosted_agent_config(voice=None, model=None, instructions=None)
+        identity.set_hosted_agent_config(
+            voice=getattr(current, "voice", None),
+            model=getattr(current, "model", None),
+            instructions=getattr(current, "instructions", None),
+        )
         if authority != before:
             setter = getattr(authority_writer, "set_hosted_agent_authority_mode", None)
             if not callable(setter):
@@ -1167,6 +1179,7 @@ def _configure_phone_call_voice_stack(
     if getattr(identity, "phone_number", None) is None and not imessage_enabled:
         return
     print()
+    prompt("  Press Enter to continue and set up phone call handling")
     print(color("  --- Phone call voice stack ---", Colors.CYAN))
     detected = _detect_openai_realtime_key()
     detected_key = detected[1] if detected else ""

--- a/inkbox_claude/setup_wizard.py
+++ b/inkbox_claude/setup_wizard.py
@@ -26,22 +26,53 @@ from typing import Any
 from urllib.parse import urlencode
 
 try:
-    from .config import INKBOX_BASE_URL_DEFAULT, inkbox_base_url_kwargs, inkbox_client_kwargs
+    from .config import (
+        INKBOX_BASE_URL_DEFAULT,
+        INKBOX_WS_PATH,
+        VoiceStack,
+        inkbox_base_url_kwargs,
+        inkbox_client_kwargs,
+        resolve_voice_stack,
+    )
     from .realtime import DEFAULT_MODEL as REALTIME_MODEL, REALTIME_URL
 except ImportError:  # pragma: no cover - direct local import/test fallback
-    from config import INKBOX_BASE_URL_DEFAULT, inkbox_base_url_kwargs, inkbox_client_kwargs
+    from config import (
+        INKBOX_BASE_URL_DEFAULT,
+        INKBOX_WS_PATH,
+        VoiceStack,
+        inkbox_base_url_kwargs,
+        inkbox_client_kwargs,
+        resolve_voice_stack,
+    )
     from realtime import DEFAULT_MODEL as REALTIME_MODEL, REALTIME_URL
 
 
 # Packages the wizard itself needs to talk to Inkbox during setup. The
 # gateway's other dependency (claude-agent-sdk) is checked by doctor.
-INKBOX_MIN_VERSION = (0, 5, 6)
-INKBOX_REQUIREMENTS = ("inkbox>=0.5.6,<1.0.0", "aiohttp>=3.9")
+INKBOX_MIN_VERSION = (0, 5, 9)
+INKBOX_REQUIREMENTS = ("inkbox>=0.5.9,<1.0.0", "aiohttp>=3.9")
 _BRACKETED_PASTE_PATTERN = re.compile(r"\x1b\[\s*200~|\x1b\[\s*201~")
 
 # Bundled avatar attached to the agent's Inkbox contact card during setup.
 _AVATAR_PATH = Path(__file__).resolve().parent / "assets" / "claude_code_avatar.png"
 _RAW_AVATAR_BASE_URL_DEFAULT = "https://inkbox.ai"
+VOICE_STACK_CHOICES = [
+    (
+        VoiceStack.INKBOX_VOICE_AI,
+        "Inkbox Voice AI — Inkbox handles calls on behalf of your agent; "
+        "Claude Code is notified when the call ends.",
+    ),
+    (
+        VoiceStack.OPENAI_REALTIME,
+        "OpenAI Realtime API — Bring your own API key; the realtime agent can "
+        "consult Claude Code for complex tasks.",
+    ),
+    (
+        VoiceStack.INKBOX_TTS_STT,
+        "Inkbox TTS/STT — Claude Code talks through the Inkbox voice stack with "
+        "increased latency.",
+    ),
+]
 
 
 # ----------------------------------------------------------------------
@@ -900,6 +931,308 @@ def _configure_realtime_calls(identity: Any, *, imessage_enabled: bool = False) 
         return
 
 
+def _voice_stack_default_index(detected_realtime_key: str) -> int:
+    stack, _ = resolve_voice_stack(
+        _env("INKBOX_VOICE_STACK"),
+        realtime_enabled=_env("INKBOX_REALTIME_ENABLED") or None,
+        realtime_api_key=detected_realtime_key,
+    )
+    return next(
+        (index for index, (candidate, _) in enumerate(VOICE_STACK_CHOICES) if candidate is stack),
+        2,
+    )
+
+
+def _local_call_ws_url(identity: Any) -> str:
+    phone = getattr(identity, "phone_number", None)
+    existing = str(getattr(phone, "client_websocket_url", "") or "").strip()
+    if existing:
+        return existing
+    public_url = _env("INKBOX_PUBLIC_URL").strip().rstrip("/")
+    if public_url:
+        scheme, _, host = public_url.partition("://")
+        return f"{'wss' if scheme == 'https' else 'ws'}://{host}{INKBOX_WS_PATH}"
+    return ""
+
+
+def _set_local_incoming_call_action(identity: Any) -> None:
+    setter = getattr(identity, "set_incoming_call_action", None)
+    if not callable(setter):
+        raise RuntimeError("the installed Inkbox SDK cannot configure identity-scoped calls")
+    ws_url = _local_call_ws_url(identity)
+    if not ws_url:
+        # The gateway reconciles the final tunnel URL at startup. Do not write
+        # a guessed URL during setup when the tunnel has not started yet.
+        return
+    setter(
+        incoming_call_action="auto_accept",
+        client_websocket_url=ws_url,
+        incoming_call_webhook_url=None,
+    )
+
+
+def _incoming_call_values(config: Any) -> dict[str, Any]:
+    return {
+        "incoming_call_action": _enum_value(
+            getattr(config, "incoming_call_action", "")
+        ),
+        "client_websocket_url": getattr(config, "client_websocket_url", None),
+        "incoming_call_webhook_url": getattr(
+            config, "incoming_call_webhook_url", None
+        ),
+    }
+
+
+def _restore_voice_ai_config(
+    identity: Any,
+    *,
+    incoming_before: Any,
+    hosted_before: Any,
+    authority_before: str,
+    authority_identity: Any | None,
+    incoming_changed: bool,
+    authority_changed: bool,
+    hosted_changed: bool,
+) -> None:
+    """Best-effort rollback when a multi-step Voice AI update fails."""
+    failures: list[str] = []
+    if incoming_changed:
+        try:
+            identity.set_incoming_call_action(**_incoming_call_values(incoming_before))
+        except Exception as exc:
+            failures.append(f"incoming-call action ({exc})")
+    if authority_changed and authority_identity is not None:
+        try:
+            authority_identity.set_hosted_agent_authority_mode(authority_before)
+        except Exception as exc:
+            failures.append(f"authority mode ({exc})")
+    if hosted_changed:
+        try:
+            identity.set_hosted_agent_config(
+                voice=getattr(hosted_before, "voice", None),
+                model=getattr(hosted_before, "model", None),
+                instructions=getattr(hosted_before, "instructions", None),
+            )
+        except Exception as exc:
+            failures.append(f"Voice AI config ({exc})")
+    if failures:
+        print_warning("  Could not fully restore the previous call configuration:")
+        for failure in failures:
+            print_warning(f"    {failure}")
+
+
+def _load_admin_identity(
+    identity: Any,
+    *,
+    base_url: str,
+    Inkbox: Any,
+    InkboxAPIError: Any,
+    WhoamiApiKeyResponse: Any,
+    ADMIN_SCOPED: Any,
+) -> Any | None:
+    admin_key = prompt(
+        "  Paste an admin-scoped Inkbox API key for this authority change",
+        password=True,
+    ).strip()
+    if not admin_key:
+        print_warning("  No admin key entered. Returning to the voice-stack choices.")
+        return None
+    try:
+        client = Inkbox(**inkbox_client_kwargs(admin_key, base_url))
+        info = client.whoami()
+        if WhoamiApiKeyResponse is not None and not isinstance(info, WhoamiApiKeyResponse):
+            print_error("  This authority change requires an admin-scoped API key.")
+            return None
+        if _enum_value(getattr(info, "auth_subtype", "")) != _enum_value(ADMIN_SCOPED):
+            print_error("  This authority change requires an admin-scoped API key.")
+            return None
+        return client.get_identity(identity.agent_handle)
+    except InkboxAPIError as exc:
+        print_error(f"  Admin key validation failed: HTTP {_error_status(exc)} {_error_detail(exc)}")
+    except Exception as exc:
+        print_error(f"  Admin key validation failed: {exc}")
+    return None
+
+
+def _configure_voice_ai(
+    identity: Any,
+    *,
+    base_url: str,
+    Inkbox: Any,
+    InkboxAPIError: Any,
+    WhoamiApiKeyResponse: Any,
+    ADMIN_SCOPED: Any,
+    authority_identity: Any | None,
+) -> tuple[bool, Any | None, str]:
+    required = (
+        "get_hosted_agent_config",
+        "get_incoming_call_action",
+        "set_hosted_agent_config",
+        "set_incoming_call_action",
+    )
+    if any(not callable(getattr(identity, name, None)) for name in required):
+        print_error("  Inkbox Voice AI requires Inkbox SDK 0.5.9 or newer.")
+        return False, authority_identity, ""
+    try:
+        current = identity.get_hosted_agent_config()
+        incoming_before = identity.get_incoming_call_action()
+    except Exception as exc:
+        print_error(f"  Could not read the Voice AI configuration: {exc}")
+        return False, authority_identity, ""
+    before = _enum_value(getattr(current, "authority_mode", "contact_scoped")) or "contact_scoped"
+    selected = prompt_choice(
+        "  How much authority should Inkbox Voice AI have?",
+        [
+            "Contact-scoped — tools are limited to the current caller and conversation.",
+            "YOLO mode — tools can use the identity's wider authorized capabilities.",
+        ],
+        1 if before == "yolo" else 0,
+    )
+    authority = "yolo" if selected == 1 else "contact_scoped"
+    authority_writer = authority_identity
+    if authority != before and authority_writer is None:
+        authority_writer = _load_admin_identity(
+            identity,
+            base_url=base_url,
+            Inkbox=Inkbox,
+            InkboxAPIError=InkboxAPIError,
+            WhoamiApiKeyResponse=WhoamiApiKeyResponse,
+            ADMIN_SCOPED=ADMIN_SCOPED,
+        )
+    if authority != before and authority_writer is None:
+        return False, authority_identity, ""
+    hosted_changed = False
+    authority_changed = False
+    incoming_changed = False
+    try:
+        # Hosted instructions intentionally remain server-owned for now.
+        hosted_changed = True
+        identity.set_hosted_agent_config(voice=None, model=None, instructions=None)
+        if authority != before:
+            setter = getattr(authority_writer, "set_hosted_agent_authority_mode", None)
+            if not callable(setter):
+                raise RuntimeError("the installed SDK cannot update Voice AI authority")
+            authority_changed = True
+            setter(authority)
+        incoming_changed = True
+        identity.set_incoming_call_action(
+            incoming_call_action="hosted_agent",
+            client_websocket_url=None,
+            incoming_call_webhook_url=None,
+        )
+    except Exception as exc:
+        print_error(f"  Inkbox Voice AI configuration failed: {exc}")
+        _restore_voice_ai_config(
+            identity,
+            incoming_before=incoming_before,
+            hosted_before=current,
+            authority_before=before,
+            authority_identity=authority_writer,
+            incoming_changed=incoming_changed,
+            authority_changed=authority_changed,
+            hosted_changed=hosted_changed,
+        )
+        return False, authority_writer, ""
+    return True, authority_writer, authority
+
+
+def _save_voice_stack(
+    stack: VoiceStack,
+    *,
+    realtime_api_key: str = "",
+    authority_mode: str = "",
+) -> None:
+    if stack is VoiceStack.OPENAI_REALTIME:
+        _save("INKBOX_REALTIME_API_KEY", realtime_api_key)
+        _save("INKBOX_REALTIME_MODEL", REALTIME_MODEL)
+        _save("INKBOX_REALTIME_ENABLED", "true")
+    else:
+        _save("INKBOX_REALTIME_ENABLED", "false")
+    if authority_mode:
+        _save("INKBOX_VOICE_AI_AUTHORITY_MODE", authority_mode)
+    _save("INKBOX_VOICE_STACK", stack.value)
+
+
+def _configure_phone_call_voice_stack(
+    identity: Any,
+    *,
+    base_url: str,
+    Inkbox: Any,
+    InkboxAPIError: Any,
+    WhoamiApiKeyResponse: Any,
+    ADMIN_SCOPED: Any,
+    imessage_enabled: bool = False,
+    authority_identity: Any | None = None,
+) -> None:
+    if getattr(identity, "phone_number", None) is None and not imessage_enabled:
+        return
+    print()
+    print(color("  --- Phone call voice stack ---", Colors.CYAN))
+    detected = _detect_openai_realtime_key()
+    detected_key = detected[1] if detected else ""
+    default_index = _voice_stack_default_index(detected_key)
+    prompt_for_key = False
+    while True:
+        selected = prompt_choice(
+            "  Choose how this agent should handle phone calls:",
+            [description for _, description in VOICE_STACK_CHOICES],
+            default_index,
+        )
+        stack = VOICE_STACK_CHOICES[selected][0]
+        default_index = selected
+        if stack is VoiceStack.INKBOX_VOICE_AI:
+            ok, authority_identity, authority = _configure_voice_ai(
+                identity,
+                base_url=base_url,
+                Inkbox=Inkbox,
+                InkboxAPIError=InkboxAPIError,
+                WhoamiApiKeyResponse=WhoamiApiKeyResponse,
+                ADMIN_SCOPED=ADMIN_SCOPED,
+                authority_identity=authority_identity,
+            )
+            if not ok:
+                continue
+            _save_voice_stack(stack, authority_mode=authority)
+            print_success("  Inkbox Voice AI is configured for phone calls.")
+            print_info("  Claude Code will be notified when each call ends.")
+            return
+        if stack is VoiceStack.OPENAI_REALTIME:
+            key = ""
+            if detected_key and not prompt_for_key:
+                key = detected_key
+                print_success(f"  Found an OpenAI API key in {detected[0]}.")
+            else:
+                key = prompt("  Paste your OpenAI API key for Realtime calls", password=True).strip()
+            if not key:
+                print_warning("  No key entered. Returning to the voice-stack choices.")
+                prompt_for_key = True
+                continue
+            print_info(f"  Testing OpenAI Realtime access with {REALTIME_MODEL}...")
+            ok, detail = _test_openai_realtime_api_key(key, REALTIME_MODEL)
+            if not ok:
+                print_error("  OpenAI Realtime validation failed.")
+                print_info(f"  {detail}")
+                detected_key = ""
+                prompt_for_key = True
+                continue
+            try:
+                _set_local_incoming_call_action(identity)
+            except Exception as exc:
+                print_error(f"  Could not configure incoming calls: {exc}")
+                continue
+            _save_voice_stack(stack, realtime_api_key=key)
+            print_success("  OpenAI Realtime is configured for phone calls.")
+            return
+        try:
+            _set_local_incoming_call_action(identity)
+        except Exception as exc:
+            print_error(f"  Could not configure incoming calls: {exc}")
+            continue
+        _save_voice_stack(stack)
+        print_success("  Inkbox TTS/STT is configured for phone calls.")
+        return
+
+
 # ----------------------------------------------------------------------
 # iMessage
 # ----------------------------------------------------------------------
@@ -1320,7 +1653,7 @@ def _api_key_flow(
     AGENT_CLAIMED: Any,
     AGENT_UNCLAIMED: Any,
     IdentityPhoneNumberCreateOptions: Any,
-) -> tuple[Any | None, str, bool]:
+) -> tuple[Any | None, str, bool, Any | None]:
     """Validate an operator-supplied API key and resolve its identity.
 
     Args:
@@ -1334,15 +1667,17 @@ def _api_key_flow(
         IdentityPhoneNumberCreateOptions (Any): Phone-options type for creates.
 
     Returns:
-        tuple[Any | None, str, bool]: (identity-or-None, api_key,
+        tuple[Any | None, str, bool, Any | None]: (identity-or-None, api_key,
         did_provision_phone — always False now that number provisioning is a
-        standalone later step).
+        standalone later step, admin-backed identity-or-None). The admin
+        object is retained in memory only so setup can update authority
+        without asking for the same credential twice.
     """
     print()
     api_key = prompt("  Paste your Inkbox API key (ApiKey_...)", password=True).strip()
     if not api_key:
         print_error("  No key provided.")
-        return None, "", False
+        return None, "", False, None
 
     try:
         client = Inkbox(**inkbox_client_kwargs(api_key, base_url))
@@ -1350,14 +1685,14 @@ def _api_key_flow(
     except InkboxAPIError as exc:
         print_error(f"  whoami failed: HTTP {_error_status(exc)} {_error_detail(exc)}")
         print_info("  Double-check the key and the environment it was issued in.")
-        return None, "", False
+        return None, "", False, None
     except Exception as exc:
         print_error(f"  whoami failed: {exc}")
-        return None, "", False
+        return None, "", False, None
 
     if WhoamiApiKeyResponse is not None and not isinstance(info, WhoamiApiKeyResponse):
         print_error("  This wizard requires an API key, but the credential is a JWT.")
-        return None, "", False
+        return None, "", False, None
 
     subtype = _enum_value(getattr(info, "auth_subtype", ""))
     org_id = getattr(info, "organization_id", "")
@@ -1366,13 +1701,17 @@ def _api_key_flow(
     # Agent-scoped keys already point at one identity; admin keys can list,
     # pick, or create, then get scoped down to a per-agent key.
     if subtype in {_enum_value(AGENT_CLAIMED), _enum_value(AGENT_UNCLAIMED)}:
-        return _pick_agent_scoped(client, api_key)
+        identity, agent_key, provisioned = _pick_agent_scoped(client, api_key)
+        return identity, agent_key, provisioned, None
     if subtype == _enum_value(ADMIN_SCOPED):
-        return _pick_admin_scoped(client, api_key, IdentityPhoneNumberCreateOptions, InkboxAPIError)
+        identity, agent_key, provisioned = _pick_admin_scoped(
+            client, api_key, IdentityPhoneNumberCreateOptions, InkboxAPIError
+        )
+        return identity, agent_key, provisioned, identity
 
     print_error(f"  Unsupported API-key subtype: {subtype!r}.")
     print_info("  Use an admin-scoped or agent-scoped Inkbox API key.")
-    return None, "", False
+    return None, "", False, None
 
 
 def _pick_agent_scoped(client: Any, api_key: str) -> tuple[Any | None, str, bool]:
@@ -1828,10 +2167,11 @@ def interactive_setup() -> None:
 
     if not has_key:
         identity, api_key, _ = _self_signup_flow(base_url, Inkbox, InkboxAPIError)
+        authority_identity = None
         if identity is None:
             return
     else:
-        identity, api_key, _ = _api_key_flow(
+        identity, api_key, _, authority_identity = _api_key_flow(
             base_url,
             Inkbox,
             InkboxAPIError,
@@ -1873,6 +2213,9 @@ def interactive_setup() -> None:
     try:
         dedicated_client = Inkbox(**inkbox_client_kwargs(api_key, base_url))
         identity, did_provision_phone = _offer_dedicated_number(dedicated_client, identity)
+        # Refresh even when number provisioning was skipped: self-signup may
+        # return a minimal identity shim that has no hosted-call methods.
+        identity = dedicated_client.get_identity(identity.agent_handle)
     except Exception as exc:
         print_warning(f"  Skipping dedicated-number setup: {exc}")
 
@@ -1884,7 +2227,16 @@ def interactive_setup() -> None:
     if did_provision_phone:
         _wait_for_sms_opt_in(api_key, base_url, getattr(identity, "phone_number", None), Inkbox)
 
-    _configure_realtime_calls(identity, imessage_enabled=imessage_on)
+    _configure_phone_call_voice_stack(
+        identity,
+        base_url=base_url,
+        Inkbox=Inkbox,
+        InkboxAPIError=InkboxAPIError,
+        WhoamiApiKeyResponse=WhoamiApiKeyResponse,
+        ADMIN_SCOPED=ADMIN_SCOPED,
+        imessage_enabled=imessage_on,
+        authority_identity=authority_identity,
+    )
 
     _setup_signing_key(api_key, base_url, Inkbox)
 

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -26,19 +26,19 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
     from media import file_to_email_attachment
 
 try:
-    from .config import BridgeConfig, INKBOX_WS_PATH, VoiceStack, call_contexts_dir
     from .a2a_delegations import (
         find_by_task,
         promote_after_send,
         record_before_send,
     )
+    from .config import INKBOX_WS_PATH, BridgeConfig, VoiceStack, call_contexts_dir
 except ImportError:  # pragma: no cover - direct local import/test fallback
-    from config import BridgeConfig, INKBOX_WS_PATH, VoiceStack, call_contexts_dir
     from a2a_delegations import (
         find_by_task,
         promote_after_send,
         record_before_send,
     )
+    from config import INKBOX_WS_PATH, BridgeConfig, VoiceStack, call_contexts_dir
 
 try:
     from claude_agent_sdk import create_sdk_mcp_server, tool
@@ -99,6 +99,14 @@ def _mark_tool_delivery(mode: str, target: str) -> None:
     mark = getattr(session, "mark_tool_delivery", None)
     if callable(mark):
         mark(mode, target)
+
+
+def _mark_tool_failure(mode: str, target: str, error: Any) -> None:
+    """Tell the active session that a host-native send tool failed."""
+    session = CURRENT_SESSION.get()
+    mark = getattr(session, "mark_tool_failure", None)
+    if callable(mark):
+        mark(mode, target, error)
 
 
 def _current_channel_hint() -> Optional[str]:
@@ -396,8 +404,10 @@ def build_inkbox_mcp_server(
         text = str(args.get("text") or "")
         target = str(args.get("to") or "").strip()
         if len(text) > SMS_MAX_LENGTH:
+            reason = _message_too_long_reason("SMS", text, SMS_MAX_LENGTH)
+            _mark_tool_failure("sms", target, reason)
             return _error(
-                _message_too_long_reason("SMS", text, SMS_MAX_LENGTH),
+                reason,
                 error_code="sms_too_long",
                 char_count=len(text),
                 max_chars=SMS_MAX_LENGTH,
@@ -424,6 +434,7 @@ def build_inkbox_mcp_server(
             _mark_tool_delivery("sms", target)
             return _result(result)
         except Exception as exc:
+            _mark_tool_failure("sms", target, exc)
             _log_send_rejection("inkbox_send_sms", exc)
             return _error(str(exc))
 

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -109,6 +109,19 @@ def _mark_tool_failure(mode: str, target: str, error: Any) -> None:
         mark(mode, target, error)
 
 
+class _HostedSMSPreflightError(RuntimeError):
+    """A trusted hosted-call guard rejected a send before provider I/O."""
+
+    error_code = "forbidden"
+
+
+def _hosted_sms_preflight(target: str) -> Optional[Dict[str, str]]:
+    """Ask the active hosted turn to reserve this send before provider I/O."""
+    session = CURRENT_SESSION.get()
+    preflight = getattr(session, "preflight_hosted_sms", None)
+    return preflight(target) if callable(preflight) else None
+
+
 def _current_channel_hint() -> Optional[str]:
     """Which Inkbox channel is the current agent turn happening on?
 
@@ -403,6 +416,16 @@ def build_inkbox_mcp_server(
     async def inkbox_send_sms(args: Dict[str, Any]) -> Dict[str, Any]:
         text = str(args.get("text") or "")
         target = str(args.get("to") or "").strip()
+        blocked = _hosted_sms_preflight(target)
+        if blocked:
+            message = str(blocked.get("message") or "Hosted-call SMS send blocked.")
+            if blocked.get("kind") == "terminal":
+                _mark_tool_failure(
+                    "sms",
+                    target,
+                    _HostedSMSPreflightError(message),
+                )
+            return _error(message, error_code="hosted_sms_send_blocked")
         if len(text) > SMS_MAX_LENGTH:
             reason = _message_too_long_reason("SMS", text, SMS_MAX_LENGTH)
             _mark_tool_failure("sms", target, reason)

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -26,14 +26,14 @@ except ImportError:  # pragma: no cover - direct local import/test fallback
     from media import file_to_email_attachment
 
 try:
-    from .config import INKBOX_WS_PATH, call_contexts_dir
+    from .config import BridgeConfig, INKBOX_WS_PATH, VoiceStack, call_contexts_dir
     from .a2a_delegations import (
         find_by_task,
         promote_after_send,
         record_before_send,
     )
 except ImportError:  # pragma: no cover - direct local import/test fallback
-    from config import INKBOX_WS_PATH, call_contexts_dir
+    from config import BridgeConfig, INKBOX_WS_PATH, VoiceStack, call_contexts_dir
     from a2a_delegations import (
         find_by_task,
         promote_after_send,
@@ -271,12 +271,36 @@ def _write_call_context(
     return token
 
 
-def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, List[str]]:
+def _hosted_call_reason(args: Dict[str, Any]) -> str:
+    """Build a bounded, useful Voice AI task from the local-call inputs."""
+    parts = [
+        str(args.get("purpose") or "").strip(),
+        (
+            f"Opening guidance: {str(args.get('opening_message') or '').strip()}"
+            if str(args.get("opening_message") or "").strip()
+            else ""
+        ),
+        (
+            f"Additional context: {str(args.get('context') or '').strip()}"
+            if str(args.get("context") or "").strip()
+            else ""
+        ),
+    ]
+    reason = "\n\n".join(part for part in parts if part)
+    return reason if len(reason) <= 2_000 else reason[:1_999].rstrip() + "…"
+
+
+def build_inkbox_mcp_server(
+    client: Any,
+    identity_handle: str,
+    cfg: Optional[BridgeConfig] = None,
+) -> Tuple[Any, List[str]]:
     """Build the in-process MCP server carrying the Inkbox tools.
 
     Args:
         client (Inkbox): Authenticated Inkbox SDK client.
         identity_handle (str): Agent identity handle the tools act as.
+        cfg (Optional[BridgeConfig]): Runtime voice-stack policy.
 
     Returns:
         Tuple[Any, List[str]]: (sdk mcp server, fully-qualified tool names
@@ -284,6 +308,7 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
     """
     if not CLAUDE_SDK_AVAILABLE:
         raise RuntimeError("claude-agent-sdk is not installed")
+    cfg = cfg or BridgeConfig()
 
     def _identity():
         return client.get_identity(identity_handle)
@@ -473,8 +498,8 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         'shared iMessage line (origination "shared_imessage_number"; only works '
         "if they are connected to you over iMessage, otherwise the call is "
         "rejected). If origination is omitted it is resolved automatically. The "
-        "call's audio bridges to the running gateway. Always pass purpose so the "
-        "live call opens with context; optionally pass opening_message, context, "
+        "configured phone-call voice stack handles the call. Always pass purpose "
+        "so the live call or hosted agent knows why it is calling; optionally pass opening_message, context, "
         "and voicemail_detection (enabled or disabled).",
         {
             "to_number": str,
@@ -496,7 +521,7 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
                     "purpose is required so the live call opens with context"
                 )
             voicemail_detection = str(
-                args.get("voicemail_detection") or ""
+                args.get("voicemail_detection") or cfg.voicemail_detection
             ).strip().lower()
             if voicemail_detection not in {"", "enabled", "disabled"}:
                 raise ValueError(
@@ -514,6 +539,37 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
                     "number and iMessage is not enabled. Provision a number or "
                     "enable iMessage first."
                 )
+
+            if cfg.voice_stack_invalid_value:
+                raise RuntimeError(
+                    f"invalid INKBOX_VOICE_STACK={cfg.voice_stack_invalid_value!r}; rerun setup"
+                )
+            hosted = cfg.voice_stack is VoiceStack.INKBOX_VOICE_AI
+            if hosted:
+                call = identity.place_call(
+                    to_number=to_number,
+                    origination=origination,
+                    mode="hosted_agent",
+                    reason=_hosted_call_reason(args),
+                    voicemail_detection=voicemail_detection,
+                )
+                record = getattr(call, "call", None) or call
+                return {
+                    "placed": True,
+                    "id": str(getattr(record, "id", "")),
+                    "to": to_number,
+                    "origination": origination,
+                    "mode": str(getattr(getattr(record, "mode", ""), "value", getattr(record, "mode", "")) or "hosted_agent"),
+                    "hosted_agent_authority_mode": str(
+                        getattr(
+                            getattr(record, "hosted_agent_authority_mode", ""),
+                            "value",
+                            getattr(record, "hosted_agent_authority_mode", ""),
+                        ) or ""
+                    ),
+                    "voicemail_detection": voicemail_detection,
+                    "status": _json_safe(getattr(record, "status", None)),
+                }
 
             phone = getattr(identity, "phone_number", None)
             ws_url = str(getattr(phone, "client_websocket_url", "") or "").strip()
@@ -538,24 +594,21 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
                 "to_number": to_number,
                 "origination": origination,
                 "client_websocket_url": ws_url,
+                "mode": "client_websocket",
+                "voicemail_detection": voicemail_detection,
             }
-            if voicemail_detection:
-                call_kwargs["voicemail_detection"] = voicemail_detection
             try:
                 call = identity.place_call(**call_kwargs)
             except TypeError:
-                if voicemail_detection:
-                    raise RuntimeError(
-                        "voicemail_detection requires inkbox SDK 0.5.8 or newer"
-                    )
-                # Older SDK without ``origination`` support → dedicated only.
-                call = identity.place_call(to_number=to_number, client_websocket_url=ws_url)
+                raise RuntimeError("phone call voice stacks require inkbox SDK 0.5.9 or newer")
             return {
                 "placed": True,
                 "id": str(getattr(call, "id", "")),
                 "to": to_number,
                 "origination": origination,
                 "context_token": token,
+                "mode": "client_websocket",
+                "voicemail_detection": voicemail_detection,
                 "status": _json_safe(getattr(call, "status", None)),
             }
 
@@ -1098,7 +1151,7 @@ def build_inkbox_mcp_server(client: Any, identity_handle: str) -> Tuple[Any, Lis
         inkbox_a2a_ask_caller,
         inkbox_a2a_fail,
     ]
-    server = create_sdk_mcp_server(name="inkbox", version="0.2.7", tools=tools)
+    server = create_sdk_mcp_server(name="inkbox", version="0.2.8", tools=tools)
     tool_names = [
         "mcp__inkbox__inkbox_whoami",
         "mcp__inkbox__inkbox_send_email",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "claude-code-plugin"
-version = "0.2.7"
+version = "0.2.8"
 description = "Inkbox bridge for Claude Code — talk to your coding agent over email, SMS, iMessage, and voice"
 requires-python = ">=3.11"
 dependencies = [
   "aiohttp>=3.9",
-  "inkbox>=0.5.8,<1.0.0",
+  "inkbox>=0.5.9,<1.0.0",
   "claude-agent-sdk>=0.1.0",
   "segno>=1.5",  # terminal QR codes for the iMessage connect step
 ]

--- a/tests/live/test_cross_channel.py
+++ b/tests/live/test_cross_channel.py
@@ -29,6 +29,7 @@ import os
 import re
 import time
 import uuid
+from datetime import UTC, datetime
 
 import pytest
 
@@ -38,6 +39,8 @@ BASE_URL = os.environ.get("INKBOX_BASE_URL", "https://inkbox.ai")
 REAL = os.environ.get("LIVE_REAL_MODEL") == "1"
 TIMEOUT_S = float(os.environ.get("LIVE_XCHANNEL_TIMEOUT", "200"))
 POLL_EVERY_S = 6.0
+CALL_PAIR_MAX_S = 60.0
+CALL_DUPLICATE_GRACE_S = 2 * POLL_EVERY_S
 
 pytestmark = pytest.mark.skipif(
     not (REMOTE_KEY and AUT_KEY and REAL),
@@ -52,6 +55,19 @@ def _digits(s: str) -> str:
 def _voicemail_detection_value(call) -> str:
     value = getattr(call, "voicemail_detection", "")
     return str(getattr(value, "value", value))
+
+
+def _record_created_at(record):
+    value = getattr(record, "created_at", None)
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
 
 
 def _client(key):
@@ -110,7 +126,8 @@ def xc():
     try:
         yield {
             "remote": remote, "aut": aut,
-            "remote_email": remote_email, "remote_pid": remote_pid,
+            "remote_email": remote_email, "remote_phone": remote_phone,
+            "remote_pid": remote_pid,
             "aut_email": aut_email, "aut_phone": aut_phone,
         }
     finally:
@@ -180,19 +197,99 @@ def _inbound_calls_from_aut(remote, remote_pid: str, aut_phone: str):
             and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
 
 
-def _wait_for_new_call(remote, remote_pid: str, aut_phone: str, before: set):
-    """Block until an inbound call from the AUT with an id not in ``before`` appears.
+def _outbound_calls_to_remote(aut, remote_phone: str):
+    """The AUT's outbound records targeting the driver's number."""
+    tail = _digits(remote_phone)[-10:]
+    return [c for c in aut.calls.list(limit=30)
+            if (getattr(c, "direction", "") or "").lower() == "outbound"
+            and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
 
-    ``before`` is the pre-request snapshot, so a stale call can't satisfy the
-    assertion — same new-id correlation the SMS/email legs use. Fails on timeout.
-    """
+
+def _fresh_calls(records, before: set, watermark: datetime):
+    return [
+        record for record in records
+        if record.id not in before
+        and (created_at := _record_created_at(record)) is not None
+        and created_at >= watermark
+    ]
+
+
+def _wait_for_new_call_pair(
+    remote,
+    aut,
+    *,
+    remote_pid: str,
+    remote_phone: str,
+    aut_phone: str,
+    before_driver: set,
+    before_aut: set,
+    driver_watermark: datetime,
+    aut_watermark: datetime,
+):
+    """Correlate one fresh driver inbound leg with one fresh AUT outbound leg."""
     deadline = time.monotonic() + TIMEOUT_S
     while time.monotonic() < deadline:
-        for c in _inbound_calls_from_aut(remote, remote_pid, aut_phone):
-            if c.id not in before:
-                return c  # a fresh call from the AUT landed on the driver's number
+        driver_calls = _fresh_calls(
+            _inbound_calls_from_aut(remote, remote_pid, aut_phone),
+            before_driver,
+            driver_watermark,
+        )
+        aut_calls = _fresh_calls(
+            _outbound_calls_to_remote(aut, remote_phone),
+            before_aut,
+            aut_watermark,
+        )
+        assert len(driver_calls) <= 1, f"duplicate driver call legs: {driver_calls!r}"
+        assert len(aut_calls) <= 1, f"duplicate AUT call legs: {aut_calls!r}"
+        if driver_calls and aut_calls:
+            driver_created = _record_created_at(driver_calls[0])
+            aut_created = _record_created_at(aut_calls[0])
+            assert driver_created is not None and aut_created is not None
+            assert abs((driver_created - aut_created).total_seconds()) <= CALL_PAIR_MAX_S
+            break
         time.sleep(POLL_EVERY_S)
-    pytest.fail(f"agent did not place a call to the driver within {TIMEOUT_S:.0f}s")
+    else:
+        pytest.fail(
+            f"agent did not persist both call legs within {TIMEOUT_S:.0f}s"
+        )
+
+    time.sleep(CALL_DUPLICATE_GRACE_S)
+    driver_calls = _fresh_calls(
+        _inbound_calls_from_aut(remote, remote_pid, aut_phone),
+        before_driver,
+        driver_watermark,
+    )
+    aut_calls = _fresh_calls(
+        _outbound_calls_to_remote(aut, remote_phone),
+        before_aut,
+        aut_watermark,
+    )
+    assert len(driver_calls) == 1, f"expected one fresh driver leg, got {driver_calls!r}"
+    assert len(aut_calls) == 1, f"expected one fresh AUT leg, got {aut_calls!r}"
+    return aut_calls[0]
+
+
+def _call_pair_snapshot(remote, aut, remote_pid, remote_phone, aut_phone):
+    driver_calls = _inbound_calls_from_aut(remote, remote_pid, aut_phone)
+    aut_calls = _outbound_calls_to_remote(aut, remote_phone)
+    driver_times = [
+        value for call in driver_calls
+        if (value := _record_created_at(call)) is not None
+    ]
+    aut_times = [
+        value for call in aut_calls
+        if (value := _record_created_at(call)) is not None
+    ]
+    return {
+        "before_driver": {call.id for call in driver_calls},
+        "before_aut": {call.id for call in aut_calls},
+        "driver_watermark": max(
+            driver_times, default=datetime.min.replace(tzinfo=UTC)
+        ),
+        "aut_watermark": max(
+            aut_times, default=datetime.min.replace(tzinfo=UTC)
+        ),
+    }
 
 
 # The driver auto-rejects these call probes so they cannot leak into the voice
@@ -213,10 +310,11 @@ def _reset_aut_session(remote, remote_pid: str, aut_phone: str) -> None:
 
 def test_email_request_gets_call(xc):
     """Email asks the agent to CALL; a new inbound call must land on the driver."""
-    remote, remote_pid, aut_phone = xc["remote"], xc["remote_pid"], xc["aut_phone"]
+    remote, aut = xc["remote"], xc["aut"]
+    remote_pid, remote_phone = xc["remote_pid"], xc["remote_phone"]
+    aut_phone = xc["aut_phone"]
     _reset_aut_session(remote, remote_pid, aut_phone)  # fresh session, no prior-call context
-    # Snapshot BEFORE sending so a pre-existing call can't be mistaken for the reply.
-    before = {c.id for c in _inbound_calls_from_aut(remote, remote_pid, aut_phone)}
+    snapshot = _call_pair_snapshot(remote, aut, remote_pid, remote_phone, aut_phone)
     remote.messages.send(
         xc["remote_email"], to=[xc["aut_email"]], subject="please call me",
         body_text=(
@@ -224,15 +322,21 @@ def test_email_request_gets_call(xc):
             "voicemail_detection disabled — I'd rather talk than type."
         ),
     )
-    call = _wait_for_new_call(remote, remote_pid, aut_phone, before)
+    call = _wait_for_new_call_pair(
+        remote, aut,
+        remote_pid=remote_pid, remote_phone=remote_phone, aut_phone=aut_phone,
+        **snapshot,
+    )
     assert _voicemail_detection_value(call) == "disabled"
 
 
 def test_sms_request_gets_call(xc):
     """SMS asks the agent to CALL; a new inbound call must land on the driver."""
-    remote, remote_pid, aut_phone = xc["remote"], xc["remote_pid"], xc["aut_phone"]
+    remote, aut = xc["remote"], xc["aut"]
+    remote_pid, remote_phone = xc["remote_pid"], xc["remote_phone"]
+    aut_phone = xc["aut_phone"]
     _reset_aut_session(remote, remote_pid, aut_phone)  # fresh session, no prior-call context
-    before = {c.id for c in _inbound_calls_from_aut(remote, remote_pid, aut_phone)}
+    snapshot = _call_pair_snapshot(remote, aut, remote_pid, remote_phone, aut_phone)
     # Be explicit that we want an actual dial — a terse "call me" lets the model
     # answer by text; the email leg's wording is unambiguous, so match it here.
     # Fresh body each send: the agent replies by calling, not texting, so this
@@ -246,5 +350,9 @@ def test_sms_request_gets_call(xc):
             f"(ref {_token()})"
         ),
     )
-    call = _wait_for_new_call(remote, remote_pid, aut_phone, before)
+    call = _wait_for_new_call_pair(
+        remote, aut,
+        remote_pid=remote_pid, remote_phone=remote_phone, aut_phone=aut_phone,
+        **snapshot,
+    )
     assert _voicemail_detection_value(call) == "disabled"

--- a/tests/live/test_cross_channel.py
+++ b/tests/live/test_cross_channel.py
@@ -49,6 +49,11 @@ def _digits(s: str) -> str:
     return re.sub(r"\D", "", s or "")
 
 
+def _voicemail_detection_value(call) -> str:
+    value = getattr(call, "voicemail_detection", "")
+    return str(getattr(value, "value", value))
+
+
 def _client(key):
     from inkbox import Inkbox
 
@@ -185,7 +190,7 @@ def _wait_for_new_call(remote, remote_pid: str, aut_phone: str, before: set):
     while time.monotonic() < deadline:
         for c in _inbound_calls_from_aut(remote, remote_pid, aut_phone):
             if c.id not in before:
-                return  # a fresh call from the AUT landed on the driver's number
+                return c  # a fresh call from the AUT landed on the driver's number
         time.sleep(POLL_EVERY_S)
     pytest.fail(f"agent did not place a call to the driver within {TIMEOUT_S:.0f}s")
 
@@ -219,7 +224,8 @@ def test_email_request_gets_call(xc):
             "voicemail_detection disabled — I'd rather talk than type."
         ),
     )
-    _wait_for_new_call(remote, remote_pid, aut_phone, before)
+    call = _wait_for_new_call(remote, remote_pid, aut_phone, before)
+    assert _voicemail_detection_value(call) == "disabled"
 
 
 def test_sms_request_gets_call(xc):
@@ -240,4 +246,5 @@ def test_sms_request_gets_call(xc):
             f"(ref {_token()})"
         ),
     )
-    _wait_for_new_call(remote, remote_pid, aut_phone, before)
+    call = _wait_for_new_call(remote, remote_pid, aut_phone, before)
+    assert _voicemail_detection_value(call) == "disabled"

--- a/tests/live/test_email_intelligence.py
+++ b/tests/live/test_email_intelligence.py
@@ -220,8 +220,8 @@ def test_reports_sender_details(ctx):
         ctx["aut_email"],
         remote_email,
         "Who am I to you? Tell me everything you have on file about me. "
-        "Include my phone number in full — every digit, with no masking, "
-        "asterisks, or abbreviation.",
+        "Include my email address and phone number in full — every character "
+        "and digit, with no masking, asterisks, or abbreviation.",
         accept=lambda candidate: (
             (not name or name.lower() in candidate)
             and any(e.lower() in candidate for e in emails)

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -264,7 +264,6 @@ def test_outbound_call_hosted_and_post_call_wakeup():
     aut_numbers = aut.phone_numbers.list()
     assert aut_numbers, "AUT identity has no phone number"
     aut_phone = aut_numbers[0].number
-    aut_number_id = str(aut_numbers[0].id)
     tail = _digits(aut_phone)[-10:]
 
     def _inbound_calls():
@@ -279,14 +278,14 @@ def test_outbound_call_hosted_and_post_call_wakeup():
                 if (getattr(c, "direction", "") or "").lower() == "outbound"
                 and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == driver_tail]
 
-    def _aut_outbound_texts():
-        return [m for m in aut.texts.list(aut_number_id, limit=30)
-                if (getattr(m, "direction", "") or "").lower() == "outbound"
-                and _digits(getattr(m, "remote_phone_number", "") or "")[-10:] == driver_tail]
+    def _driver_inbound_texts():
+        return [m for m in remote.texts.list(st["number_id"], limit=200)
+                if (getattr(m, "direction", "") or "").lower() == "inbound"
+                and _digits(getattr(m, "remote_phone_number", "") or "")[-10:] == tail]
 
     before_calls = {c.id for c in _inbound_calls()}
     before_outbound = {c.id for c in _outbound_calls()}
-    before_texts = {m.id for m in _aut_outbound_texts()}
+    before_texts = {m.id for m in _driver_inbound_texts()}
     remote.texts.send(st["number_id"], to=aut_phone, text=_call_me_text())
 
     call_id = None
@@ -321,7 +320,7 @@ def test_outbound_call_hosted_and_post_call_wakeup():
     delivered = []
     while time.monotonic() < deadline:
         delivered = [
-            message for message in _aut_outbound_texts()
+            message for message in _driver_inbound_texts()
             if message.id not in before_texts
             and HOSTED_POST_CALL_MARKER in (message.text or "")
         ]
@@ -336,7 +335,7 @@ def test_outbound_call_hosted_and_post_call_wakeup():
     # captured model reply must not leak onto the requesting channel.
     time.sleep(2 * POLL_EVERY_S)
     new_texts = [
-        message for message in _aut_outbound_texts()
+        message for message in _driver_inbound_texts()
         if message.id not in before_texts
     ]
     assert len(new_texts) == 1, (

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -264,6 +264,7 @@ def test_outbound_call_hosted_and_post_call_wakeup():
     aut_numbers = aut.phone_numbers.list()
     assert aut_numbers, "AUT identity has no phone number"
     aut_phone = aut_numbers[0].number
+    aut_number_id = str(aut_numbers[0].id)
     tail = _digits(aut_phone)[-10:]
 
     def _inbound_calls():
@@ -278,14 +279,14 @@ def test_outbound_call_hosted_and_post_call_wakeup():
                 if (getattr(c, "direction", "") or "").lower() == "outbound"
                 and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == driver_tail]
 
-    def _driver_inbound_texts():
-        return [m for m in remote.texts.list(st["number_id"], limit=200)
-                if (getattr(m, "direction", "") or "").lower() == "inbound"
-                and _digits(getattr(m, "remote_phone_number", "") or "")[-10:] == tail]
+    def _aut_outbound_texts():
+        return [m for m in aut.texts.list(aut_number_id, limit=200)
+                if (getattr(m, "direction", "") or "").lower() == "outbound"
+                and _digits(getattr(m, "remote_phone_number", "") or "")[-10:] == driver_tail]
 
     before_calls = {c.id for c in _inbound_calls()}
     before_outbound = {c.id for c in _outbound_calls()}
-    before_texts = {m.id for m in _driver_inbound_texts()}
+    before_texts = {m.id for m in _aut_outbound_texts()}
     remote.texts.send(st["number_id"], to=aut_phone, text=_call_me_text())
 
     call_id = None
@@ -320,7 +321,7 @@ def test_outbound_call_hosted_and_post_call_wakeup():
     delivered = []
     while time.monotonic() < deadline:
         delivered = [
-            message for message in _driver_inbound_texts()
+            message for message in _aut_outbound_texts()
             if message.id not in before_texts
             and HOSTED_POST_CALL_MARKER in (message.text or "")
         ]
@@ -335,7 +336,7 @@ def test_outbound_call_hosted_and_post_call_wakeup():
     # captured model reply must not leak onto the requesting channel.
     time.sleep(2 * POLL_EVERY_S)
     new_texts = [
-        message for message in _driver_inbound_texts()
+        message for message in _aut_outbound_texts()
         if message.id not in before_texts
     ]
     assert len(new_texts) == 1, (

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -1,12 +1,14 @@
 """Live voice-call suite — real phone calls, real model, transcript-verified.
 
-Two scenarios, each run against a bridge booted in the matching speech mode (the
+Three scenarios, each run against a bridge booted in the matching speech mode (the
 workflow sets that up and selects the scenario via VOICE_SCENARIO):
 
   * inbound_inkbox   — the driver calls the agent; the agent answers with Inkbox
                        STT/TTS and holds a turn.
   * outbound_realtime — the driver texts "call me"; the agent places a call back,
                        powered by the realtime API, and holds a turn.
+  * outbound_hosted — the driver texts "call me"; Inkbox Voice AI runs the call,
+                      then call.ended wakes Claude Code to perform one action.
 
 A companion driver process (voice_driver.py) bridges the driver's side of the call
 over an Inkbox tunnel and speaks one line. We then read the stored call transcript
@@ -46,6 +48,7 @@ AUT_KEY = os.environ.get("CLAUDE_CODE_INKBOX_API_KEY")
 BASE_URL = os.environ.get("INKBOX_BASE_URL", "https://inkbox.ai")
 REAL = os.environ.get("LIVE_REAL_MODEL") == "1"
 SCENARIO = os.environ.get("VOICE_SCENARIO", "")
+HOSTED_POST_CALL_MARKER = os.environ.get("HOSTED_POST_CALL_MARKER", "")
 STATE_FILE = os.environ.get("VOICE_DRIVER_STATE", "/tmp/voice_driver_state.json")
 TIMEOUT_S = float(os.environ.get("LIVE_VOICE_TIMEOUT", "220"))
 POLL_EVERY_S = 6.0
@@ -238,3 +241,53 @@ def test_outbound_call_realtime():
             f"outbound call must be powered by the realtime API (Inkbox speech off), got tts={tts} stt={stt}"
     finally:
         _hangup_call(remote, call_id)
+
+
+@pytest.mark.skipif(SCENARIO != "outbound_hosted", reason="outbound Voice AI leg only")
+def test_outbound_call_hosted_and_post_call_wakeup():
+    """Voice AI runs the call; Claude executes its open action after call.ended."""
+    assert HOSTED_POST_CALL_MARKER, "HOSTED_POST_CALL_MARKER is required"
+    st = _driver_state()
+    remote, aut = _client(REMOTE_KEY), _client(AUT_KEY)
+    aut_phone = _aut_phone(aut)
+    tail = _digits(aut_phone)[-10:]
+
+    def _inbound_calls():
+        return [c for c in remote.calls.list(limit=30)
+                if (getattr(c, "direction", "") or "").lower() == "inbound"
+                and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
+
+    def _inbound_texts():
+        return [m for m in remote.texts.list(st["number_id"], limit=30)
+                if (getattr(m, "direction", "") or "").lower() == "inbound"
+                and _digits(getattr(m, "remote_phone_number", "") or "")[-10:] == tail]
+
+    before_calls = {c.id for c in _inbound_calls()}
+    before_texts = {m.id for m in _inbound_texts()}
+    remote.texts.send(st["number_id"], to=aut_phone, text=_call_me_text())
+
+    call_id = None
+    try:
+        deadline = time.monotonic() + TIMEOUT_S
+        while time.monotonic() < deadline:
+            fresh = [c for c in _inbound_calls() if c.id not in before_calls]
+            if fresh:
+                call_id = fresh[0].id
+                break
+            time.sleep(POLL_EVERY_S)
+        assert call_id, f"agent never placed a hosted call within {TIMEOUT_S:.0f}s"
+        _wait_for_two_way_call(remote, st["number_id"], call_id)
+
+        call = remote.calls.get(call_id)
+        assert str(getattr(getattr(call, "mode", ""), "value", getattr(call, "mode", ""))) == "hosted_agent"
+        assert str(getattr(getattr(call, "voicemail_detection", ""), "value", getattr(call, "voicemail_detection", ""))) == "disabled"
+    finally:
+        _hangup_call(remote, call_id)
+
+    deadline = time.monotonic() + TIMEOUT_S
+    while time.monotonic() < deadline:
+        for message in _inbound_texts():
+            if message.id not in before_texts and HOSTED_POST_CALL_MARKER in (message.text or ""):
+                return
+        time.sleep(POLL_EVERY_S)
+    pytest.fail("hosted call ended but Claude Code did not execute its post-call SMS action")

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -53,6 +53,14 @@ GATEWAY_LOG = os.environ.get("GATEWAY_LOG", "")
 STATE_FILE = os.environ.get("VOICE_DRIVER_STATE", "/tmp/voice_driver_state.json")
 TIMEOUT_S = float(os.environ.get("LIVE_VOICE_TIMEOUT", "220"))
 POLL_EVERY_S = 6.0
+HOSTED_POST_CALL_SETTLEMENT_S = 90.0
+HOSTED_DUPLICATE_GRACE_S = 2 * POLL_EVERY_S
+HOSTED_SCENARIO_TIMEOUT_S = (
+    TIMEOUT_S
+    + HOSTED_POST_CALL_SETTLEMENT_S
+    + HOSTED_DUPLICATE_GRACE_S
+    + POLL_EVERY_S
+)
 TERMINAL_FAILURE_STATUSES = {"canceled", "failed"}
 # A call can end normally and still never carry a conversation - answering-machine
 # detection hanging up on the driver ends it `completed`, hangup_reason=voicemail.
@@ -69,6 +77,14 @@ pytestmark = pytest.mark.skipif(
 
 def _digits(s: str) -> str:
     return re.sub(r"\D", "", s or "")
+
+
+def _enum_value(value) -> str:
+    return str(getattr(value, "value", value))
+
+
+def _voicemail_detection_value(call) -> str:
+    return _enum_value(getattr(call, "voicemail_detection", ""))
 
 
 def _spoken_tokens(value: str | None) -> list[str]:
@@ -331,6 +347,8 @@ def test_inbound_call_inkbox_tts_stt():
     try:
         agent_said = _wait_for_two_way_call(remote, st["number_id"], call.id)
         assert agent_said, "agent produced no speech on the inbound call"
+        persisted = remote.calls.get(call.id)
+        assert _voicemail_detection_value(persisted) == "disabled"
 
         tts, stt = _aut_speech_mode(aut, "inbound", st["number"])
         assert tts and stt, f"inbound call should run Inkbox STT/TTS, got tts={tts} stt={stt}"
@@ -365,6 +383,8 @@ def test_outbound_call_realtime():
                 break
             time.sleep(POLL_EVERY_S)
         assert call_id, f"agent never placed a call back within {TIMEOUT_S:.0f}s"
+        persisted = remote.calls.get(call_id)
+        assert _voicemail_detection_value(persisted) == "disabled"
 
         agent_said = _wait_for_two_way_call(remote, st["number_id"], call_id)
         assert agent_said, "agent produced no speech on the outbound call"
@@ -409,8 +429,26 @@ def test_outbound_call_hosted_and_post_call_wakeup():
             and driver_number in _sms_target_numbers(message)
         ]
 
-    before_calls = {c.id for c in _inbound_calls()}
-    before_outbound = {c.id for c in _outbound_calls()}
+    baseline_driver_calls = _inbound_calls()
+    baseline_aut_calls = _outbound_calls()
+    before_calls = {c.id for c in baseline_driver_calls}
+    before_outbound = {c.id for c in baseline_aut_calls}
+    driver_call_watermark = max(
+        (
+            created_at
+            for call in baseline_driver_calls
+            if (created_at := _message_created_at(call)) is not None
+        ),
+        default=datetime.min.replace(tzinfo=UTC),
+    )
+    aut_call_watermark = max(
+        (
+            created_at
+            for call in baseline_aut_calls
+            if (created_at := _message_created_at(call)) is not None
+        ),
+        default=datetime.min.replace(tzinfo=UTC),
+    )
     baseline_sms = _outbound_sms_to_driver()
     before_sms = {message.id for message in baseline_sms}
     baseline_times = [
@@ -426,33 +464,74 @@ def test_outbound_call_hosted_and_post_call_wakeup():
         "GATEWAY_LOG must expose the bridge's host-native tool settlement"
     )
     log_offset = os.path.getsize(GATEWAY_LOG)
-    hosted_deadline = time.monotonic() + TIMEOUT_S
+    identity_handle = aut.mailboxes.list()[0].email_address.split("@", 1)[0]
+    hosted_config = aut.get_identity(identity_handle).get_hosted_agent_config()
+    expected_authority = _enum_value(
+        getattr(hosted_config, "authority_mode", "contact_scoped")
+    ) or "contact_scoped"
+    scenario_deadline = time.monotonic() + HOSTED_SCENARIO_TIMEOUT_S
+    pre_hangup_deadline = (
+        scenario_deadline
+        - HOSTED_POST_CALL_SETTLEMENT_S
+        - HOSTED_DUPLICATE_GRACE_S
+        - POLL_EVERY_S
+    )
     remote.texts.send(st["number_id"], to=aut_phone, text=_call_me_text())
 
     call_id = None
+    placed = None
     try:
-        while time.monotonic() < hosted_deadline:
-            fresh = [c for c in _inbound_calls() if c.id not in before_calls]
-            if fresh:
-                call_id = fresh[0].id
+        while time.monotonic() < pre_hangup_deadline:
+            fresh_driver = [
+                call
+                for call in _inbound_calls()
+                if call.id not in before_calls
+                and (created_at := _message_created_at(call)) is not None
+                and created_at >= driver_call_watermark
+            ]
+            fresh_aut = [
+                call
+                for call in _outbound_calls()
+                if call.id not in before_outbound
+                and (created_at := _message_created_at(call)) is not None
+                and created_at >= aut_call_watermark
+            ]
+            if fresh_driver:
+                call_id = max(fresh_driver, key=_message_created_at).id
+            if fresh_aut:
+                placed = max(fresh_aut, key=_message_created_at)
+            if call_id and placed is not None:
                 break
             time.sleep(POLL_EVERY_S)
-        assert call_id, f"agent never placed a hosted call within {TIMEOUT_S:.0f}s"
+        assert call_id and placed is not None, (
+            "hosted call pairing did not find both fresh driver and AUT legs "
+            f"(driver_call_id={call_id!r}, aut_call_id={getattr(placed, 'id', None)!r})"
+        )
+        driver_call = remote.calls.get(call_id)
+        driver_created_at = _message_created_at(driver_call)
+        aut_created_at = _message_created_at(placed)
+        assert driver_created_at is not None and aut_created_at is not None
+        assert abs((driver_created_at - aut_created_at).total_seconds()) <= 60, (
+            "fresh driver and AUT records are not the same hosted call: "
+            f"driver_created_at={driver_created_at!r} "
+            f"aut_created_at={aut_created_at!r}"
+        )
         _wait_for_two_way_call(
             remote,
             st["number_id"],
             call_id,
-            deadline=hosted_deadline,
+            deadline=pre_hangup_deadline,
         )
 
         # A phone call has two independently handled legs. The driver's inbound
         # leg is intentionally ``client_websocket`` so the scripted media peer
         # can answer it; the AUT's outbound leg is the one Voice AI must own.
-        fresh_outbound = [c for c in _outbound_calls() if c.id not in before_outbound]
-        assert fresh_outbound, "AUT has no matching outbound call record"
-        placed = fresh_outbound[0]
         assert str(getattr(getattr(placed, "mode", ""), "value", getattr(placed, "mode", ""))) == "hosted_agent"
-        assert str(getattr(getattr(placed, "voicemail_detection", ""), "value", getattr(placed, "voicemail_detection", ""))) == "disabled"
+        assert _voicemail_detection_value(placed) == "disabled"
+        assert getattr(placed, "reason", None)
+        assert _enum_value(
+            getattr(placed, "hosted_agent_authority_mode", "")
+        ) == expected_authority
 
         # Do not hang up merely because the words reached the caller transcript.
         # Voice AI must also persist the matching open action on the AUT call;
@@ -464,7 +543,7 @@ def test_outbound_call_hosted_and_post_call_wakeup():
             aut,
             placed.id,
             HOSTED_POST_CALL_MARKER,
-            deadline=hosted_deadline,
+            deadline=pre_hangup_deadline,
         )
     finally:
         _hangup_call(remote, call_id)
@@ -475,10 +554,12 @@ def test_outbound_call_hosted_and_post_call_wakeup():
         f"call_id={placed_call_id}"
     )
     completed_marker = f"completed hosted call completion call_id={placed_call_id}"
-    deadline = time.monotonic() + TIMEOUT_S
+    settlement_deadline = (
+        scenario_deadline - HOSTED_DUPLICATE_GRACE_S - POLL_EVERY_S
+    )
     log = ""
     marker_sms = []
-    while time.monotonic() < deadline:
+    while time.monotonic() < settlement_deadline:
         log = _gateway_log_since(log_offset)
         marker_sms = [
             message
@@ -519,7 +600,10 @@ def test_outbound_call_hosted_and_post_call_wakeup():
     # Give any accidental second attempt time to become visible, then prove the
     # API-accepted side effect occurred exactly once. Carrier delivery is
     # asynchronous and belongs to the SMS delivery lane, not reconciliation.
-    time.sleep(2 * POLL_EVERY_S)
+    assert time.monotonic() + HOSTED_DUPLICATE_GRACE_S <= scenario_deadline, (
+        "hosted settlement left no room for the duplicate-detection grace window"
+    )
+    time.sleep(HOSTED_DUPLICATE_GRACE_S)
     marker_sms = [
         message
         for message in _outbound_sms_to_driver()

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -261,18 +261,16 @@ def test_outbound_call_hosted_and_post_call_wakeup():
     assert HOSTED_POST_CALL_MARKER, "HOSTED_POST_CALL_MARKER is required"
     st = _driver_state()
     remote, aut = _client(REMOTE_KEY), _client(AUT_KEY)
-    aut_phone = _aut_phone(aut)
+    aut_numbers = aut.phone_numbers.list()
+    assert aut_numbers, "AUT identity has no phone number"
+    aut_phone = aut_numbers[0].number
+    aut_number_id = str(aut_numbers[0].id)
     tail = _digits(aut_phone)[-10:]
 
     def _inbound_calls():
         return [c for c in remote.calls.list(limit=30)
                 if (getattr(c, "direction", "") or "").lower() == "inbound"
                 and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
-
-    def _inbound_texts():
-        return [m for m in remote.texts.list(st["number_id"], limit=30)
-                if (getattr(m, "direction", "") or "").lower() == "inbound"
-                and _digits(getattr(m, "remote_phone_number", "") or "")[-10:] == tail]
 
     driver_tail = _digits(st["number"])[-10:]
 
@@ -281,9 +279,14 @@ def test_outbound_call_hosted_and_post_call_wakeup():
                 if (getattr(c, "direction", "") or "").lower() == "outbound"
                 and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == driver_tail]
 
+    def _aut_outbound_texts():
+        return [m for m in aut.texts.list(aut_number_id, limit=30)
+                if (getattr(m, "direction", "") or "").lower() == "outbound"
+                and _digits(getattr(m, "remote_phone_number", "") or "")[-10:] == driver_tail]
+
     before_calls = {c.id for c in _inbound_calls()}
     before_outbound = {c.id for c in _outbound_calls()}
-    before_texts = {m.id for m in _inbound_texts()}
+    before_texts = {m.id for m in _aut_outbound_texts()}
     remote.texts.send(st["number_id"], to=aut_phone, text=_call_me_text())
 
     call_id = None
@@ -315,9 +318,29 @@ def test_outbound_call_hosted_and_post_call_wakeup():
         _hangup_call(remote, call_id)
 
     deadline = time.monotonic() + TIMEOUT_S
+    delivered = []
     while time.monotonic() < deadline:
-        for message in _inbound_texts():
-            if message.id not in before_texts and HOSTED_POST_CALL_MARKER in (message.text or ""):
-                return
+        delivered = [
+            message for message in _aut_outbound_texts()
+            if message.id not in before_texts
+            and HOSTED_POST_CALL_MARKER in (message.text or "")
+        ]
+        if delivered:
+            break
         time.sleep(POLL_EVERY_S)
-    pytest.fail("hosted call ended but Claude Code did not execute its post-call SMS action")
+    assert delivered, (
+        "hosted call ended but Claude Code did not execute its post-call SMS action"
+    )
+
+    # Prove the explicit tool side effect is the only post-call SMS; a plain
+    # captured model reply must not leak onto the requesting channel.
+    time.sleep(2 * POLL_EVERY_S)
+    new_texts = [
+        message for message in _aut_outbound_texts()
+        if message.id not in before_texts
+    ]
+    assert len(new_texts) == 1, (
+        "hosted post-call processing leaked model text or duplicated the "
+        f"commitment: {[getattr(message, 'text', '') for message in new_texts]}"
+    )
+    assert HOSTED_POST_CALL_MARKER in (new_texts[0].text or "")

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -93,7 +93,11 @@ def _spoken_tokens(value: str | None) -> list[str]:
 
 
 def _spoken_key(value: str | None) -> str:
-    return "".join(_spoken_tokens(value))
+    key = "".join(_spoken_tokens(value))
+    # Claude is a common ASR homophone for "cloud". Canonicalize the observed
+    # boundary-less form too ("cloudpapa") without relaxing any of the other
+    # current-run marker, action, status, channel, or recipient requirements.
+    return key.replace("cloud", "claude")
 
 
 def _message_created_at(message):

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -87,6 +87,51 @@ def _voicemail_detection_value(call) -> str:
     return _enum_value(getattr(call, "voicemail_detection", ""))
 
 
+def _fresh_call_records(records, before: set, watermark: datetime):
+    return [
+        record for record in records
+        if record.id not in before
+        and (created_at := _message_created_at(record)) is not None
+        and created_at >= watermark
+    ]
+
+
+def _call_pair_diagnostic(driver_calls, aut_calls) -> str:
+    return (
+        "phase=call_pairing "
+        f"driver_ids={[str(call.id) for call in driver_calls]} "
+        f"aut_ids={[str(call.id) for call in aut_calls]}"
+    )
+
+
+def _correlate_fresh_call_pair(
+    driver_records,
+    aut_records,
+    *,
+    before_driver: set,
+    before_aut: set,
+    driver_watermark: datetime,
+    aut_watermark: datetime,
+):
+    """Return the exact driver/AUT records for one newly persisted call."""
+    driver_calls = _fresh_call_records(
+        driver_records, before_driver, driver_watermark
+    )
+    aut_calls = _fresh_call_records(aut_records, before_aut, aut_watermark)
+    diagnostic = _call_pair_diagnostic(driver_calls, aut_calls)
+    assert len(driver_calls) <= 1, f"{diagnostic} duplicate driver legs"
+    assert len(aut_calls) <= 1, f"{diagnostic} duplicate AUT legs"
+    if not driver_calls or not aut_calls:
+        return None
+    driver_created = _message_created_at(driver_calls[0])
+    aut_created = _message_created_at(aut_calls[0])
+    assert driver_created is not None and aut_created is not None
+    assert abs((driver_created - aut_created).total_seconds()) <= 60, (
+        f"{diagnostic} timestamps do not describe one call"
+    )
+    return driver_calls[0], aut_calls[0]
+
+
 def _spoken_tokens(value: str | None) -> list[str]:
     """Normalize speech-carried text without depending on punctuation/case."""
     return re.findall(r"[a-z0-9]+", (value or "").casefold())
@@ -367,27 +412,65 @@ def test_outbound_call_realtime():
     remote, aut = _client(REMOTE_KEY), _client(AUT_KEY)
     aut_phone = _aut_phone(aut)
     tail = _digits(aut_phone)[-10:]
+    driver_tail = _digits(st["number"])[-10:]
 
     def _inbound_from_aut():
         return [c for c in remote.calls.list(limit=30)
                 if (getattr(c, "direction", "") or "").lower() == "inbound"
                 and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
 
-    before = {c.id for c in _inbound_from_aut()}
+    def _outbound_from_aut():
+        return [c for c in aut.calls.list(limit=30)
+                if (getattr(c, "direction", "") or "").lower() == "outbound"
+                and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == driver_tail]
+
+    baseline_driver = _inbound_from_aut()
+    baseline_aut = _outbound_from_aut()
+    before_driver = {call.id for call in baseline_driver}
+    before_aut = {call.id for call in baseline_aut}
+    driver_watermark = max(
+        (
+            created_at for call in baseline_driver
+            if (created_at := _message_created_at(call)) is not None
+        ),
+        default=datetime.min.replace(tzinfo=UTC),
+    )
+    aut_watermark = max(
+        (
+            created_at for call in baseline_aut
+            if (created_at := _message_created_at(call)) is not None
+        ),
+        default=datetime.min.replace(tzinfo=UTC),
+    )
     remote.texts.send(st["number_id"], to=aut_phone, text=_call_me_text())
 
     call_id = None
+    aut_call = None
     try:
-        # Wait for the agent to dial back, then verify the call transcript.
+        # Pair the driver's inbound media leg with the AUT's outbound request.
         deadline = time.monotonic() + TIMEOUT_S
         while time.monotonic() < deadline:
-            fresh = [c for c in _inbound_from_aut() if c.id not in before]
-            if fresh:
-                call_id = fresh[0].id
+            pair = _correlate_fresh_call_pair(
+                _inbound_from_aut(),
+                _outbound_from_aut(),
+                before_driver=before_driver,
+                before_aut=before_aut,
+                driver_watermark=driver_watermark,
+                aut_watermark=aut_watermark,
+            )
+            if pair is not None:
+                driver_call, aut_call = pair
+                call_id = driver_call.id
                 break
             time.sleep(POLL_EVERY_S)
-        assert call_id, f"agent never placed a call back within {TIMEOUT_S:.0f}s"
-        persisted = remote.calls.get(call_id)
+        assert call_id and aut_call is not None, (
+            f"agent never persisted both call legs within {TIMEOUT_S:.0f}s; "
+            + _call_pair_diagnostic(
+                _fresh_call_records(_inbound_from_aut(), before_driver, driver_watermark),
+                _fresh_call_records(_outbound_from_aut(), before_aut, aut_watermark),
+            )
+        )
+        persisted = aut.calls.get(aut_call.id)
         assert _voicemail_detection_value(persisted) == "disabled"
 
         agent_said = _wait_for_two_way_call(remote, st["number_id"], call_id)

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -22,6 +22,7 @@ import os
 import re
 import time
 import uuid
+from datetime import UTC, datetime
 
 import pytest
 
@@ -70,6 +71,51 @@ def _digits(s: str) -> str:
     return re.sub(r"\D", "", s or "")
 
 
+def _spoken_tokens(value: str | None) -> list[str]:
+    """Normalize speech-carried text without depending on punctuation/case."""
+    return re.findall(r"[a-z0-9]+", (value or "").casefold())
+
+
+def _spoken_key(value: str | None) -> str:
+    return "".join(_spoken_tokens(value))
+
+
+def _message_created_at(message):
+    """Return an aware server timestamp from an SDK SMS row."""
+    value = getattr(message, "created_at", None)
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _sms_target_numbers(message) -> set[str]:
+    """All authoritative targets represented by an outbound SMS row."""
+    values = [getattr(message, "remote_phone_number", "") or ""]
+    values.extend(
+        getattr(recipient, "recipient_phone_number", "") or ""
+        for recipient in (getattr(message, "recipients", None) or [])
+    )
+    return {digits for value in values if (digits := _digits(value))}
+
+
+def _has_after_call_sms_intent(value: str | None) -> bool:
+    tokens = _spoken_tokens(value)
+    token_set = set(tokens)
+    joined = " ".join(tokens)
+    after_call = "after" in token_set and bool(
+        token_set & {"call", "hangup", "hang", "hung"}
+    )
+    send = bool(token_set & {"send", "text"})
+    sms = bool(token_set & {"sms", "text", "message"}) or "s m s" in joined
+    return after_call and send and sms
+
+
 def _client(key):
     from inkbox import Inkbox
 
@@ -103,6 +149,28 @@ def _segments(remote, number_id, call_id):
     rem = [s for s in segs if (getattr(s, "party", "") or "").lower() == "remote" and (s.text or "").strip()]
     loc = [s for s in segs if (getattr(s, "party", "") or "").lower() == "local" and (s.text or "").strip()]
     return segs, rem, loc
+
+
+def _wait_for_persisted_hosted_request(remote, number_id, call_id, marker):
+    """Wait for the current after-call SMS request in the caller transcript."""
+    marker_key = _spoken_key(marker)
+    assert marker_key
+    deadline = time.monotonic() + min(TIMEOUT_S, 90)
+    last = ""
+    while time.monotonic() < deadline:
+        try:
+            _all, _rem, local = _segments(remote, number_id, call_id)
+            text = " ".join(segment.text.strip() for segment in local)
+            if marker_key in _spoken_key(text) and _has_after_call_sms_intent(text):
+                return
+            last = f"local transcript so far: {text!r}"
+        except Exception as exc:  # transcripts may trail call teardown briefly
+            last = f"transcripts not ready: {exc!r}"
+        time.sleep(POLL_EVERY_S)
+    pytest.fail(
+        "call ended before the current after-call SMS request was persisted "
+        f"({last})"
+    )
 
 
 def _call_state(remote, call_id) -> tuple[str, str]:
@@ -273,22 +341,43 @@ def test_outbound_call_hosted_and_post_call_wakeup():
     aut_numbers = aut.phone_numbers.list()
     assert aut_numbers, "AUT identity has no phone number"
     aut_phone = aut_numbers[0].number
+    aut_number_id = aut_numbers[0].id
     tail = _digits(aut_phone)[-10:]
+    driver_number = _digits(st["number"])
 
     def _inbound_calls():
         return [c for c in remote.calls.list(limit=30)
                 if (getattr(c, "direction", "") or "").lower() == "inbound"
                 and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == tail]
 
-    driver_tail = _digits(st["number"])[-10:]
+    driver_tail = driver_number[-10:]
 
     def _outbound_calls():
         return [c for c in aut.calls.list(limit=30)
                 if (getattr(c, "direction", "") or "").lower() == "outbound"
                 and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == driver_tail]
 
+    def _outbound_sms_to_driver():
+        return [
+            message
+            for message in aut.texts.list(aut_number_id, limit=200)
+            if (getattr(message, "direction", "") or "").lower() == "outbound"
+            and driver_number in _sms_target_numbers(message)
+        ]
+
     before_calls = {c.id for c in _inbound_calls()}
     before_outbound = {c.id for c in _outbound_calls()}
+    baseline_sms = _outbound_sms_to_driver()
+    before_sms = {message.id for message in baseline_sms}
+    baseline_times = [
+        created_at
+        for message in baseline_sms
+        if (created_at := _message_created_at(message)) is not None
+    ]
+    sms_watermark = max(
+        baseline_times,
+        default=datetime.min.replace(tzinfo=UTC),
+    )
     assert GATEWAY_LOG and os.path.exists(GATEWAY_LOG), (
         "GATEWAY_LOG must expose the bridge's host-native tool settlement"
     )
@@ -320,13 +409,12 @@ def test_outbound_call_hosted_and_post_call_wakeup():
         # ends the call itself. Let that complete so Voice AI can acknowledge
         # and persist the instruction before call.ended wakes Claude Code.
         _wait_for_call_end(remote, call_id)
-        segments, _remote_segments, _local_segments = _segments(
-            remote, st["number_id"], call_id,
+        _wait_for_persisted_hosted_request(
+            remote,
+            st["number_id"],
+            call_id,
+            HOSTED_POST_CALL_MARKER,
         )
-        assert any(
-            HOSTED_POST_CALL_MARKER in (segment.text or "")
-            for segment in segments
-        ), "the driver's post-call instruction was not persisted in the transcript"
     finally:
         _hangup_call(remote, call_id)
 
@@ -338,9 +426,19 @@ def test_outbound_call_hosted_and_post_call_wakeup():
     completed_marker = f"completed hosted call completion call_id={placed_call_id}"
     deadline = time.monotonic() + TIMEOUT_S
     log = ""
+    marker_sms = []
     while time.monotonic() < deadline:
         log = _gateway_log_since(log_offset)
-        if tool_marker in log and completed_marker in log:
+        marker_sms = [
+            message
+            for message in _outbound_sms_to_driver()
+            if message.id not in before_sms
+            and (created_at := _message_created_at(message)) is not None
+            and created_at >= sms_watermark
+            and _spoken_key(HOSTED_POST_CALL_MARKER)
+            in _spoken_key(getattr(message, "text", None))
+        ]
+        if tool_marker in log and completed_marker in log and marker_sms:
             break
         time.sleep(POLL_EVERY_S)
     assert tool_marker in log, (
@@ -349,6 +447,29 @@ def test_outbound_call_hosted_and_post_call_wakeup():
     )
     assert completed_marker in log, (
         "hosted SMS was sent but its post-call receipt did not complete"
+    )
+    assert marker_sms, (
+        "hosted completion did not create a current exact-recipient sender-side "
+        "SMS row with the spoken marker"
+    )
+
+    # Give any accidental second attempt time to become visible, then prove the
+    # API-accepted side effect occurred exactly once. Carrier delivery is
+    # asynchronous and belongs to the SMS delivery lane, not reconciliation.
+    time.sleep(2 * POLL_EVERY_S)
+    marker_sms = [
+        message
+        for message in _outbound_sms_to_driver()
+        if message.id not in before_sms
+        and (created_at := _message_created_at(message)) is not None
+        and created_at >= sms_watermark
+        and _spoken_key(HOSTED_POST_CALL_MARKER)
+        in _spoken_key(getattr(message, "text", None))
+    ]
+    assert len(marker_sms) == 1, (
+        "hosted post-call processing did not produce exactly one current-marker "
+        "SMS to the authoritative caller: "
+        f"{[getattr(message, 'text', '') for message in marker_sms]}"
     )
     assert log.count(tool_marker) == 1, (
         "hosted post-call processing recorded duplicate successful SMS side effects"

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -116,6 +116,38 @@ def _has_after_call_sms_intent(value: str | None) -> bool:
     return after_call and send and sms
 
 
+def _has_sms_action_intent(value: str | None) -> bool:
+    """Recognize a persisted send-SMS action without requiring prose wording."""
+    tokens = _spoken_tokens(value)
+    token_set = set(tokens)
+    joined = " ".join(tokens)
+    send = bool(token_set & {"send", "text"})
+    sms = bool(token_set & {"sms", "text", "message"}) or "s m s" in joined
+    return send and sms
+
+
+def _matching_post_call_action(call, marker):
+    """Return the open current-marker SMS action persisted for a hosted call."""
+    marker_key = _spoken_key(marker)
+    for item in getattr(call, "post_call_action_items", None) or []:
+        if isinstance(item, dict):
+            status = item.get("status", "")
+            action = item.get("action", "")
+            details = item.get("details", "")
+        else:
+            status = getattr(item, "status", "")
+            action = getattr(item, "action", "")
+            details = getattr(item, "details", "")
+        value = f"{action} {details}"
+        if (
+            str(status).casefold() == "open"
+            and marker_key in _spoken_key(value)
+            and _has_sms_action_intent(value)
+        ):
+            return item
+    return None
+
+
 def _client(key):
     from inkbox import Inkbox
 
@@ -151,25 +183,48 @@ def _segments(remote, number_id, call_id):
     return segs, rem, loc
 
 
-def _wait_for_persisted_hosted_request(remote, number_id, call_id, marker):
-    """Wait for the current after-call SMS request in the caller transcript."""
+def _wait_for_persisted_hosted_request(
+    remote,
+    number_id,
+    call_id,
+    aut,
+    aut_call_id,
+    marker,
+    *,
+    deadline,
+):
+    """Wait for both caller intent and the AUT's durable open action item."""
     marker_key = _spoken_key(marker)
     assert marker_key
-    deadline = time.monotonic() + min(TIMEOUT_S, 90)
-    last = ""
+    transcript_ready = False
+    action_ready = False
+    last_transcript = ""
+    last_actions = ""
     while time.monotonic() < deadline:
         try:
             _all, _rem, local = _segments(remote, number_id, call_id)
             text = " ".join(segment.text.strip() for segment in local)
-            if marker_key in _spoken_key(text) and _has_after_call_sms_intent(text):
-                return
-            last = f"local transcript so far: {text!r}"
+            transcript_ready = (
+                marker_key in _spoken_key(text)
+                and _has_after_call_sms_intent(text)
+            )
+            last_transcript = repr(text)
         except Exception as exc:  # transcripts may trail call teardown briefly
-            last = f"transcripts not ready: {exc!r}"
+            last_transcript = f"not ready: {exc!r}"
+        try:
+            aut_call = aut.calls.get(aut_call_id)
+            action_ready = _matching_post_call_action(aut_call, marker) is not None
+            last_actions = repr(getattr(aut_call, "post_call_action_items", None))
+        except Exception as exc:
+            last_actions = f"not ready: {exc!r}"
+        if transcript_ready and action_ready:
+            return
         time.sleep(POLL_EVERY_S)
     pytest.fail(
-        "call ended before the current after-call SMS request was persisted "
-        f"({last})"
+        "hosted call did not persist both current caller intent and its open "
+        "post-call SMS action before the shared deadline "
+        f"(transcript_ready={transcript_ready}, action_ready={action_ready}, "
+        f"local_transcript={last_transcript}, action_items={last_actions})"
     )
 
 
@@ -188,21 +243,10 @@ def _call_state(remote, call_id) -> tuple[str, str]:
     return status, " ".join(fields)
 
 
-def _wait_for_call_end(client, call_id) -> None:
-    """Wait for the scripted driver to finish instead of cutting its turn off."""
-    deadline = time.monotonic() + TIMEOUT_S
-    last = ""
-    while time.monotonic() < deadline:
-        status, last = _call_state(client, call_id)
-        if status in ENDED_STATUSES | TERMINAL_FAILURE_STATUSES:
-            return
-        time.sleep(POLL_EVERY_S)
-    pytest.fail(f"call did not end within {TIMEOUT_S:.0f}s ({last})")
-
-
-def _wait_for_two_way_call(remote, number_id, call_id):
+def _wait_for_two_way_call(remote, number_id, call_id, *, deadline=None):
     """Block until the call transcript shows BOTH the agent and the driver spoke."""
-    deadline = time.monotonic() + TIMEOUT_S
+    if deadline is None:
+        deadline = time.monotonic() + TIMEOUT_S
     last = ""
     ended_at = None
     while time.monotonic() < deadline:
@@ -382,19 +426,24 @@ def test_outbound_call_hosted_and_post_call_wakeup():
         "GATEWAY_LOG must expose the bridge's host-native tool settlement"
     )
     log_offset = os.path.getsize(GATEWAY_LOG)
+    hosted_deadline = time.monotonic() + TIMEOUT_S
     remote.texts.send(st["number_id"], to=aut_phone, text=_call_me_text())
 
     call_id = None
     try:
-        deadline = time.monotonic() + TIMEOUT_S
-        while time.monotonic() < deadline:
+        while time.monotonic() < hosted_deadline:
             fresh = [c for c in _inbound_calls() if c.id not in before_calls]
             if fresh:
                 call_id = fresh[0].id
                 break
             time.sleep(POLL_EVERY_S)
         assert call_id, f"agent never placed a hosted call within {TIMEOUT_S:.0f}s"
-        _wait_for_two_way_call(remote, st["number_id"], call_id)
+        _wait_for_two_way_call(
+            remote,
+            st["number_id"],
+            call_id,
+            deadline=hosted_deadline,
+        )
 
         # A phone call has two independently handled legs. The driver's inbound
         # leg is intentionally ``client_websocket`` so the scripted media peer
@@ -405,15 +454,17 @@ def test_outbound_call_hosted_and_post_call_wakeup():
         assert str(getattr(getattr(placed, "mode", ""), "value", getattr(placed, "mode", ""))) == "hosted_agent"
         assert str(getattr(getattr(placed, "voicemail_detection", ""), "value", getattr(placed, "voicemail_detection", ""))) == "disabled"
 
-        # The driver speaks the action after its short human greeting and then
-        # ends the call itself. Let that complete so Voice AI can acknowledge
-        # and persist the instruction before call.ended wakes Claude Code.
-        _wait_for_call_end(remote, call_id)
+        # Do not hang up merely because the words reached the caller transcript.
+        # Voice AI must also persist the matching open action on the AUT call;
+        # both gates share the original placement deadline.
         _wait_for_persisted_hosted_request(
             remote,
             st["number_id"],
             call_id,
+            aut,
+            placed.id,
             HOSTED_POST_CALL_MARKER,
+            deadline=hosted_deadline,
         )
     finally:
         _hangup_call(remote, call_id)
@@ -448,9 +499,21 @@ def test_outbound_call_hosted_and_post_call_wakeup():
     assert completed_marker in log, (
         "hosted SMS was sent but its post-call receipt did not complete"
     )
+    current_candidates = [
+        {
+            "id": getattr(message, "id", None),
+            "created_at": getattr(message, "created_at", None),
+            "targets": sorted(_sms_target_numbers(message)),
+            "text": getattr(message, "text", ""),
+        }
+        for message in _outbound_sms_to_driver()
+        if message.id not in before_sms
+        and (created_at := _message_created_at(message)) is not None
+        and created_at >= sms_watermark
+    ]
     assert marker_sms, (
         "hosted completion did not create a current exact-recipient sender-side "
-        "SMS row with the spoken marker"
+        f"SMS row with the spoken marker; candidates={current_candidates!r}"
     )
 
     # Give any accidental second attempt time to become visible, then prove the
@@ -466,10 +529,22 @@ def test_outbound_call_hosted_and_post_call_wakeup():
         and _spoken_key(HOSTED_POST_CALL_MARKER)
         in _spoken_key(getattr(message, "text", None))
     ]
+    current_candidates = [
+        {
+            "id": getattr(message, "id", None),
+            "created_at": getattr(message, "created_at", None),
+            "targets": sorted(_sms_target_numbers(message)),
+            "text": getattr(message, "text", ""),
+        }
+        for message in _outbound_sms_to_driver()
+        if message.id not in before_sms
+        and (created_at := _message_created_at(message)) is not None
+        and created_at >= sms_watermark
+    ]
     assert len(marker_sms) == 1, (
         "hosted post-call processing did not produce exactly one current-marker "
         "SMS to the authoritative caller: "
-        f"{[getattr(message, 'text', '') for message in marker_sms]}"
+        f"candidates={current_candidates!r}"
     )
     assert log.count(tool_marker) == 1, (
         "hosted post-call processing recorded duplicate successful SMS side effects"

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -213,6 +213,43 @@ def _matching_post_call_action(call, marker):
     return None
 
 
+def _post_call_action_diagnostic(call, marker) -> dict[str, int | bool]:
+    """Bounded, content-redacted predicates for the hosted action gate."""
+    items = getattr(call, "post_call_action_items", None) or []
+    open_count = 0
+    marker_count = 0
+    sms_count = 0
+    matching_action = False
+    marker_key = _spoken_key(marker)
+    for item in items[:10]:
+        if isinstance(item, dict):
+            status = item.get("status", "")
+            action = item.get("action", "")
+            details = item.get("details", "")
+        else:
+            status = getattr(item, "status", "")
+            action = getattr(item, "action", "")
+            details = getattr(item, "details", "")
+        value = f"{action} {details}"
+        is_open = str(status).casefold() == "open"
+        has_marker = bool(marker_key) and marker_key in _spoken_key(value)
+        has_sms_intent = _has_sms_action_intent(value)
+        open_count += int(is_open)
+        marker_count += int(has_marker)
+        sms_count += int(has_sms_intent)
+        matching_action = matching_action or (
+            is_open and has_marker and has_sms_intent
+        )
+    return {
+        "item_count": len(items),
+        "inspected_count": min(len(items), 10),
+        "open_count": open_count,
+        "marker_count": marker_count,
+        "sms_count": sms_count,
+        "matching_action": matching_action,
+    }
+
+
 def _client(key):
     from inkbox import Inkbox
 
@@ -263,8 +300,8 @@ def _wait_for_persisted_hosted_request(
     assert marker_key
     transcript_ready = False
     action_ready = False
-    last_transcript = ""
-    last_actions = ""
+    transcript_diagnostic: dict[str, int | bool | str] = {}
+    action_diagnostic: dict[str, int | bool | str] = {}
     while time.monotonic() < deadline:
         try:
             _all, _rem, local = _segments(remote, number_id, call_id)
@@ -273,15 +310,19 @@ def _wait_for_persisted_hosted_request(
                 marker_key in _spoken_key(text)
                 and _has_after_call_sms_intent(text)
             )
-            last_transcript = repr(text)
+            transcript_diagnostic = {
+                "segment_count": len(local),
+                "marker_present": marker_key in _spoken_key(text),
+                "after_call_sms_intent": _has_after_call_sms_intent(text),
+            }
         except Exception as exc:  # transcripts may trail call teardown briefly
-            last_transcript = f"not ready: {exc!r}"
+            transcript_diagnostic = {"error_type": type(exc).__name__}
         try:
             aut_call = aut.calls.get(aut_call_id)
             action_ready = _matching_post_call_action(aut_call, marker) is not None
-            last_actions = repr(getattr(aut_call, "post_call_action_items", None))
+            action_diagnostic = _post_call_action_diagnostic(aut_call, marker)
         except Exception as exc:
-            last_actions = f"not ready: {exc!r}"
+            action_diagnostic = {"error_type": type(exc).__name__}
         if transcript_ready and action_ready:
             return
         time.sleep(POLL_EVERY_S)
@@ -289,7 +330,7 @@ def _wait_for_persisted_hosted_request(
         "hosted call did not persist both current caller intent and its open "
         "post-call SMS action before the shared deadline "
         f"(transcript_ready={transcript_ready}, action_ready={action_ready}, "
-        f"local_transcript={last_transcript}, action_items={last_actions})"
+        f"transcript_gate={transcript_diagnostic}, action_gate={action_diagnostic})"
     )
 
 

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -111,6 +111,18 @@ def _call_state(remote, call_id) -> tuple[str, str]:
     return status, " ".join(fields)
 
 
+def _wait_for_call_end(client, call_id) -> None:
+    """Wait for the scripted driver to finish instead of cutting its turn off."""
+    deadline = time.monotonic() + TIMEOUT_S
+    last = ""
+    while time.monotonic() < deadline:
+        status, last = _call_state(client, call_id)
+        if status in ENDED_STATUSES | TERMINAL_FAILURE_STATUSES:
+            return
+        time.sleep(POLL_EVERY_S)
+    pytest.fail(f"call did not end within {TIMEOUT_S:.0f}s ({last})")
+
+
 def _wait_for_two_way_call(remote, number_id, call_id):
     """Block until the call transcript shows BOTH the agent and the driver spoke."""
     deadline = time.monotonic() + TIMEOUT_S
@@ -262,7 +274,15 @@ def test_outbound_call_hosted_and_post_call_wakeup():
                 if (getattr(m, "direction", "") or "").lower() == "inbound"
                 and _digits(getattr(m, "remote_phone_number", "") or "")[-10:] == tail]
 
+    driver_tail = _digits(st["number"])[-10:]
+
+    def _outbound_calls():
+        return [c for c in aut.calls.list(limit=30)
+                if (getattr(c, "direction", "") or "").lower() == "outbound"
+                and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == driver_tail]
+
     before_calls = {c.id for c in _inbound_calls()}
+    before_outbound = {c.id for c in _outbound_calls()}
     before_texts = {m.id for m in _inbound_texts()}
     remote.texts.send(st["number_id"], to=aut_phone, text=_call_me_text())
 
@@ -278,9 +298,19 @@ def test_outbound_call_hosted_and_post_call_wakeup():
         assert call_id, f"agent never placed a hosted call within {TIMEOUT_S:.0f}s"
         _wait_for_two_way_call(remote, st["number_id"], call_id)
 
-        call = remote.calls.get(call_id)
-        assert str(getattr(getattr(call, "mode", ""), "value", getattr(call, "mode", ""))) == "hosted_agent"
-        assert str(getattr(getattr(call, "voicemail_detection", ""), "value", getattr(call, "voicemail_detection", ""))) == "disabled"
+        # A phone call has two independently handled legs. The driver's inbound
+        # leg is intentionally ``client_websocket`` so the scripted media peer
+        # can answer it; the AUT's outbound leg is the one Voice AI must own.
+        fresh_outbound = [c for c in _outbound_calls() if c.id not in before_outbound]
+        assert fresh_outbound, "AUT has no matching outbound call record"
+        placed = fresh_outbound[0]
+        assert str(getattr(getattr(placed, "mode", ""), "value", getattr(placed, "mode", ""))) == "hosted_agent"
+        assert str(getattr(getattr(placed, "voicemail_detection", ""), "value", getattr(placed, "voicemail_detection", ""))) == "disabled"
+
+        # The driver speaks the action after its short human greeting and then
+        # ends the call itself. Let that complete so Voice AI can acknowledge
+        # and persist the instruction before call.ended wakes Claude Code.
+        _wait_for_call_end(remote, call_id)
     finally:
         _hangup_call(remote, call_id)
 

--- a/tests/live/test_voice.py
+++ b/tests/live/test_voice.py
@@ -25,7 +25,6 @@ import uuid
 
 import pytest
 
-
 # The agent answers a call request by dialing back, not by texting, so these
 # driver→AUT SMS never get an SMS reply to reset the server's conversation
 # cadence. Two identical no-reply sends to the same number trip the
@@ -49,6 +48,7 @@ BASE_URL = os.environ.get("INKBOX_BASE_URL", "https://inkbox.ai")
 REAL = os.environ.get("LIVE_REAL_MODEL") == "1"
 SCENARIO = os.environ.get("VOICE_SCENARIO", "")
 HOSTED_POST_CALL_MARKER = os.environ.get("HOSTED_POST_CALL_MARKER", "")
+GATEWAY_LOG = os.environ.get("GATEWAY_LOG", "")
 STATE_FILE = os.environ.get("VOICE_DRIVER_STATE", "/tmp/voice_driver_state.json")
 TIMEOUT_S = float(os.environ.get("LIVE_VOICE_TIMEOUT", "220"))
 POLL_EVERY_S = 6.0
@@ -79,6 +79,15 @@ def _client(key):
 def _driver_state() -> dict:
     with open(STATE_FILE) as fh:
         return json.load(fh)
+
+
+def _gateway_log_since(offset: int) -> str:
+    """Return gateway log output emitted after the hosted-call request."""
+    if not GATEWAY_LOG or not os.path.exists(GATEWAY_LOG):
+        return ""
+    with open(GATEWAY_LOG, encoding="utf-8", errors="replace") as handle:
+        handle.seek(offset)
+        return handle.read()
 
 
 def _aut_phone(aut) -> str:
@@ -264,7 +273,6 @@ def test_outbound_call_hosted_and_post_call_wakeup():
     aut_numbers = aut.phone_numbers.list()
     assert aut_numbers, "AUT identity has no phone number"
     aut_phone = aut_numbers[0].number
-    aut_number_id = str(aut_numbers[0].id)
     tail = _digits(aut_phone)[-10:]
 
     def _inbound_calls():
@@ -279,14 +287,12 @@ def test_outbound_call_hosted_and_post_call_wakeup():
                 if (getattr(c, "direction", "") or "").lower() == "outbound"
                 and _digits(getattr(c, "remote_phone_number", "") or "")[-10:] == driver_tail]
 
-    def _aut_outbound_texts():
-        return [m for m in aut.texts.list(aut_number_id, limit=200)
-                if (getattr(m, "direction", "") or "").lower() == "outbound"
-                and _digits(getattr(m, "remote_phone_number", "") or "")[-10:] == driver_tail]
-
     before_calls = {c.id for c in _inbound_calls()}
     before_outbound = {c.id for c in _outbound_calls()}
-    before_texts = {m.id for m in _aut_outbound_texts()}
+    assert GATEWAY_LOG and os.path.exists(GATEWAY_LOG), (
+        "GATEWAY_LOG must expose the bridge's host-native tool settlement"
+    )
+    log_offset = os.path.getsize(GATEWAY_LOG)
     remote.texts.send(st["number_id"], to=aut_phone, text=_call_me_text())
 
     call_id = None
@@ -314,33 +320,36 @@ def test_outbound_call_hosted_and_post_call_wakeup():
         # ends the call itself. Let that complete so Voice AI can acknowledge
         # and persist the instruction before call.ended wakes Claude Code.
         _wait_for_call_end(remote, call_id)
+        segments, _remote_segments, _local_segments = _segments(
+            remote, st["number_id"], call_id,
+        )
+        assert any(
+            HOSTED_POST_CALL_MARKER in (segment.text or "")
+            for segment in segments
+        ), "the driver's post-call instruction was not persisted in the transcript"
     finally:
         _hangup_call(remote, call_id)
 
+    placed_call_id = str(placed.id)
+    tool_marker = (
+        "confirmed hosted call SMS tool completion "
+        f"call_id={placed_call_id}"
+    )
+    completed_marker = f"completed hosted call completion call_id={placed_call_id}"
     deadline = time.monotonic() + TIMEOUT_S
-    delivered = []
+    log = ""
     while time.monotonic() < deadline:
-        delivered = [
-            message for message in _aut_outbound_texts()
-            if message.id not in before_texts
-            and HOSTED_POST_CALL_MARKER in (message.text or "")
-        ]
-        if delivered:
+        log = _gateway_log_since(log_offset)
+        if tool_marker in log and completed_marker in log:
             break
         time.sleep(POLL_EVERY_S)
-    assert delivered, (
-        "hosted call ended but Claude Code did not execute its post-call SMS action"
+    assert tool_marker in log, (
+        "hosted call ended without one exact-recipient SMS confirmed by the "
+        "Claude session's post-SDK-return delivery marker"
     )
-
-    # Prove the explicit tool side effect is the only post-call SMS; a plain
-    # captured model reply must not leak onto the requesting channel.
-    time.sleep(2 * POLL_EVERY_S)
-    new_texts = [
-        message for message in _aut_outbound_texts()
-        if message.id not in before_texts
-    ]
-    assert len(new_texts) == 1, (
-        "hosted post-call processing leaked model text or duplicated the "
-        f"commitment: {[getattr(message, 'text', '') for message in new_texts]}"
+    assert completed_marker in log, (
+        "hosted SMS was sent but its post-call receipt did not complete"
     )
-    assert HOSTED_POST_CALL_MARKER in (new_texts[0].text or "")
+    assert log.count(tool_marker) == 1, (
+        "hosted post-call processing recorded duplicate successful SMS side effects"
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-from inkbox_claude.config import read_config
+from inkbox_claude.config import VoiceStack, read_config, resolve_voice_stack
 
 
 def test_read_config_defaults(monkeypatch):
@@ -68,3 +68,39 @@ def test_realtime_key_falls_back_to_openai_env(monkeypatch):
     cfg = read_config()
     assert cfg.realtime.enabled is True
     assert cfg.realtime.api_key == "sk-openai"
+
+
+def test_canonical_voice_stack_wins_over_legacy_realtime(monkeypatch):
+    _clear_realtime_env(monkeypatch)
+    monkeypatch.setenv("INKBOX_REALTIME_ENABLED", "true")
+    monkeypatch.setenv("INKBOX_REALTIME_API_KEY", "sk-old")
+    monkeypatch.setenv("INKBOX_VOICE_STACK", "inkbox_voice_ai")
+    cfg = read_config()
+    assert cfg.voice_stack is VoiceStack.INKBOX_VOICE_AI
+
+
+def test_legacy_realtime_install_resolves_to_realtime(monkeypatch):
+    _clear_realtime_env(monkeypatch)
+    monkeypatch.delenv("INKBOX_VOICE_STACK", raising=False)
+    monkeypatch.setenv("INKBOX_REALTIME_ENABLED", "true")
+    monkeypatch.setenv("INKBOX_REALTIME_API_KEY", "sk-old")
+    assert read_config().voice_stack is VoiceStack.OPENAI_REALTIME
+
+
+def test_invalid_voice_stack_fails_closed_to_local_and_is_reported(monkeypatch):
+    monkeypatch.setenv("INKBOX_VOICE_STACK", "magic")
+    cfg = read_config()
+    assert cfg.voice_stack is VoiceStack.INKBOX_TTS_STT
+    assert cfg.voice_stack_invalid_value == "magic"
+
+
+def test_voice_authority_and_voicemail_config(monkeypatch):
+    monkeypatch.setenv("INKBOX_VOICE_AI_AUTHORITY_MODE", "yolo")
+    monkeypatch.setenv("INKBOX_VOICEMAIL_DETECTION", "disabled")
+    cfg = read_config()
+    assert cfg.voice_ai_authority_mode == "yolo"
+    assert cfg.voicemail_detection == "disabled"
+
+
+def test_resolve_voice_stack_defaults_to_tts_stt():
+    assert resolve_voice_stack(None) == (VoiceStack.INKBOX_TTS_STT, "")

--- a/tests/test_delivery_failure_retry.py
+++ b/tests/test_delivery_failure_retry.py
@@ -26,6 +26,74 @@ from inkbox_claude.config import BridgeConfig
 MAX = gateway.OUTBOUND_FAILURE_MAX_ATTEMPTS
 
 
+@pytest.mark.parametrize(
+    ("attempt", "error_code", "error_detail", "required", "forbidden"),
+    [
+        (
+            1,
+            "40002",
+            "Temporary spam filter rejection",
+            "FIRST SAFE RETRY REQUIRED",
+            "[SILENT]",
+        ),
+        (
+            2,
+            "40002",
+            "Temporary spam filter rejection",
+            "RETRY OPTIONAL",
+            "FIRST SAFE RETRY REQUIRED",
+        ),
+        (
+            1,
+            "recipient_opted_out",
+            "Recipient opted out",
+            "DO NOT RETRY",
+            "FIRST SAFE RETRY REQUIRED",
+        ),
+        (
+            2,
+            "invalid_phone_number",
+            "Destination unreachable",
+            "DO NOT RETRY",
+            "RETRY OPTIONAL",
+        ),
+        (
+            1,
+            "unknown",
+            "Provider rejected the message",
+            "REVIEW BEFORE RETRY",
+            "FIRST SAFE RETRY REQUIRED",
+        ),
+        (
+            2,
+            "unknown",
+            "Provider rejected the message",
+            "REVIEW BEFORE RETRY",
+            "RETRY OPTIONAL",
+        ),
+    ],
+)
+def test_delivery_failure_instruction_uses_attempt_and_classification(
+    attempt,
+    error_code,
+    error_detail,
+    required,
+    forbidden,
+):
+    instruction = gateway._delivery_failure_reply_instruction(
+        mode="sms",
+        error_code=error_code,
+        error_detail=error_detail,
+        attempt=attempt,
+    )
+    assert required in instruction
+    assert forbidden not in instruction
+    if "DO NOT RETRY" in required or "REVIEW BEFORE RETRY" in required:
+        assert "[SILENT]" in instruction
+    if required == "RETRY OPTIONAL":
+        assert "[SILENT]" in instruction
+
+
 @pytest.fixture(autouse=True)
 def fake_web(monkeypatch):
     """aiohttp isn't installed in tests; stub the json_response the handlers use."""
@@ -153,6 +221,8 @@ def test_sms_spam_block_wakes_agent_with_rule():
     assert "message_blocked_spam_filter rule=markdown_artifacts" in text
     assert "reads as bot traffic in SMS" in text
     assert "**Jane Doe** is on file." in text
+    assert "SMS failure classification: FIRST SAFE RETRY REQUIRED" in text
+    assert "[SILENT]" not in text
 
 
 def test_sms_retry_budget_caps_total_sends():
@@ -167,6 +237,10 @@ def test_sms_retry_budget_caps_total_sends():
     assert len(prompts) == MAX - 1
     assert f"attempt=1/{MAX}" in prompts[0]
     assert f"attempt=2/{MAX}" in prompts[1]
+    assert "FIRST SAFE RETRY REQUIRED" in prompts[0]
+    assert "[SILENT]" not in prompts[0]
+    assert "RETRY OPTIONAL" in prompts[1]
+    assert "[SILENT]" in prompts[1]
 
 
 def test_transient_sms_error_does_not_wake_agent():
@@ -195,6 +269,8 @@ def test_sms_too_long_wakes_agent():
     assert len(prompts) == 1
     assert "channel=sms stage=send_rejected" in prompts[0]
     assert "sms_too_long" in prompts[0]
+    assert "SMS failure classification: FIRST SAFE RETRY REQUIRED" in prompts[0]
+    assert "[SILENT]" not in prompts[0]
 
 
 def test_imessage_opt_out_wakes_agent():
@@ -239,6 +315,8 @@ def test_carrier_delivery_failed_wakes_agent():
     assert "[40002]" in text
     assert "flagged by a SPAM filter" in text
     assert "Sorry Kim — the site isn't built yet." in text
+    assert "SMS failure classification: FIRST SAFE RETRY REQUIRED" in text
+    assert "[SILENT]" not in text
 
 
 def test_carrier_delivery_failed_replay_is_deduped():

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,94 @@
+"""Doctor keeps identity reachability separate from remote voice config."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+from inkbox_claude import daemon, doctor
+from inkbox_claude.config import BridgeConfig, VoiceStack
+
+
+def test_voice_config_probe_failures_do_not_mark_identity_unreachable(
+    monkeypatch, tmp_path,
+):
+    identity = types.SimpleNamespace(
+        mailbox=types.SimpleNamespace(email_address="agent@example.com"),
+        phone_number=types.SimpleNamespace(number="+15551234567"),
+        imessage_enabled=False,
+        get_incoming_call_action=lambda: (_ for _ in ()).throw(
+            RuntimeError("incoming config unavailable")
+        ),
+        get_hosted_agent_config=lambda: (_ for _ in ()).throw(
+            RuntimeError("authority config unavailable")
+        ),
+    )
+    client = types.SimpleNamespace(get_identity=lambda _handle: identity)
+    inkbox_module = types.ModuleType("inkbox")
+    inkbox_module.Inkbox = lambda **_kwargs: client
+    monkeypatch.setitem(sys.modules, "inkbox", inkbox_module)
+    monkeypatch.setattr(daemon, "_maybe_load_env_file", lambda: None)
+    monkeypatch.setattr(doctor.shutil, "which", lambda _name: "/usr/bin/claude")
+    monkeypatch.setattr(
+        doctor,
+        "read_config",
+        lambda: BridgeConfig(
+            api_key="ApiKey_agent",
+            identity="agent",
+            signing_key="whsec_test",
+            project_dir=str(tmp_path),
+            voice_stack=VoiceStack.INKBOX_VOICE_AI,
+            voice_ai_authority_mode="yolo",
+        ),
+    )
+
+    checks = doctor.run_doctor()
+    by_name = {name: (ok, detail) for name, ok, detail in checks}
+    reachable = [row for row in checks if row[0] == "identity reachable"]
+
+    assert reachable == [("identity reachable", True, "agent@example.com, +15551234567")]
+    assert by_name["incoming call action"] == (
+        False,
+        "incoming config unavailable",
+    )
+    assert by_name["Voice AI authority"] == (
+        False,
+        "authority config unavailable",
+    )
+
+
+def test_doctor_reports_remote_routing_mismatch(monkeypatch, tmp_path):
+    identity = types.SimpleNamespace(
+        mailbox=types.SimpleNamespace(email_address="agent@example.com"),
+        phone_number=types.SimpleNamespace(number="+15551234567"),
+        imessage_enabled=False,
+        get_incoming_call_action=lambda: types.SimpleNamespace(
+            incoming_call_action="hosted_agent"
+        ),
+    )
+    client = types.SimpleNamespace(get_identity=lambda _handle: identity)
+    inkbox_module = types.ModuleType("inkbox")
+    inkbox_module.Inkbox = lambda **_kwargs: client
+    monkeypatch.setitem(sys.modules, "inkbox", inkbox_module)
+    monkeypatch.setattr(daemon, "_maybe_load_env_file", lambda: None)
+    monkeypatch.setattr(doctor.shutil, "which", lambda _name: "/usr/bin/claude")
+    monkeypatch.setattr(
+        doctor,
+        "read_config",
+        lambda: BridgeConfig(
+            api_key="ApiKey_agent",
+            identity="agent",
+            signing_key="whsec_test",
+            project_dir=str(tmp_path),
+            voice_stack=VoiceStack.INKBOX_TTS_STT,
+        ),
+    )
+
+    by_name = {
+        name: (ok, detail)
+        for name, ok, detail in doctor.run_doctor()
+    }
+    assert by_name["incoming call action"] == (
+        False,
+        "hosted_agent (expected auto_accept)",
+    )

--- a/tests/test_gateway_call_config.py
+++ b/tests/test_gateway_call_config.py
@@ -8,7 +8,7 @@ SDKs that predate ``set_incoming_call_action``.
 import types
 
 from inkbox_claude import gateway
-from inkbox_claude.config import BridgeConfig
+from inkbox_claude.config import BridgeConfig, VoiceStack
 
 
 class _FakeSubscriptions:
@@ -91,8 +91,10 @@ def _phone():
     return types.SimpleNamespace(id="phone-1", number="+15550001111")
 
 
-def _patched_gateway(identity, subscriptions=None):
-    gw = gateway.InkboxGateway(BridgeConfig(identity="claude", require_signature=False))
+def _patched_gateway(identity, subscriptions=None, *, voice_stack=VoiceStack.INKBOX_TTS_STT):
+    gw = gateway.InkboxGateway(BridgeConfig(
+        identity="claude", require_signature=False, voice_stack=voice_stack
+    ))
     gw._inkbox = _FakeInkbox(identity, subscriptions)
     gw._public_url = "https://agent.example"
     gw._public_host = "agent.example"
@@ -111,6 +113,17 @@ def test_incoming_call_config_is_identity_scoped_with_number():
     }
     # The identity-scoped write replaces the legacy number-scoped one.
     assert gw._inkbox.phone_numbers.updated == []
+
+
+def test_voice_ai_reconciles_hosted_incoming_action_without_local_urls():
+    identity = _Identity(phone=_phone())
+    _patched_gateway(identity, voice_stack=VoiceStack.INKBOX_VOICE_AI)
+
+    assert identity.incoming_call_kwargs == {
+        "incoming_call_action": "hosted_agent",
+        "client_websocket_url": None,
+        "incoming_call_webhook_url": None,
+    }
 
 
 def test_incoming_call_config_registered_for_imessage_only_identity():
@@ -174,9 +187,11 @@ def test_a2a_and_imessage_use_channel_coherent_subscriptions():
 
     assert [created["event_types"] for created in subscriptions.created] == [
         gateway.A2A_EVENTS,
+        gateway.CALL_EVENTS,
         gateway.IMESSAGE_EVENTS,
     ]
     assert [created["url"] for created in subscriptions.created] == [
+        "https://agent.example/webhook",
         "https://agent.example/webhook",
         "https://agent.example/webhook",
     ]
@@ -195,11 +210,10 @@ def test_imessage_reconcile_preserves_existing_a2a_channel_subscription():
     )
 
     assert subscriptions.deleted == []
-    assert subscriptions.created == [{
-        "agent_identity_id": "identity-1",
-        "url": "https://agent.example/webhook",
-        "event_types": gateway.IMESSAGE_EVENTS,
-    }]
+    assert [created["event_types"] for created in subscriptions.created] == [
+        gateway.CALL_EVENTS,
+        gateway.IMESSAGE_EVENTS,
+    ]
 
 
 def test_a2a_only_subscription_is_skipped_on_older_api():
@@ -209,4 +223,4 @@ def test_a2a_only_subscription_is_skipped_on_older_api():
         subscriptions=subscriptions,
     )
 
-    assert subscriptions.created == []
+    assert [created["event_types"] for created in subscriptions.created] == [gateway.CALL_EVENTS]

--- a/tests/test_gateway_startup_validation.py
+++ b/tests/test_gateway_startup_validation.py
@@ -1,0 +1,44 @@
+import asyncio
+
+import pytest
+
+from inkbox_claude import gateway as gateway_module
+from inkbox_claude.config import BridgeConfig, RealtimeConfig, VoiceStack
+from inkbox_claude.gateway import InkboxGateway
+
+
+def _enable_gateway_dependencies(monkeypatch):
+    monkeypatch.setattr(gateway_module, "AIOHTTP_AVAILABLE", True)
+    monkeypatch.setattr(gateway_module, "INKBOX_AVAILABLE", True)
+
+
+def test_gateway_rejects_realtime_stack_without_api_key(monkeypatch):
+    _enable_gateway_dependencies(monkeypatch)
+    gateway = InkboxGateway(BridgeConfig(
+        api_key="ApiKey_test",
+        identity="agent",
+        voice_stack=VoiceStack.OPENAI_REALTIME,
+        realtime=RealtimeConfig(enabled=False, api_key=""),
+    ))
+
+    with pytest.raises(
+        RuntimeError,
+        match="openai_realtime requires INKBOX_REALTIME_API_KEY",
+    ):
+        asyncio.run(gateway.run())
+
+
+def test_gateway_rejects_invalid_voice_ai_authority(monkeypatch):
+    _enable_gateway_dependencies(monkeypatch)
+    gateway = InkboxGateway(BridgeConfig(
+        api_key="ApiKey_test",
+        identity="agent",
+        voice_stack=VoiceStack.INKBOX_VOICE_AI,
+        voice_ai_authority_mode="unbounded",
+    ))
+
+    with pytest.raises(
+        RuntimeError,
+        match="INKBOX_VOICE_AI_AUTHORITY_MODE must be contact_scoped or yolo",
+    ):
+        asyncio.run(gateway.run())

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -231,11 +231,16 @@ def test_restart_resumes_only_recoverable_sms_correction(tmp_path, monkeypatch):
     async def scenario():
         monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
         gateway, prompts = _gateway(tmp_path)
+        payload = _payload()
+        payload["data"]["post_call_action_items"].append({
+            "action": "Update the release checklist",
+            "status": "open",
+        })
         gateway._write_hosted_call_registry(
             "call-1",
             event_id="event-call-1",
             state="running",
-            payload=_payload(),
+            payload=payload,
             outcome="completed",
         )
         assert reserve_hosted_sms_attempt(
@@ -249,6 +254,8 @@ def test_restart_resumes_only_recoverable_sms_correction(tmp_path, monkeypatch):
         assert len(prompts) == 1
         assert "[hosted_post_call_sms_correction]" in prompts[0]
         assert "Review the outcome, transcript" not in prompts[0]
+        assert "Send the summary" in prompts[0]
+        assert "Update the release checklist" not in prompts[0]
         assert gateway.sessions.session.hosted_contexts == [{
             "call_id": "call-1",
             "attempt": 2,

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -234,6 +234,7 @@ def test_hosted_sms_recoverable_failure_gets_one_correction(tmp_path):
 
         assert len(prompts) == 2
         assert "only correction attempt" in prompts[1]
+        assert "Do not return [SILENT], skip, or defer" in prompts[1]
         assert "+15551112222" in prompts[1]
         entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
         assert entry["state"] == "completed"
@@ -496,6 +497,10 @@ def test_hosted_transcript_sms_commitment_classifier_is_narrow():
     assert gateway_module._hosted_requires_sms(
         [], [("local", "After I hang up, text the release status to Dima.")]
     )
+    assert gateway_module._hosted_requires_sms(
+        [],
+        [("remote", "Don't text me now; after this call ends, text me the code.")],
+    )
     assert not gateway_module._hosted_requires_sms(
         [],
         [
@@ -527,6 +532,13 @@ def test_hosted_transcript_sms_commitment_classifier_is_narrow():
             {"status": "open", "action": "Do not send me an SMS."},
             {"status": "open", "action": "Text the operator by SMS."},
         ],
+        [],
+    )
+    assert gateway_module._hosted_requires_sms(
+        [{
+            "status": "open",
+            "action": "Do not text now; text the operator after the call.",
+        }],
         [],
     )
 

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -318,6 +318,75 @@ def test_hosted_sms_correction_requires_one_clean_success(tmp_path):
     asyncio.run(scenario())
 
 
+def test_hosted_transcript_sms_commitment_requires_settlement(tmp_path):
+    async def scenario():
+        missing = CapturedTurnResult(text="", tool_deliveries=())
+        gateway, prompts = _gateway(tmp_path, results=[missing, _sms_result()])
+        payload = _payload()
+        payload["data"]["post_call_action_items"] = []
+        payload["data"]["transcript"]["entries"] = [{
+            "party": "remote",
+            "text": "After we hang up, send me one SMS with the release status.",
+        }]
+
+        await gateway._on_hosted_call_ended(payload)
+        await _drain(gateway)
+
+        assert len(prompts) == 2
+        assert "tool was not called" in prompts[1]
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "completed"
+
+    asyncio.run(scenario())
+
+
+def test_hosted_transcript_generic_text_references_do_not_require_sms(tmp_path):
+    async def scenario():
+        gateway, prompts = _gateway(tmp_path)
+        payload = _payload()
+        payload["data"]["post_call_action_items"] = []
+        payload["data"]["transcript"]["entries"] = [
+            {"party": "remote", "text": "I got your text yesterday."},
+            {"party": "remote", "text": "Can you see my earlier SMS messages?"},
+            {"party": "local", "text": "We discussed texting during the call."},
+        ]
+
+        await gateway._on_hosted_call_ended(payload)
+        await _drain(gateway)
+
+        assert len(prompts) == 1
+        assert gateway.sessions.session.detailed_calls == 0
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "completed"
+
+    asyncio.run(scenario())
+
+
+def test_hosted_transcript_sms_commitment_classifier_is_narrow():
+    assert gateway_module._hosted_requires_sms(
+        [], [("remote", "After we hang up, text Alex with the release status.")]
+    )
+    assert gateway_module._hosted_requires_sms(
+        [], [("remote", "Could you text her the confirmation?")]
+    )
+    assert gateway_module._hosted_requires_sms(
+        [], [("remote", "Please text Alex the confirmation.")]
+    )
+    assert gateway_module._hosted_requires_sms(
+        [], [("local", "I'll text you the final result.")]
+    )
+    assert not gateway_module._hosted_requires_sms(
+        [],
+        [
+            ("remote", "I got your text yesterday."),
+            ("remote", "Can you see my earlier SMS messages?"),
+            ("local", "We discussed texting during the call."),
+            ("local", "I will send her the confirmation."),
+            ("remote", "After we hang up, send me the summary."),
+        ],
+    )
+
+
 def test_hosted_non_sms_action_preserves_plain_capture_behavior(tmp_path):
     async def scenario():
         gateway, prompts = _gateway(tmp_path)

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -97,6 +97,9 @@ def test_hosted_completion_runs_once_and_suppresses_plain_text(tmp_path):
         assert len(prompts) == 1
         assert "Remote party phone number: +15551112222" in prompts[0]
         assert "Contact memories are background only" in prompts[0]
+        assert "inkbox_send_sms" in prompts[0]
+        assert "`to` set to that exact remote number" in prompts[0]
+        assert "Do not finish until each required tool reports success" in prompts[0]
         assert "Send the summary" in prompts[0]
         assert gateway.sessions.chat_ids == ["contact-1"]
         assert json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]["state"] == "completed"

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -108,14 +108,37 @@ def test_hosted_completion_runs_once_and_suppresses_plain_text(tmp_path):
     asyncio.run(scenario())
 
 
-def test_hosted_completion_registry_is_private_and_contains_recovery_payload(tmp_path):
+def test_hosted_completion_registry_is_private_bounded_and_drops_completed_payload(tmp_path):
     async def scenario():
         gateway, _ = _gateway(tmp_path)
-        await gateway._on_hosted_call_ended(_payload())
+        payload = _payload()
+        payload["data"]["contacts"][0]["memories"] = ["private" * 20_000]
+        payload["data"]["transcript"]["entries"][0]["text"] = "secret" * 100_000
+        payload["data"]["post_call_action_items"] = [
+            {
+                "id": f"action-{index}",
+                "action": "a" * 10_000,
+                "details": "d" * 20_000,
+                "status": "open",
+            }
+            for index in range(150)
+        ]
+        await gateway._on_hosted_call_ended(payload)
+        queued = json.loads(
+            gateway._hosted_call_registry_path.read_text()
+        )["call-1"]
+        replay = queued["payload"]["data"]
+        assert "transcript" not in replay
+        assert "memories" not in replay["contacts"][0]
+        assert len(replay["post_call_action_items"]) == 100
+        assert len(replay["post_call_action_items"][0]["action"]) == 4_000
+        assert len(replay["post_call_action_items"][0]["details"]) == 8_000
+        assert gateway._hosted_call_registry_path.stat().st_mode & 0o777 == 0o600
+
         await _drain(gateway)
         entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
-        assert entry["payload"]["event_type"] == "call.ended"
-        assert gateway._hosted_call_registry_path.stat().st_mode & 0o777 == 0o600
+        assert entry["state"] == "completed"
+        assert "payload" not in entry
 
     asyncio.run(scenario())
 

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -59,15 +59,31 @@ def _payload(call_id="call-1"):
     }
 
 
+def _non_sms_payload(call_id="call-1"):
+    payload = _payload(call_id)
+    payload["data"]["post_call_action_items"] = [{
+        "action": "Update the release checklist",
+        "status": "open",
+    }]
+    payload["data"]["transcript"]["entries"] = [{
+        "party": "remote",
+        "text": "Please update the release checklist.",
+    }]
+    return payload
+
+
 class _Session:
-    def __init__(self, prompts, error=None, results=None):
+    def __init__(self, prompts, error=None, results=None, gate=None):
         self.prompts = prompts
         self.error = error
         self.results = list(results or [_sms_result()])
+        self.gate = gate
         self.detailed_calls = 0
 
     async def run_consult(self, prompt):
         self.prompts.append(prompt)
+        if self.gate is not None:
+            await self.gate.wait()
         if self.error:
             raise self.error
         return "This plain text must not be delivered"
@@ -75,17 +91,19 @@ class _Session:
     async def run_consult_detailed(self, prompt):
         self.detailed_calls += 1
         self.prompts.append(prompt)
+        if self.gate is not None:
+            await self.gate.wait()
         if self.error:
             raise self.error
         return self.results.pop(0)
 
 
 class _Sessions:
-    def __init__(self, prompts, error=None, results=None):
+    def __init__(self, prompts, error=None, results=None, gate=None):
         self.prompts = prompts
         self.error = error
         self.chat_ids = []
-        self.session = _Session(self.prompts, self.error, results)
+        self.session = _Session(self.prompts, self.error, results, gate)
 
     def get(self, chat_id):
         self.chat_ids.append(chat_id)
@@ -105,14 +123,14 @@ class _TranscriptFailureInkbox:
         return types.SimpleNamespace(list_transcripts=fail)
 
 
-def _gateway(tmp_path, *, error=None, results=None):
+def _gateway(tmp_path, *, error=None, results=None, gate=None):
     gateway_module.web = types.SimpleNamespace(json_response=lambda value: value)
     cfg = BridgeConfig(identity="claude", voice_stack=VoiceStack.INKBOX_VOICE_AI)
     gateway = InkboxGateway(cfg)
     gateway._hosted_call_registry_path = tmp_path / "hosted.json"
     gateway._inkbox = _Inkbox()
     prompts = []
-    gateway.sessions = _Sessions(prompts, error, results)
+    gateway.sessions = _Sessions(prompts, error, results, gate)
     return gateway, prompts
 
 
@@ -177,6 +195,50 @@ def test_hosted_sms_failed_correction_is_terminal_and_not_replayed(tmp_path):
         await _drain(gateway)
 
         assert len(prompts) == 2
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "failed"
+        assert entry["retryable"] is False
+
+        restarted, restarted_prompts = _gateway(tmp_path)
+        await restarted._recover_hosted_call_completions()
+        assert restarted._hosted_call_jobs == {}
+        assert restarted_prompts == []
+
+    asyncio.run(scenario())
+
+
+def test_hosted_sms_turn_exception_is_terminal_and_not_replayed(tmp_path):
+    async def scenario():
+        gateway, prompts = _gateway(
+            tmp_path, error=RuntimeError("capture transport failed")
+        )
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+
+        assert len(prompts) == 1
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "failed"
+        assert entry["retryable"] is False
+
+        restarted, restarted_prompts = _gateway(tmp_path)
+        await restarted._recover_hosted_call_completions()
+        assert restarted._hosted_call_jobs == {}
+        assert restarted_prompts == []
+
+    asyncio.run(scenario())
+
+
+def test_hosted_sms_turn_cancellation_is_terminal_and_not_replayed(tmp_path):
+    async def scenario():
+        gate = asyncio.Event()
+        gateway, prompts = _gateway(tmp_path, gate=gate)
+        await gateway._on_hosted_call_ended(_payload())
+        while not prompts:
+            await asyncio.sleep(0)
+        task = next(iter(gateway._hosted_call_jobs.values()))
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
         entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
         assert entry["state"] == "failed"
         assert entry["retryable"] is False
@@ -390,7 +452,20 @@ def test_hosted_transcript_sms_commitment_classifier_is_narrow():
             ("local", "I'll text you the final result."),
             ("remote", "After we hang up, review the text conversation."),
             ("remote", "Review the text exchange after we hang up."),
+            ("remote", "After we hang up, do not send me an SMS."),
+            ("remote", "After the call ends, don't text me."),
+            ("remote", "Never text me after the call is over."),
         ],
+    )
+    assert not gateway_module._hosted_requires_sms(
+        [{"status": "open", "action": "Do not send me an SMS."}], []
+    )
+    assert gateway_module._hosted_requires_sms(
+        [
+            {"status": "open", "action": "Do not send me an SMS."},
+            {"status": "open", "action": "Text the operator by SMS."},
+        ],
+        [],
     )
 
 
@@ -463,7 +538,7 @@ def test_full_transcript_failure_uses_inline_webhook_transcript(tmp_path):
 def test_failed_completion_is_recovered_after_restart(tmp_path):
     async def scenario():
         first, _ = _gateway(tmp_path, error=RuntimeError("Claude unavailable"))
-        await first._on_hosted_call_ended(_payload())
+        await first._on_hosted_call_ended(_non_sms_payload())
         await _drain(first)
         assert json.loads(first._hosted_call_registry_path.read_text())["call-1"]["state"] == "failed"
 
@@ -479,7 +554,7 @@ def test_failed_completion_is_recovered_after_restart(tmp_path):
 def test_recovery_remains_retryable_when_authoritative_transcript_fails(tmp_path):
     async def scenario():
         first, _ = _gateway(tmp_path, error=RuntimeError("Claude unavailable"))
-        await first._on_hosted_call_ended(_payload())
+        await first._on_hosted_call_ended(_non_sms_payload())
         await _drain(first)
 
         unsettled, prompts = _gateway(tmp_path)

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -99,7 +99,10 @@ def test_hosted_completion_runs_once_and_suppresses_plain_text(tmp_path):
         assert "Contact memories are background only" in prompts[0]
         assert "inkbox_send_sms" in prompts[0]
         assert "`to` set to that exact remote number" in prompts[0]
-        assert "Do not finish until each required tool reports success" in prompts[0]
+        assert "Every safe, still-needed commitment must be attempted" in prompts[0]
+        assert "Mark it complete only after the required tool reports success" in prompts[0]
+        assert "After a terminal error or a failed second attempt" in prompts[0]
+        assert "stop without claiming success or duplicating the send" in prompts[0]
         assert "Send the summary" in prompts[0]
         assert gateway.sessions.chat_ids == ["contact-1"]
         assert json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]["state"] == "completed"

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -389,6 +389,7 @@ def test_hosted_transcript_sms_commitment_classifier_is_narrow():
             ("remote", "Please text me the status."),
             ("local", "I'll text you the final result."),
             ("remote", "After we hang up, review the text conversation."),
+            ("remote", "Review the text exchange after we hang up."),
         ],
     )
 

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -44,7 +44,7 @@ def _payload(call_id="call-1"):
                 "reason": "Check the release",
                 "status": "completed",
             },
-            "contacts": [{"id": "contact-1", "preferred_name": "Dima"}],
+            "contacts": [{"id": "contact-1", "preferred_name": "Ada"}],
             "outcome": "completed",
             "post_call_action_items": [
                 {
@@ -541,7 +541,7 @@ def test_hosted_transcript_sms_commitment_classifier_is_narrow():
         [], [("local", "I'll send you a text message after we hang up.")]
     )
     assert gateway_module._hosted_requires_sms(
-        [], [("local", "After I hang up, text the release status to Dima.")]
+        [], [("local", "After I hang up, text the release status to Ada.")]
     )
     assert gateway_module._hosted_requires_sms(
         [],

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -367,13 +367,13 @@ def test_hosted_transcript_sms_commitment_classifier_is_narrow():
         [], [("remote", "After we hang up, text Alex with the release status.")]
     )
     assert gateway_module._hosted_requires_sms(
-        [], [("remote", "Could you text her the confirmation?")]
+        [], [("remote", "When this call ends, could you text her the confirmation?")]
     )
     assert gateway_module._hosted_requires_sms(
-        [], [("remote", "Please text Alex the confirmation.")]
+        [], [("remote", "Please text Alex the confirmation once the call is over.")]
     )
     assert gateway_module._hosted_requires_sms(
-        [], [("local", "I'll text you the final result.")]
+        [], [("local", "I'll send you a text message after we hang up.")]
     )
     assert not gateway_module._hosted_requires_sms(
         [],
@@ -383,6 +383,8 @@ def test_hosted_transcript_sms_commitment_classifier_is_narrow():
             ("local", "We discussed texting during the call."),
             ("local", "I will send her the confirmation."),
             ("remote", "After we hang up, send me the summary."),
+            ("remote", "Please text me the status."),
+            ("local", "I'll text you the final result."),
         ],
     )
 

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -375,6 +375,9 @@ def test_hosted_transcript_sms_commitment_classifier_is_narrow():
     assert gateway_module._hosted_requires_sms(
         [], [("local", "I'll send you a text message after we hang up.")]
     )
+    assert gateway_module._hosted_requires_sms(
+        [], [("local", "After I hang up, text the release status to Dima.")]
+    )
     assert not gateway_module._hosted_requires_sms(
         [],
         [
@@ -385,6 +388,7 @@ def test_hosted_transcript_sms_commitment_classifier_is_narrow():
             ("remote", "After we hang up, send me the summary."),
             ("remote", "Please text me the status."),
             ("local", "I'll text you the final result."),
+            ("remote", "After we hang up, review the text conversation."),
         ],
     )
 

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -614,6 +614,30 @@ def test_hosted_non_sms_action_preserves_plain_capture_behavior(tmp_path):
     asyncio.run(scenario())
 
 
+def test_hosted_callback_prompt_anchors_authoritative_caller_over_contact_memory(
+    tmp_path,
+):
+    async def scenario():
+        gateway, prompts = _gateway(tmp_path)
+        payload = _payload()
+        payload["data"]["post_call_action_items"] = [{
+            "action": "Call the current caller back after this call",
+            "status": "open",
+        }]
+        payload["data"]["contacts"][0].update({
+            "phone_numbers": ["+19999999999"],
+            "memories": ["A similarly named contact prefers +19999999999."],
+        })
+
+        await gateway._on_hosted_call_ended(payload)
+        await _drain(gateway)
+
+        assert "Remote party phone number: +15551112222" in prompts[0]
+        assert "must not override it" in prompts[0]
+
+    asyncio.run(scenario())
+
+
 def test_hosted_completion_registry_is_private_bounded_and_drops_completed_payload(tmp_path):
     async def scenario():
         gateway, _ = _gateway(tmp_path)

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -3,8 +3,28 @@ import json
 import types
 
 from inkbox_claude import gateway as gateway_module
-from inkbox_claude.gateway import InkboxGateway
 from inkbox_claude.config import BridgeConfig, VoiceStack
+from inkbox_claude.gateway import InkboxGateway
+from inkbox_claude.sessions import CapturedTurnResult, ToolDeliveryResult
+
+
+def _sms_result(
+    *,
+    target="+15551112222",
+    sent=True,
+    error_kind="none",
+    aborted=False,
+):
+    return CapturedTurnResult(
+        text="This plain text must not be delivered",
+        tool_deliveries=(ToolDeliveryResult(
+            mode="sms",
+            target=target,
+            sent=sent,
+            error_kind=error_kind,
+        ),),
+        aborted=aborted,
+    )
 
 
 def _payload(call_id="call-1"):
@@ -23,7 +43,11 @@ def _payload(call_id="call-1"):
             "contacts": [{"id": "contact-1", "preferred_name": "Dima"}],
             "outcome": "completed",
             "post_call_action_items": [
-                {"action": "Send the summary", "status": "open"},
+                {
+                    "action": "Send the summary",
+                    "details": "Use SMS after hangup",
+                    "status": "open",
+                },
             ],
             "transcript": {
                 "entries": [
@@ -36,9 +60,11 @@ def _payload(call_id="call-1"):
 
 
 class _Session:
-    def __init__(self, prompts, error=None):
+    def __init__(self, prompts, error=None, results=None):
         self.prompts = prompts
         self.error = error
+        self.results = list(results or [_sms_result()])
+        self.detailed_calls = 0
 
     async def run_consult(self, prompt):
         self.prompts.append(prompt)
@@ -46,16 +72,24 @@ class _Session:
             raise self.error
         return "This plain text must not be delivered"
 
+    async def run_consult_detailed(self, prompt):
+        self.detailed_calls += 1
+        self.prompts.append(prompt)
+        if self.error:
+            raise self.error
+        return self.results.pop(0)
+
 
 class _Sessions:
-    def __init__(self, prompts, error=None):
+    def __init__(self, prompts, error=None, results=None):
         self.prompts = prompts
         self.error = error
         self.chat_ids = []
+        self.session = _Session(self.prompts, self.error, results)
 
     def get(self, chat_id):
         self.chat_ids.append(chat_id)
-        return _Session(self.prompts, self.error)
+        return self.session
 
 
 class _Inkbox:
@@ -71,14 +105,14 @@ class _TranscriptFailureInkbox:
         return types.SimpleNamespace(list_transcripts=fail)
 
 
-def _gateway(tmp_path, *, error=None):
+def _gateway(tmp_path, *, error=None, results=None):
     gateway_module.web = types.SimpleNamespace(json_response=lambda value: value)
     cfg = BridgeConfig(identity="claude", voice_stack=VoiceStack.INKBOX_VOICE_AI)
     gateway = InkboxGateway(cfg)
     gateway._hosted_call_registry_path = tmp_path / "hosted.json"
     gateway._inkbox = _Inkbox()
     prompts = []
-    gateway.sessions = _Sessions(prompts, error)
+    gateway.sessions = _Sessions(prompts, error, results)
     return gateway, prompts
 
 
@@ -104,12 +138,201 @@ def test_hosted_completion_runs_once_and_suppresses_plain_text(tmp_path):
         assert "After a terminal error or a failed second attempt" in prompts[0]
         assert "stop without claiming success or duplicating the send" in prompts[0]
         assert "Send the summary" in prompts[0]
+        assert "Use SMS after hangup" in prompts[0]
         assert gateway.sessions.chat_ids == ["contact-1"]
         assert json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]["state"] == "completed"
 
         await gateway._on_hosted_call_ended(_payload())
         await _drain(gateway)
         assert len(prompts) == 1
+
+    asyncio.run(scenario())
+
+
+def test_hosted_sms_recoverable_failure_gets_one_correction(tmp_path):
+    async def scenario():
+        gateway, prompts = _gateway(tmp_path, results=[
+            _sms_result(sent=False, error_kind="recoverable"),
+            _sms_result(),
+        ])
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+
+        assert len(prompts) == 2
+        assert "only correction attempt" in prompts[1]
+        assert "+15551112222" in prompts[1]
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "completed"
+
+    asyncio.run(scenario())
+
+
+def test_hosted_sms_failed_correction_is_terminal_and_not_replayed(tmp_path):
+    async def scenario():
+        gateway, prompts = _gateway(tmp_path, results=[
+            _sms_result(sent=False, error_kind="recoverable"),
+            _sms_result(sent=False, error_kind="recoverable"),
+        ])
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+
+        assert len(prompts) == 2
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "failed"
+        assert entry["retryable"] is False
+
+        restarted, restarted_prompts = _gateway(tmp_path)
+        await restarted._recover_hosted_call_completions()
+        assert restarted._hosted_call_jobs == {}
+        assert restarted_prompts == []
+
+    asyncio.run(scenario())
+
+
+def test_hosted_sms_terminal_failure_does_not_get_correction(tmp_path):
+    async def scenario():
+        gateway, prompts = _gateway(tmp_path, results=[
+            _sms_result(sent=False, error_kind="terminal"),
+        ])
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+
+        assert len(prompts) == 1
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "failed"
+        assert entry["retryable"] is False
+
+    asyncio.run(scenario())
+
+
+def test_hosted_sms_wrong_target_does_not_get_correction(tmp_path):
+    async def scenario():
+        gateway, prompts = _gateway(tmp_path, results=[
+            _sms_result(target="+19999999999"),
+        ])
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+
+        assert len(prompts) == 1
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "failed"
+        assert entry["retryable"] is False
+
+    asyncio.run(scenario())
+
+
+def test_hosted_sms_duplicate_successes_do_not_get_correction(tmp_path):
+    async def scenario():
+        duplicate = CapturedTurnResult(
+            text="",
+            tool_deliveries=_sms_result().tool_deliveries * 2,
+        )
+        gateway, prompts = _gateway(tmp_path, results=[duplicate])
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+
+        assert len(prompts) == 1
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "failed"
+        assert entry["retryable"] is False
+
+    asyncio.run(scenario())
+
+
+def test_hosted_sms_failure_then_success_in_one_turn_is_terminal(tmp_path):
+    async def scenario():
+        mixed = CapturedTurnResult(
+            text="",
+            tool_deliveries=(
+                _sms_result(sent=False, error_kind="recoverable").tool_deliveries[0],
+                _sms_result().tool_deliveries[0],
+            ),
+        )
+        gateway, prompts = _gateway(tmp_path, results=[mixed])
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+
+        assert len(prompts) == 1
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "failed"
+        assert entry["retryable"] is False
+
+    asyncio.run(scenario())
+
+
+def test_hosted_sms_aborted_capture_is_terminal_without_correction(tmp_path):
+    async def scenario():
+        gateway, prompts = _gateway(tmp_path, results=[_sms_result(aborted=True)])
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+
+        assert len(prompts) == 1
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "failed"
+        assert entry["retryable"] is False
+
+        restarted, restarted_prompts = _gateway(tmp_path)
+        await restarted._recover_hosted_call_completions()
+        assert restarted._hosted_call_jobs == {}
+        assert restarted_prompts == []
+
+    asyncio.run(scenario())
+
+
+def test_hosted_sms_missing_attempt_gets_one_clean_correction(tmp_path):
+    async def scenario():
+        missing = CapturedTurnResult(text="", tool_deliveries=())
+        gateway, prompts = _gateway(tmp_path, results=[missing, _sms_result()])
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+
+        assert len(prompts) == 2
+        assert "tool was not called" in prompts[1]
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "completed"
+
+    asyncio.run(scenario())
+
+
+def test_hosted_sms_correction_requires_one_clean_success(tmp_path):
+    async def scenario():
+        mixed = CapturedTurnResult(
+            text="",
+            tool_deliveries=(
+                _sms_result().tool_deliveries[0],
+                _sms_result(sent=False, error_kind="recoverable").tool_deliveries[0],
+            ),
+        )
+        gateway, prompts = _gateway(tmp_path, results=[
+            _sms_result(sent=False, error_kind="recoverable"),
+            mixed,
+        ])
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+
+        assert len(prompts) == 2
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "failed"
+        assert entry["retryable"] is False
+
+    asyncio.run(scenario())
+
+
+def test_hosted_non_sms_action_preserves_plain_capture_behavior(tmp_path):
+    async def scenario():
+        gateway, prompts = _gateway(tmp_path)
+        payload = _payload()
+        payload["data"]["post_call_action_items"] = [{
+            "action": "Update the release checklist",
+            "status": "open",
+        }]
+        await gateway._on_hosted_call_ended(payload)
+        await _drain(gateway)
+
+        assert len(prompts) == 1
+        assert gateway.sessions.session.detailed_calls == 0
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "completed"
 
     asyncio.run(scenario())
 

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -5,6 +5,7 @@ import types
 from inkbox_claude import gateway as gateway_module
 from inkbox_claude.config import BridgeConfig, VoiceStack
 from inkbox_claude.gateway import InkboxGateway
+from inkbox_claude.hosted_sms_guard import reserve_hosted_sms_attempt
 from inkbox_claude.sessions import CapturedTurnResult, ToolDeliveryResult
 
 
@@ -88,9 +89,10 @@ class _Session:
             raise self.error
         return "This plain text must not be delivered"
 
-    async def run_consult_detailed(self, prompt):
+    async def run_consult_detailed(self, prompt, **kwargs):
         self.detailed_calls += 1
         self.prompts.append(prompt)
+        self.hosted_contexts.append(kwargs.get("hosted_sms_context"))
         if self.gate is not None:
             await self.gate.wait()
         if self.error:
@@ -104,6 +106,7 @@ class _Sessions:
         self.error = error
         self.chat_ids = []
         self.session = _Session(self.prompts, self.error, results, gate)
+        self.session.hosted_contexts = []
 
     def get(self, chat_id):
         self.chat_ids.append(chat_id)
@@ -163,6 +166,59 @@ def test_hosted_completion_runs_once_and_suppresses_plain_text(tmp_path):
         await gateway._on_hosted_call_ended(_payload())
         await _drain(gateway)
         assert len(prompts) == 1
+
+    asyncio.run(scenario())
+
+
+def test_hosted_sms_context_is_bound_to_each_bounded_attempt(tmp_path):
+    async def scenario():
+        gateway, _prompts = _gateway(tmp_path, results=[
+            _sms_result(sent=False, error_kind="recoverable"),
+            _sms_result(),
+        ])
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+
+        assert gateway.sessions.session.hosted_contexts == [
+            {
+                "call_id": "call-1",
+                "attempt": 1,
+                "remote_phone": "+15551112222",
+            },
+            {
+                "call_id": "call-1",
+                "attempt": 2,
+                "remote_phone": "+15551112222",
+            },
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_restart_does_not_replay_a_reserved_hosted_sms_attempt(tmp_path, monkeypatch):
+    async def scenario():
+        monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
+        gateway, _prompts = _gateway(tmp_path)
+        gateway._write_hosted_call_registry(
+            "call-1",
+            event_id="event-call-1",
+            state="running",
+            payload=_payload(),
+        )
+        assert reserve_hosted_sms_attempt(
+            "call-1", 1, "+15551112222"
+        ) is True
+
+        restarted, restarted_prompts = _gateway(tmp_path)
+        await restarted._recover_hosted_call_completions()
+
+        assert restarted._hosted_call_jobs == {}
+        assert restarted_prompts == []
+        entry = json.loads(
+            restarted._hosted_call_registry_path.read_text()
+        )["call-1"]
+        assert entry["state"] == "failed"
+        assert entry["retryable"] is False
 
     asyncio.run(scenario())
 
@@ -459,6 +515,12 @@ def test_hosted_transcript_sms_commitment_classifier_is_narrow():
     )
     assert not gateway_module._hosted_requires_sms(
         [{"status": "open", "action": "Do not send me an SMS."}], []
+    )
+    assert not gateway_module._hosted_requires_sms(
+        [{"status": "open", "action": "Review the text exchange."}], []
+    )
+    assert not gateway_module._hosted_requires_sms(
+        [{"status": "open", "action": "Search SMS history."}], []
     )
     assert gateway_module._hosted_requires_sms(
         [

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -171,6 +171,32 @@ def test_failed_completion_is_recovered_after_restart(tmp_path):
     asyncio.run(scenario())
 
 
+def test_recovery_remains_retryable_when_authoritative_transcript_fails(tmp_path):
+    async def scenario():
+        first, _ = _gateway(tmp_path, error=RuntimeError("Claude unavailable"))
+        await first._on_hosted_call_ended(_payload())
+        await _drain(first)
+
+        unsettled, prompts = _gateway(tmp_path)
+        unsettled._inkbox = _TranscriptFailureInkbox()
+        await unsettled._recover_hosted_call_completions()
+        await _drain(unsettled)
+        entry = json.loads(
+            unsettled._hosted_call_registry_path.read_text()
+        )["call-1"]
+        assert entry["state"] == "failed"
+        assert prompts == []
+
+        settled, prompts = _gateway(tmp_path)
+        await settled._recover_hosted_call_completions()
+        await _drain(settled)
+        entry = json.loads(settled._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "completed"
+        assert len(prompts) == 1
+
+    asyncio.run(scenario())
+
+
 def test_non_hosted_call_does_not_start_completion_turn(tmp_path):
     async def scenario():
         gateway, prompts = _gateway(tmp_path)

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -1,0 +1,161 @@
+import asyncio
+import json
+import types
+
+from inkbox_claude import gateway as gateway_module
+from inkbox_claude.gateway import InkboxGateway
+from inkbox_claude.config import BridgeConfig, VoiceStack
+
+
+def _payload(call_id="call-1"):
+    return {
+        "id": f"event-{call_id}",
+        "event_type": "call.ended",
+        "data": {
+            "call": {
+                "id": call_id,
+                "mode": "hosted_agent",
+                "direction": "outbound",
+                "remote_phone_number": "+15551112222",
+                "reason": "Check the release",
+                "status": "completed",
+            },
+            "contacts": [{"id": "contact-1", "preferred_name": "Dima"}],
+            "outcome": "completed",
+            "post_call_action_items": [
+                {"action": "Send the summary", "status": "open"},
+            ],
+            "transcript": {
+                "entries": [
+                    {"party": "remote", "text": "Please send the summary."},
+                    {"party": "local", "text": "I will."},
+                ],
+            },
+        },
+    }
+
+
+class _Session:
+    def __init__(self, prompts, error=None):
+        self.prompts = prompts
+        self.error = error
+
+    async def run_consult(self, prompt):
+        self.prompts.append(prompt)
+        if self.error:
+            raise self.error
+        return "This plain text must not be delivered"
+
+
+class _Sessions:
+    def __init__(self, prompts, error=None):
+        self.prompts = prompts
+        self.error = error
+        self.chat_ids = []
+
+    def get(self, chat_id):
+        self.chat_ids.append(chat_id)
+        return _Session(self.prompts, self.error)
+
+
+class _Inkbox:
+    def get_identity(self, _handle):
+        return types.SimpleNamespace(list_transcripts=lambda _call_id: [])
+
+
+class _TranscriptFailureInkbox:
+    def get_identity(self, _handle):
+        def fail(_call_id):
+            raise RuntimeError("transcript endpoint not settled")
+
+        return types.SimpleNamespace(list_transcripts=fail)
+
+
+def _gateway(tmp_path, *, error=None):
+    gateway_module.web = types.SimpleNamespace(json_response=lambda value: value)
+    cfg = BridgeConfig(identity="claude", voice_stack=VoiceStack.INKBOX_VOICE_AI)
+    gateway = InkboxGateway(cfg)
+    gateway._hosted_call_registry_path = tmp_path / "hosted.json"
+    gateway._inkbox = _Inkbox()
+    prompts = []
+    gateway.sessions = _Sessions(prompts, error)
+    return gateway, prompts
+
+
+async def _drain(gateway):
+    await asyncio.sleep(0)
+    tasks = list(gateway._hosted_call_jobs.values())
+    if tasks:
+        await asyncio.gather(*tasks)
+
+
+def test_hosted_completion_runs_once_and_suppresses_plain_text(tmp_path):
+    async def scenario():
+        gateway, prompts = _gateway(tmp_path)
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+        assert len(prompts) == 1
+        assert "Remote party phone number: +15551112222" in prompts[0]
+        assert "Contact memories are background only" in prompts[0]
+        assert "Send the summary" in prompts[0]
+        assert gateway.sessions.chat_ids == ["contact-1"]
+        assert json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]["state"] == "completed"
+
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+        assert len(prompts) == 1
+
+    asyncio.run(scenario())
+
+
+def test_hosted_completion_registry_is_private_and_contains_recovery_payload(tmp_path):
+    async def scenario():
+        gateway, _ = _gateway(tmp_path)
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["payload"]["event_type"] == "call.ended"
+        assert gateway._hosted_call_registry_path.stat().st_mode & 0o777 == 0o600
+
+    asyncio.run(scenario())
+
+
+def test_full_transcript_failure_uses_inline_webhook_transcript(tmp_path):
+    async def scenario():
+        gateway, prompts = _gateway(tmp_path)
+        gateway._inkbox = _TranscriptFailureInkbox()
+        await gateway._on_hosted_call_ended(_payload())
+        await _drain(gateway)
+        assert "Please send the summary." in prompts[0]
+        assert json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]["state"] == "completed"
+
+    asyncio.run(scenario())
+
+
+def test_failed_completion_is_recovered_after_restart(tmp_path):
+    async def scenario():
+        first, _ = _gateway(tmp_path, error=RuntimeError("Claude unavailable"))
+        await first._on_hosted_call_ended(_payload())
+        await _drain(first)
+        assert json.loads(first._hosted_call_registry_path.read_text())["call-1"]["state"] == "failed"
+
+        restarted, prompts = _gateway(tmp_path)
+        await restarted._recover_hosted_call_completions()
+        await _drain(restarted)
+        assert len(prompts) == 1
+        assert json.loads(restarted._hosted_call_registry_path.read_text())["call-1"]["state"] == "completed"
+
+    asyncio.run(scenario())
+
+
+def test_non_hosted_call_does_not_start_completion_turn(tmp_path):
+    async def scenario():
+        gateway, prompts = _gateway(tmp_path)
+        payload = _payload()
+        payload["data"]["call"]["mode"] = "client_websocket"
+        await gateway._on_hosted_call_ended(payload)
+        await _drain(gateway)
+        assert prompts == []
+        assert not gateway._hosted_call_registry_path.exists()
+
+    asyncio.run(scenario())

--- a/tests/test_hosted_call_completion.py
+++ b/tests/test_hosted_call_completion.py
@@ -5,7 +5,10 @@ import types
 from inkbox_claude import gateway as gateway_module
 from inkbox_claude.config import BridgeConfig, VoiceStack
 from inkbox_claude.gateway import InkboxGateway
-from inkbox_claude.hosted_sms_guard import reserve_hosted_sms_attempt
+from inkbox_claude.hosted_sms_guard import (
+    reserve_hosted_sms_attempt,
+    settle_hosted_sms_attempt,
+)
 from inkbox_claude.sessions import CapturedTurnResult, ToolDeliveryResult
 
 
@@ -219,6 +222,41 @@ def test_restart_does_not_replay_a_reserved_hosted_sms_attempt(tmp_path, monkeyp
         )["call-1"]
         assert entry["state"] == "failed"
         assert entry["retryable"] is False
+        assert "payload" not in entry
+
+    asyncio.run(scenario())
+
+
+def test_restart_resumes_only_recoverable_sms_correction(tmp_path, monkeypatch):
+    async def scenario():
+        monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
+        gateway, prompts = _gateway(tmp_path)
+        gateway._write_hosted_call_registry(
+            "call-1",
+            event_id="event-call-1",
+            state="running",
+            payload=_payload(),
+            outcome="completed",
+        )
+        assert reserve_hosted_sms_attempt(
+            "call-1", 1, "+15551112222"
+        ) is True
+        settle_hosted_sms_attempt("call-1", 1, "recoverable")
+
+        await gateway._recover_hosted_call_completions()
+        await _drain(gateway)
+
+        assert len(prompts) == 1
+        assert "[hosted_post_call_sms_correction]" in prompts[0]
+        assert "Review the outcome, transcript" not in prompts[0]
+        assert gateway.sessions.session.hosted_contexts == [{
+            "call_id": "call-1",
+            "attempt": 2,
+            "remote_phone": "+15551112222",
+        }]
+        entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
+        assert entry["state"] == "completed"
+        assert "payload" not in entry
 
     asyncio.run(scenario())
 
@@ -255,6 +293,7 @@ def test_hosted_sms_failed_correction_is_terminal_and_not_replayed(tmp_path):
         entry = json.loads(gateway._hosted_call_registry_path.read_text())["call-1"]
         assert entry["state"] == "failed"
         assert entry["retryable"] is False
+        assert "payload" not in entry
 
         restarted, restarted_prompts = _gateway(tmp_path)
         await restarted._recover_hosted_call_completions()
@@ -500,6 +539,12 @@ def test_hosted_transcript_sms_commitment_classifier_is_narrow():
     assert gateway_module._hosted_requires_sms(
         [],
         [("remote", "Don't text me now; after this call ends, text me the code.")],
+    )
+    assert gateway_module._hosted_requires_sms(
+        [], [("remote", "After this call ends; text me release-ready.")]
+    )
+    assert gateway_module._hosted_requires_sms(
+        [], [("remote", "Text me release-ready. Do it once this call is over.")]
     )
     assert not gateway_module._hosted_requires_sms(
         [],

--- a/tests/test_live_cross_channel_contract_helpers.py
+++ b/tests/test_live_cross_channel_contract_helpers.py
@@ -1,0 +1,88 @@
+"""Deterministic proof for cross-channel call-leg correlation."""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _load_cross_channel_module():
+    path = Path(__file__).parent / "live" / "test_cross_channel.py"
+    spec = importlib.util.spec_from_file_location("claude_live_cross_channel", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cross = _load_cross_channel_module()
+
+
+class _Calls:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def list(self, **_kwargs):
+        return list(self.rows)
+
+
+def _record(record_id, direction, remote, created_at, voicemail="enabled"):
+    return SimpleNamespace(
+        id=record_id,
+        direction=direction,
+        remote_phone_number=remote,
+        created_at=created_at,
+        voicemail_detection=voicemail,
+    )
+
+
+def test_wait_for_call_pair_returns_aut_outbound_not_driver_inbound(monkeypatch):
+    stamp = datetime(2026, 8, 1, 12, 0, tzinfo=UTC)
+    driver = _record("driver-1", "inbound", "+12025550111", stamp, "enabled")
+    wrong_aut = _record("aut-wrong", "outbound", "+12025550199", stamp)
+    aut = _record("aut-1", "outbound", "+12025550110", stamp, "disabled")
+    sleeps = []
+    monkeypatch.setattr(cross.time, "sleep", sleeps.append)
+
+    selected = cross._wait_for_new_call_pair(
+        SimpleNamespace(calls=_Calls([driver])),
+        SimpleNamespace(calls=_Calls([wrong_aut, aut])),
+        remote_pid="remote-number-id",
+        remote_phone="+12025550110",
+        aut_phone="+12025550111",
+        before_driver=set(),
+        before_aut=set(),
+        driver_watermark=stamp - timedelta(seconds=1),
+        aut_watermark=stamp - timedelta(seconds=1),
+    )
+
+    assert selected is aut
+    assert cross._voicemail_detection_value(selected) == "disabled"
+    assert sleeps == [cross.CALL_DUPLICATE_GRACE_S]
+
+
+def test_wait_for_call_pair_rejects_duplicate_aut_legs(monkeypatch):
+    stamp = datetime(2026, 8, 1, 12, 0, tzinfo=UTC)
+    driver = _record("driver-1", "inbound", "+12025550111", stamp)
+    aut_calls = [
+        _record("aut-1", "outbound", "+12025550110", stamp),
+        _record("aut-2", "outbound", "+12025550110", stamp),
+    ]
+    monkeypatch.setattr(cross.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(AssertionError, match="duplicate AUT call legs"):
+        cross._wait_for_new_call_pair(
+            SimpleNamespace(calls=_Calls([driver])),
+            SimpleNamespace(calls=_Calls(aut_calls)),
+            remote_pid="remote-number-id",
+            remote_phone="+12025550110",
+            aut_phone="+12025550111",
+            before_driver=set(),
+            before_aut=set(),
+            driver_watermark=stamp - timedelta(seconds=1),
+            aut_watermark=stamp - timedelta(seconds=1),
+        )

--- a/tests/test_live_voice_contract_helpers.py
+++ b/tests/test_live_voice_contract_helpers.py
@@ -1,0 +1,70 @@
+"""Deterministic checks for the hosted-call live-test evidence helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_voice_module():
+    path = Path(__file__).parent / "live" / "test_voice.py"
+    spec = importlib.util.spec_from_file_location("claude_live_voice_helpers", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+voice = _load_voice_module()
+
+
+def test_spoken_marker_normalizes_punctuation_and_case():
+    assert voice._spoken_key("Victor-Echo, JULIET!") == "victorechojuliet"
+
+
+def test_after_call_sms_intent_requires_after_call_language():
+    assert voice._has_after_call_sms_intent(
+        "After we hang up, send an S.M.S. containing Victor Echo."
+    )
+    assert not voice._has_after_call_sms_intent(
+        "Send an SMS containing Victor Echo during this call."
+    )
+
+
+def test_sms_targets_include_recipient_rows():
+    message = SimpleNamespace(
+        remote_phone_number=None,
+        recipients=[SimpleNamespace(recipient_phone_number="+1 (516) 555-0101")],
+    )
+    assert voice._sms_target_numbers(message) == {"15165550101"}
+
+
+def test_record_timestamp_accepts_datetime_and_iso_z():
+    stamp = datetime(2026, 8, 1, 12, 0, tzinfo=UTC)
+    assert voice._message_created_at(SimpleNamespace(created_at=stamp)) == stamp
+    assert voice._message_created_at(
+        SimpleNamespace(created_at="2026-08-01T12:00:00Z")
+    ) == stamp
+
+
+def test_matching_post_call_action_requires_open_current_marker_sms():
+    marker = "victor echo juliet"
+    matching = {
+        "status": "open",
+        "action": "send_sms",
+        "details": "After the call, send Victor-Echo, Juliet to the caller.",
+    }
+    assert voice._matching_post_call_action(
+        SimpleNamespace(post_call_action_items=[matching]), marker
+    ) is matching
+
+    for item in (
+        {**matching, "status": "canceled"},
+        {**matching, "details": "Send a different marker."},
+        {**matching, "action": "create_note", "details": marker},
+    ):
+        assert voice._matching_post_call_action(
+            SimpleNamespace(post_call_action_items=[item]), marker
+        ) is None

--- a/tests/test_live_voice_contract_helpers.py
+++ b/tests/test_live_voice_contract_helpers.py
@@ -22,6 +22,7 @@ voice = _load_voice_module()
 
 def test_spoken_marker_normalizes_punctuation_and_case():
     assert voice._spoken_key("Victor-Echo, JULIET!") == "victorechojuliet"
+    assert voice._spoken_key("cloudpapa") == voice._spoken_key("Claude Papa")
 
 
 def test_after_call_sms_intent_requires_after_call_language():

--- a/tests/test_live_voice_contract_helpers.py
+++ b/tests/test_live_voice_contract_helpers.py
@@ -49,6 +49,16 @@ def test_record_timestamp_accepts_datetime_and_iso_z():
     ) == stamp
 
 
+def test_voicemail_detection_value_accepts_sdk_enum_or_wire_string():
+    enum_like = SimpleNamespace(value="disabled")
+    assert voice._voicemail_detection_value(
+        SimpleNamespace(voicemail_detection=enum_like)
+    ) == "disabled"
+    assert voice._voicemail_detection_value(
+        SimpleNamespace(voicemail_detection="disabled")
+    ) == "disabled"
+
+
 def test_matching_post_call_action_requires_open_current_marker_sms():
     marker = "victor echo juliet"
     matching = {

--- a/tests/test_live_voice_contract_helpers.py
+++ b/tests/test_live_voice_contract_helpers.py
@@ -7,6 +7,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 
 def _load_voice_module():
     path = Path(__file__).parent / "live" / "test_voice.py"
@@ -60,6 +62,45 @@ def test_voicemail_detection_value_accepts_sdk_enum_or_wire_string():
     ) == "disabled"
 
 
+def test_call_pair_correlation_keeps_driver_and_aut_ownership():
+    stamp = datetime(2026, 8, 1, 12, 0, tzinfo=UTC)
+    driver = SimpleNamespace(
+        id="driver-1", created_at=stamp, voicemail_detection="enabled"
+    )
+    aut = SimpleNamespace(
+        id="aut-1", created_at=stamp, voicemail_detection="disabled"
+    )
+
+    assert voice._correlate_fresh_call_pair(
+        [driver],
+        [aut],
+        before_driver=set(),
+        before_aut=set(),
+        driver_watermark=stamp,
+        aut_watermark=stamp,
+    ) == (driver, aut)
+
+
+def test_call_pair_duplicate_diagnostic_names_owner_and_ids():
+    stamp = datetime(2026, 8, 1, 12, 0, tzinfo=UTC)
+    driver = SimpleNamespace(id="driver-1", created_at=stamp)
+    aut = [
+        SimpleNamespace(id="aut-1", created_at=stamp),
+        SimpleNamespace(id="aut-2", created_at=stamp),
+    ]
+
+    with pytest.raises(
+        AssertionError,
+        match=r"phase=call_pairing .*aut-1.*aut-2.*duplicate AUT legs",
+    ):
+        voice._correlate_fresh_call_pair(
+            [driver],
+            aut,
+            before_driver=set(),
+            before_aut=set(),
+            driver_watermark=stamp,
+            aut_watermark=stamp,
+        )
 def test_matching_post_call_action_requires_open_current_marker_sms():
     marker = "victor echo juliet"
     matching = {

--- a/tests/test_live_voice_contract_helpers.py
+++ b/tests/test_live_voice_contract_helpers.py
@@ -101,6 +101,8 @@ def test_call_pair_duplicate_diagnostic_names_owner_and_ids():
             driver_watermark=stamp,
             aut_watermark=stamp,
         )
+
+
 def test_matching_post_call_action_requires_open_current_marker_sms():
     marker = "victor echo juliet"
     matching = {
@@ -120,3 +122,35 @@ def test_matching_post_call_action_requires_open_current_marker_sms():
         assert voice._matching_post_call_action(
             SimpleNamespace(post_call_action_items=[item]), marker
         ) is None
+
+
+def test_action_gate_diagnostic_is_bounded_and_content_redacted():
+    secret = "customer-secret-" * 10_000
+    call = SimpleNamespace(
+        post_call_action_items=[
+            {
+                "status": "open",
+                "action": "send_sms",
+                "details": f"Send Victor Echo Juliet {secret}",
+            },
+            *[
+                {"status": "closed", "action": secret, "details": secret}
+                for _ in range(15)
+            ],
+        ]
+    )
+
+    diagnostic = voice._post_call_action_diagnostic(
+        call,
+        "Victor Echo Juliet",
+    )
+
+    assert diagnostic == {
+        "item_count": 16,
+        "inspected_count": 10,
+        "open_count": 1,
+        "marker_count": 1,
+        "sms_count": 1,
+        "matching_action": True,
+    }
+    assert "customer-secret" not in repr(diagnostic)

--- a/tests/test_live_voice_contract_helpers.py
+++ b/tests/test_live_voice_contract_helpers.py
@@ -22,6 +22,17 @@ def _load_voice_module():
 voice = _load_voice_module()
 
 
+def test_workflow_requires_action_first_exact_body_and_readback():
+    workflow = (Path(__file__).parent.parent / ".github/workflows/live-voice.yml").read_text()
+
+    assert (
+        "After we hang up, send me one SMS. Create the post-call action now with "
+        "this exact SMS body: $marker. Read those five words back to me after the "
+        "action is saved. Do not send it during the call."
+        in workflow
+    )
+
+
 def test_spoken_marker_normalizes_punctuation_and_case():
     assert voice._spoken_key("Victor-Echo, JULIET!") == "victorechojuliet"
     assert voice._spoken_key("cloudpapa") == voice._spoken_key("Claude Papa")

--- a/tests/test_live_voice_helpers.py
+++ b/tests/test_live_voice_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -82,14 +83,34 @@ def test_wait_for_two_way_call_checks_terminal_state_while_transcripts_are_unava
     assert "status='failed'" in str(exc.value)
 
 
-def test_wait_for_call_end_returns_after_scripted_driver_completes():
+def test_wait_for_persisted_hosted_request_requires_transcript_and_action():
     voice = _load_live_voice_module()
-    client = SimpleNamespace(calls=_Calls(
+    marker = "victor echo juliet"
+    remote = SimpleNamespace(calls=_Calls(
         call=SimpleNamespace(
-            status="completed", reason="test", hangup_reason="remote",
-            started_at="before", ended_at="now", is_blocked=False,
+            status="answered", reason="test", hangup_reason=None,
+            started_at="before", ended_at=None, is_blocked=False,
         ),
+        transcripts=[SimpleNamespace(
+            party="local",
+            text=f"After this call ends, send one SMS containing {marker}.",
+        )],
+    ))
+    aut = SimpleNamespace(calls=_Calls(
+        call=SimpleNamespace(post_call_action_items=[{
+            "status": "open",
+            "action": "send_sms",
+            "details": f"Send {marker} to the caller.",
+        }]),
         transcripts=[],
     ))
 
-    assert voice._wait_for_call_end(client, "call-id") is None
+    assert voice._wait_for_persisted_hosted_request(
+        remote,
+        "unused-number-id",
+        "driver-call-id",
+        aut,
+        "aut-call-id",
+        marker,
+        deadline=time.monotonic() + 1,
+    ) is None

--- a/tests/test_live_voice_helpers.py
+++ b/tests/test_live_voice_helpers.py
@@ -80,3 +80,16 @@ def test_wait_for_two_way_call_checks_terminal_state_while_transcripts_are_unava
 
     assert "transcripts not ready" in str(exc.value)
     assert "status='failed'" in str(exc.value)
+
+
+def test_wait_for_call_end_returns_after_scripted_driver_completes():
+    voice = _load_live_voice_module()
+    client = SimpleNamespace(calls=_Calls(
+        call=SimpleNamespace(
+            status="completed", reason="test", hangup_reason="remote",
+            started_at="before", ended_at="now", is_blocked=False,
+        ),
+        transcripts=[],
+    ))
+
+    assert voice._wait_for_call_end(client, "call-id") is None

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -100,6 +100,59 @@ def test_stop_command_aborts_queued_detailed_capture():
     asyncio.run(scenario())
 
 
+def test_clear_command_aborts_queued_detailed_capture():
+    async def scenario():
+        sent = []
+        session = make_session(sent)
+        parked_worker = asyncio.create_task(asyncio.sleep(30))
+        session._worker = parked_worker
+        consult = asyncio.create_task(session.run_consult_detailed("post-call"))
+        await asyncio.sleep(0)
+
+        await session.handle_inbound("/clear", "sms", {"to": "+15551112222"})
+
+        result = await asyncio.wait_for(consult, timeout=1)
+        assert result.aborted is True
+        assert result.tool_deliveries == ()
+        assert sent[-1][1].startswith("Started a fresh conversation")
+        parked_worker.cancel()
+
+    asyncio.run(scenario())
+
+
+def test_stop_command_aborts_running_detailed_capture():
+    async def scenario():
+        sent = []
+        session = make_session(sent)
+        started = asyncio.Event()
+        interrupted = asyncio.Event()
+
+        class FakeClient:
+            async def query(self, _text):
+                started.set()
+
+            async def receive_response(self):
+                await interrupted.wait()
+                raise RuntimeError("Claude turn interrupted")
+                yield  # pragma: no cover
+
+            async def interrupt(self):
+                interrupted.set()
+
+        session._client = FakeClient()
+        consult = asyncio.create_task(session.run_consult_detailed("post-call"))
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        await session.handle_inbound("/stop", "sms", {"to": "+15551112222"})
+
+        result = await asyncio.wait_for(consult, timeout=1)
+        assert result.aborted is True
+        assert result.tool_deliveries == ()
+        assert sent[-1][1] == "Stopped."
+
+    asyncio.run(scenario())
+
+
 def test_clear_command_aborts_running_detailed_capture():
     async def scenario():
         sent = []
@@ -316,10 +369,12 @@ def test_tool_failure_capture_keeps_only_sanitized_classification():
         (422, {"error": "message_blocked_spam_filter", "rule": "emoji_overload"}, "recoverable"),
         (422, {"error": "message_blocked_spam_filter", "rule": "profanity"}, "recoverable"),
         (422, {"error": "content_rejected_by_carrier"}, "recoverable"),
-        (502, {"error": "carrier_unavailable"}, "recoverable"),
-        (429, {"error": "carrier_rate_limit"}, "recoverable"),
-        (None, {"error": "carrier_rate_limit"}, "recoverable"),
-        (None, {"error": "inkbox_duplicate_body"}, "recoverable"),
+        (502, {"error": "carrier_unavailable"}, "terminal"),
+        (429, {"error": "carrier_rate_limit"}, "terminal"),
+        (None, {"error": "carrier_rate_limit"}, "terminal"),
+        (None, {"error": "inkbox_duplicate_body"}, "terminal"),
+        (408, {"error": "request_timeout"}, "terminal"),
+        (503, {"error": "upstream_failure"}, "terminal"),
         (None, {"error": "forbidden"}, "terminal"),
         (403, {"error": "recipient_opted_out"}, "terminal"),
         (422, {"error": "invalid_phone_number"}, "terminal"),
@@ -345,6 +400,7 @@ def test_tool_failure_capture_uses_structured_sms_policy(status, detail, expecte
 
 
 def test_hosted_tool_status_rules_do_not_broaden_normal_delivery_policy():
+    assert sms_delivery_failure_policy("carrier_unavailable", "") == "retry"
     assert sms_delivery_failure_policy("carrier_rate_limit", "") == "conditional"
     assert sms_delivery_failure_policy("inkbox_duplicate_body", "") == "conditional"
     assert sms_delivery_failure_policy("forbidden", "") == "conditional"

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -11,6 +11,7 @@ from inkbox_claude.delivery_policy import (
     sms_delivery_failure_policy,
     sms_tool_failure_kind,
 )
+from inkbox_claude.hosted_sms_guard import hosted_sms_attempt_state
 from inkbox_claude.sessions import (
     ContactSession,
     _parse_index,
@@ -38,6 +39,93 @@ def make_session(sent, typing=None):
         identity_info={"handle": "t", "email": "", "phone": ""},
         typing_fn=typing_fn,
     )
+
+
+def test_hosted_sms_preflight_is_durable_exact_target_and_single_use(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
+    session = make_session([])
+    session._turn_active = True
+    session._current_hosted_sms_context = {
+        "call_id": "call-1",
+        "attempt": 1,
+        "remote_phone": "+15551112222",
+    }
+
+    blocked = session.preflight_hosted_sms("+15559990000")
+    assert blocked and blocked["kind"] == "terminal"
+    assert blocked["message"].startswith("Hosted-call SMS target does not match")
+    assert hosted_sms_attempt_state("call-1", 1) is None
+    assert session.preflight_hosted_sms("+15551112222") is None
+    assert hosted_sms_attempt_state("call-1", 1) == "pending"
+    duplicate = session.preflight_hosted_sms("+15551112222")
+    assert duplicate and duplicate["kind"] == "duplicate"
+    assert "duplicate send blocked" in duplicate["message"]
+
+    session.mark_tool_delivery("sms", "+15551112222")
+    assert hosted_sms_attempt_state("call-1", 1) == "success"
+    attempt_path = next((tmp_path / "hosted_sms_attempts").glob("*.json"))
+    assert attempt_path.stat().st_mode & 0o777 == 0o600
+    assert attempt_path.parent.stat().st_mode & 0o777 == 0o700
+
+    restarted = make_session([])
+    restarted._turn_active = True
+    restarted._current_hosted_sms_context = dict(
+        session._current_hosted_sms_context
+    )
+    duplicate = restarted.preflight_hosted_sms("+15551112222")
+    assert duplicate and duplicate["kind"] == "duplicate"
+
+
+def test_hosted_sms_recoverable_result_settles_reserved_attempt(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
+    session = make_session([])
+    session._turn_active = True
+    session._current_hosted_sms_context = {
+        "call_id": "call-2",
+        "attempt": 1,
+        "remote_phone": "+15551112222",
+    }
+    assert session.preflight_hosted_sms("+15551112222") is None
+
+    session.mark_tool_failure(
+        "sms",
+        "+15551112222",
+        "SMS message is too long; maximum is 1600 characters.",
+    )
+
+    assert hosted_sms_attempt_state("call-2", 1) == "recoverable"
+
+
+def test_hosted_sms_terminal_preflight_failure_is_durably_settled(
+    tmp_path, monkeypatch,
+):
+    class Forbidden(RuntimeError):
+        error_code = "forbidden"
+
+    monkeypatch.setenv("INKBOX_CLAUDE_HOME", str(tmp_path))
+    session = make_session([])
+    session._turn_active = True
+    session._current_hosted_sms_context = {
+        "call_id": "call-3",
+        "attempt": 1,
+        "remote_phone": "+15551112222",
+    }
+
+    blocked = session.preflight_hosted_sms("+15559990000")
+    assert blocked and blocked["kind"] == "terminal"
+    session.mark_tool_failure(
+        "sms",
+        "+15559990000",
+        Forbidden(blocked["message"]),
+    )
+
+    assert hosted_sms_attempt_state("call-3", 1) == "terminal"
+    assert session._current_tool_deliveries[-1].sent is False
+    assert session._current_tool_deliveries[-1].error_kind == "terminal"
 
 
 def test_abort_settles_queued_capture_future():

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -3,12 +3,15 @@ import json
 import os
 from pathlib import Path
 
+import pytest
+
 from inkbox_claude import sessions as sessions_mod
 from inkbox_claude.config import BridgeConfig
+from inkbox_claude.delivery_policy import sms_tool_failure_kind
 from inkbox_claude.sessions import (
     ContactSession,
-    _Turn,
     _parse_index,
+    _Turn,
     list_recent_sessions,
 )
 
@@ -48,6 +51,84 @@ def test_abort_settles_queued_capture_future():
         assert fut.done()
         assert fut.result() == ""
         assert session._queue.empty()
+
+    asyncio.run(scenario())
+
+
+def test_abort_settles_queued_detailed_capture_with_empty_tool_result():
+    async def scenario():
+        session = make_session([])
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        await session._queue.put(_Turn(
+            text="do work",
+            future=fut,
+            capture_tools=True,
+        ))
+
+        await session._abort_in_flight()
+
+        result = fut.result()
+        assert result.text == ""
+        assert result.tool_deliveries == ()
+        assert result.aborted is True
+        assert session._queue.empty()
+
+    asyncio.run(scenario())
+
+
+def test_stop_command_aborts_queued_detailed_capture():
+    async def scenario():
+        sent = []
+        session = make_session(sent)
+        parked_worker = asyncio.create_task(asyncio.sleep(30))
+        session._worker = parked_worker
+        consult = asyncio.create_task(session.run_consult_detailed("post-call"))
+        await asyncio.sleep(0)
+
+        await session.handle_inbound("/stop", "sms", {"to": "+15551112222"})
+
+        result = await asyncio.wait_for(consult, timeout=1)
+        assert result.aborted is True
+        assert result.tool_deliveries == ()
+        assert sent[-1][1] == "Stopped."
+        parked_worker.cancel()
+
+    asyncio.run(scenario())
+
+
+def test_clear_command_aborts_running_detailed_capture():
+    async def scenario():
+        sent = []
+        session = make_session(sent)
+        started = asyncio.Event()
+        interrupted = asyncio.Event()
+
+        class FakeClient:
+            async def query(self, _text):
+                started.set()
+
+            async def receive_response(self):
+                await interrupted.wait()
+                raise RuntimeError("Claude turn interrupted")
+                yield  # pragma: no cover
+
+            async def interrupt(self):
+                interrupted.set()
+
+            async def disconnect(self):
+                interrupted.set()
+
+        session._client = FakeClient()
+        consult = asyncio.create_task(session.run_consult_detailed("post-call"))
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        await session.handle_inbound("/clear", "sms", {"to": "+15551112222"})
+
+        result = await asyncio.wait_for(consult, timeout=1)
+        assert result.aborted is True
+        assert result.tool_deliveries == ()
+        assert sent[-1][1].startswith("Started a fresh conversation")
 
     asyncio.run(scenario())
 
@@ -188,6 +269,10 @@ def test_tool_delivery_matches_sms_and_imessage_routing():
     session.reply_meta = {"to": "+1 (555) 111-2222", "conversation_id": "sms-conv"}
     session.mark_tool_delivery("sms", "+15551112222")
     assert session._current_channel_tool_delivery is True
+    captured = session._current_tool_deliveries[-1]
+    assert (captured.mode, captured.target, captured.sent, captured.error_kind) == (
+        "sms", "+15551112222", True, "none",
+    )
 
     session._current_channel_tool_delivery = False
     session.mark_tool_delivery("sms", "sms-conv")
@@ -198,6 +283,59 @@ def test_tool_delivery_matches_sms_and_imessage_routing():
     session.reply_meta = {"conversation_id": "imessage-conv"}
     session.mark_tool_delivery("imessage", "imessage-conv")
     assert session._current_channel_tool_delivery is True
+
+
+def test_tool_failure_capture_keeps_only_sanitized_classification():
+    session = make_session([])
+    session._turn_active = True
+
+    class Failure(Exception):
+        def __init__(self, message):
+            super().__init__(message)
+            self.detail = {
+                "message": "invalid phone number secret-provider-payload",
+                "provider_id": "provider-secret-123",
+            }
+
+    session.mark_tool_failure("sms", "+15551112222", Failure("forbidden raw body"))
+
+    captured = session._current_tool_deliveries[-1]
+    assert (captured.mode, captured.target, captured.sent, captured.error_kind) == (
+        "sms", "+15551112222", False, "terminal",
+    )
+    assert "secret" not in repr(captured)
+    assert "provider" not in repr(captured)
+
+
+@pytest.mark.parametrize(
+    ("status", "detail", "expected"),
+    [
+        (422, {"error": "message_blocked_spam_filter", "rule": "emoji_overload"}, "recoverable"),
+        (422, {"error": "message_blocked_spam_filter", "rule": "profanity"}, "recoverable"),
+        (422, {"error": "content_rejected_by_carrier"}, "recoverable"),
+        (502, {"error": "carrier_unavailable"}, "recoverable"),
+        (429, {"error": "carrier_rate_limit"}, "recoverable"),
+        (403, {"error": "recipient_opted_out"}, "terminal"),
+        (422, {"error": "invalid_phone_number"}, "terminal"),
+    ],
+)
+def test_tool_failure_capture_uses_structured_sms_policy(status, detail, expected):
+    session = make_session([])
+    session._turn_active = True
+
+    class Failure(Exception):
+        def __init__(self):
+            super().__init__("opaque SDK error")
+            self.status_code = status
+            self.detail = detail
+
+    session.mark_tool_failure("sms", "+15551112222", Failure())
+
+    captured = session._current_tool_deliveries[-1]
+    assert captured.error_kind == expected
+    assert sms_tool_failure_kind(Failure()) == expected
+    assert "message_blocked" not in repr(captured)
+    assert "emoji" not in repr(captured)
 
 
 def test_pending_escalation_consumes_next_inbound():

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -7,7 +7,10 @@ import pytest
 
 from inkbox_claude import sessions as sessions_mod
 from inkbox_claude.config import BridgeConfig
-from inkbox_claude.delivery_policy import sms_tool_failure_kind
+from inkbox_claude.delivery_policy import (
+    sms_delivery_failure_policy,
+    sms_tool_failure_kind,
+)
 from inkbox_claude.sessions import (
     ContactSession,
     _parse_index,
@@ -315,6 +318,9 @@ def test_tool_failure_capture_keeps_only_sanitized_classification():
         (422, {"error": "content_rejected_by_carrier"}, "recoverable"),
         (502, {"error": "carrier_unavailable"}, "recoverable"),
         (429, {"error": "carrier_rate_limit"}, "recoverable"),
+        (None, {"error": "carrier_rate_limit"}, "recoverable"),
+        (None, {"error": "inkbox_duplicate_body"}, "recoverable"),
+        (None, {"error": "forbidden"}, "terminal"),
         (403, {"error": "recipient_opted_out"}, "terminal"),
         (422, {"error": "invalid_phone_number"}, "terminal"),
     ],
@@ -336,6 +342,12 @@ def test_tool_failure_capture_uses_structured_sms_policy(status, detail, expecte
     assert sms_tool_failure_kind(Failure()) == expected
     assert "message_blocked" not in repr(captured)
     assert "emoji" not in repr(captured)
+
+
+def test_hosted_tool_status_rules_do_not_broaden_normal_delivery_policy():
+    assert sms_delivery_failure_policy("carrier_rate_limit", "") == "conditional"
+    assert sms_delivery_failure_policy("inkbox_duplicate_body", "") == "conditional"
+    assert sms_delivery_failure_policy("forbidden", "") == "conditional"
 
 
 def test_pending_escalation_consumes_next_inbound():

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -90,7 +90,7 @@ def test_install_command_prefers_uv_when_available(monkeypatch):
         "install",
         "--python",
         "/tmp/venv/bin/python",
-        "inkbox>=0.5.6,<1.0.0",
+        "inkbox>=0.5.9,<1.0.0",
         "aiohttp>=3.9",
     ]]
 
@@ -100,10 +100,10 @@ def test_install_command_falls_back_to_pip_and_ensurepip(monkeypatch):
     monkeypatch.setattr(setup_wizard.shutil, "which", lambda _name: None)
 
     assert setup_wizard._install_commands() == [
-        [["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.6,<1.0.0", "aiohttp>=3.9"]],
+        [["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.9,<1.0.0", "aiohttp>=3.9"]],
         [
             ["/tmp/venv/bin/python", "-m", "ensurepip", "--upgrade"],
-            ["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.6,<1.0.0", "aiohttp>=3.9"],
+            ["/tmp/venv/bin/python", "-m", "pip", "install", "inkbox>=0.5.9,<1.0.0", "aiohttp>=3.9"],
         ],
     ]
 
@@ -122,7 +122,7 @@ def test_missing_sdk_guidance_prints_interpreter(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "/tmp/venv/bin/python" in out
     assert "uv pip install --python" in out
-    assert "inkbox>=0.5.6,<1.0.0" in out
+    assert "inkbox>=0.5.9,<1.0.0" in out
 
 
 # ----------------------------------------------------------------------
@@ -158,7 +158,7 @@ def test_api_key_flow_rejects_unknown_auth_subtype(monkeypatch, capsys):
         object,
     )
 
-    assert result == (None, "", False)
+    assert result == (None, "", False, None)
     assert "Unsupported API-key subtype" in capsys.readouterr().out
 
 
@@ -213,7 +213,7 @@ def test_admin_api_key_flow_selects_existing_identity_and_mints_agent_key(monkey
     monkeypatch.setattr(setup_wizard, "prompt", lambda *_args, **_kwargs: "ApiKey_admin")
     monkeypatch.setattr(setup_wizard, "prompt_choice", lambda *_args, **_kwargs: 1)
 
-    identity, agent_key, did_provision_phone = setup_wizard._api_key_flow(
+    identity, agent_key, did_provision_phone, authority_identity = setup_wizard._api_key_flow(
         "https://inkbox.ai",
         FakeInkbox,
         Exception,
@@ -227,6 +227,7 @@ def test_admin_api_key_flow_selects_existing_identity_and_mints_agent_key(monkey
     assert identity.agent_handle == "selected-agent"
     assert agent_key == "ApiKey_agent_selected"
     assert did_provision_phone is False
+    assert authority_identity is identity
     assert FakeInkbox.instance.api_keys.created == [
         {
             "label": "Claude Code bridge - selected-agent",
@@ -280,7 +281,7 @@ def test_admin_api_key_flow_can_create_identity_and_mint_agent_key(monkeypatch):
     monkeypatch.setattr(setup_wizard, "prompt", lambda *_args, **_kwargs: next(answers))
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *_args, **_kwargs: False)
 
-    identity, agent_key, did_provision_phone = setup_wizard._api_key_flow(
+    identity, agent_key, did_provision_phone, authority_identity = setup_wizard._api_key_flow(
         "https://inkbox.ai",
         FakeInkbox,
         Exception,
@@ -294,6 +295,7 @@ def test_admin_api_key_flow_can_create_identity_and_mint_agent_key(monkeypatch):
     assert identity.agent_handle == "new-agent"
     assert agent_key == "ApiKey_agent_new"
     assert did_provision_phone is False
+    assert authority_identity is identity
     assert FakeInkbox.instance.created_identities == [
         ("new-agent", {"display_name": "New Agent", "phone_number": None})
     ]
@@ -609,7 +611,154 @@ def test_configure_realtime_offered_for_imessage_only_identity(tmp_path, monkeyp
     setup_wizard._configure_realtime_calls(
         types.SimpleNamespace(phone_number=None), imessage_enabled=True
     )
-    assert setup_wizard._env("INKBOX_REALTIME_ENABLED") == "true"
+
+
+class _VoiceIdentity:
+    def __init__(self, authority="contact_scoped"):
+        self.agent_handle = "agent"
+        self.phone_number = types.SimpleNamespace(
+            client_websocket_url="wss://agent.example/phone/media/ws"
+        )
+        self.authority = authority
+        self.hosted_updates = []
+        self.incoming_updates = []
+        self.authority_updates = []
+        self.incoming_before = types.SimpleNamespace(
+            incoming_call_action="auto_accept",
+            client_websocket_url="wss://old.example/phone/media/ws",
+            incoming_call_webhook_url="https://old.example/webhook",
+        )
+
+    def get_hosted_agent_config(self):
+        return types.SimpleNamespace(authority_mode=self.authority)
+
+    def set_hosted_agent_config(self, **kwargs):
+        self.hosted_updates.append(kwargs)
+
+    def get_incoming_call_action(self):
+        return self.incoming_before
+
+    def set_incoming_call_action(self, **kwargs):
+        self.incoming_updates.append(kwargs)
+
+    def set_hosted_agent_authority_mode(self, authority):
+        self.authority_updates.append(authority)
+
+
+def _voice_setup_kwargs():
+    return {
+        "base_url": "",
+        "Inkbox": object,
+        "InkboxAPIError": Exception,
+        "WhoamiApiKeyResponse": object,
+        "ADMIN_SCOPED": "admin_scoped",
+    }
+
+
+def test_phone_voice_stack_configures_tts_stt(tmp_path, monkeypatch):
+    monkeypatch.setenv("INKBOX_CLAUDE_ENV_FILE", str(tmp_path / ".env"))
+    monkeypatch.setattr(setup_wizard, "prompt_choice", lambda *a, **k: 2)
+    identity = _VoiceIdentity()
+
+    setup_wizard._configure_phone_call_voice_stack(identity, **_voice_setup_kwargs())
+
+    assert setup_wizard._env("INKBOX_VOICE_STACK") == "inkbox_tts_stt"
+    assert setup_wizard._env("INKBOX_REALTIME_ENABLED") == "false"
+    assert identity.incoming_updates[-1]["incoming_call_action"] == "auto_accept"
+
+
+def test_realtime_validation_failure_loops_back_to_all_choices(tmp_path, monkeypatch):
+    monkeypatch.setenv("INKBOX_CLAUDE_ENV_FILE", str(tmp_path / ".env"))
+    choices = iter([1, 2])
+    monkeypatch.setattr(setup_wizard, "prompt_choice", lambda *a, **k: next(choices))
+    monkeypatch.setattr(setup_wizard, "prompt", lambda *a, **k: "sk-invalid")
+    monkeypatch.setattr(
+        setup_wizard,
+        "_test_openai_realtime_api_key",
+        lambda *a, **k: (False, "invalid key"),
+    )
+    identity = _VoiceIdentity()
+
+    setup_wizard._configure_phone_call_voice_stack(identity, **_voice_setup_kwargs())
+
+    assert setup_wizard._env("INKBOX_VOICE_STACK") == "inkbox_tts_stt"
+    assert setup_wizard._env("INKBOX_REALTIME_ENABLED") == "false"
+
+
+def test_voice_ai_reuses_admin_identity_without_persisting_admin_key(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    monkeypatch.setenv("INKBOX_CLAUDE_ENV_FILE", str(env_file))
+    choices = iter([0, 1])
+    monkeypatch.setattr(setup_wizard, "prompt_choice", lambda *a, **k: next(choices))
+    monkeypatch.setattr(
+        setup_wizard,
+        "prompt",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("admin key must be reused")),
+    )
+    identity = _VoiceIdentity(authority="contact_scoped")
+    admin_identity = _VoiceIdentity(authority="contact_scoped")
+
+    setup_wizard._configure_phone_call_voice_stack(
+        identity,
+        authority_identity=admin_identity,
+        **_voice_setup_kwargs(),
+    )
+
+    assert admin_identity.authority_updates == ["yolo"]
+    assert identity.hosted_updates == [{"voice": None, "model": None, "instructions": None}]
+    assert identity.incoming_updates == [{
+        "incoming_call_action": "hosted_agent",
+        "client_websocket_url": None,
+        "incoming_call_webhook_url": None,
+    }]
+    assert setup_wizard._env("INKBOX_VOICE_STACK") == "inkbox_voice_ai"
+    assert setup_wizard._env("INKBOX_VOICE_AI_AUTHORITY_MODE") == "yolo"
+    assert "admin" not in env_file.read_text().lower()
+
+
+def test_voice_ai_failure_restores_all_prior_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("INKBOX_CLAUDE_ENV_FILE", str(tmp_path / ".env"))
+    choices = iter([0, 1, 2])
+    monkeypatch.setattr(setup_wizard, "prompt_choice", lambda *a, **k: next(choices))
+    identity = _VoiceIdentity(authority="contact_scoped")
+    identity.get_hosted_agent_config = lambda: types.SimpleNamespace(
+        authority_mode="contact_scoped",
+        voice="old-voice",
+        model="old-model",
+        instructions="old instructions",
+    )
+    incoming_calls = 0
+
+    def fail_then_restore(**kwargs):
+        nonlocal incoming_calls
+        incoming_calls += 1
+        identity.incoming_updates.append(kwargs)
+        if incoming_calls == 1:
+            raise RuntimeError("incoming update failed")
+
+    identity.set_incoming_call_action = fail_then_restore
+    admin_identity = _VoiceIdentity()
+    # First selection attempts Voice AI and fails; second returns to TTS/STT.
+    setup_wizard._configure_phone_call_voice_stack(
+        identity,
+        authority_identity=admin_identity,
+        **_voice_setup_kwargs(),
+    )
+
+    assert admin_identity.authority_updates == ["yolo", "contact_scoped"]
+    assert identity.hosted_updates == [
+        {"voice": None, "model": None, "instructions": None},
+        {"voice": "old-voice", "model": "old-model", "instructions": "old instructions"},
+    ]
+    assert identity.incoming_updates[1] == {
+        "incoming_call_action": "auto_accept",
+        "client_websocket_url": "wss://old.example/phone/media/ws",
+        "incoming_call_webhook_url": "https://old.example/webhook",
+    }
+    assert identity.incoming_updates[-1]["client_websocket_url"] == (
+        "wss://agent.example/phone/media/ws"
+    )
+    assert setup_wizard._env("INKBOX_VOICE_STACK") == "inkbox_tts_stt"
 
 
 # ----------------------------------------------------------------------
@@ -773,7 +922,7 @@ def test_wizard_walks_imessage_before_dedicated_number(tmp_path, monkeypatch):
     monkeypatch.setattr(setup_wizard, "_ensure_inkbox_sdk", lambda: fake_symbols)
     monkeypatch.setattr(setup_wizard, "prompt_yes_no", lambda *a, **k: True)
     monkeypatch.setattr(
-        setup_wizard, "_api_key_flow", lambda *a, **k: (identity, "ApiKey_x", False)
+        setup_wizard, "_api_key_flow", lambda *a, **k: (identity, "ApiKey_x", False, None)
     )
     monkeypatch.setattr(setup_wizard, "_configure_avatar", lambda *a, **k: order.append("avatar"))
     monkeypatch.setattr(
@@ -790,11 +939,11 @@ def test_wizard_walks_imessage_before_dedicated_number(tmp_path, monkeypatch):
         lambda *a, **k: order.append("sms_opt_in"),
     )
 
-    def fake_realtime(_identity, *, imessage_enabled=False):
-        order.append("realtime")
+    def fake_voice_stack(_identity, *, imessage_enabled=False, **_kwargs):
+        order.append("voice_stack")
         seen["imessage_enabled"] = imessage_enabled
 
-    monkeypatch.setattr(setup_wizard, "_configure_realtime_calls", fake_realtime)
+    monkeypatch.setattr(setup_wizard, "_configure_phone_call_voice_stack", fake_voice_stack)
     monkeypatch.setattr(setup_wizard, "_setup_signing_key", lambda *a, **k: order.append("signing_key"))
     monkeypatch.setattr(setup_wizard, "_configure_project_dir", lambda: order.append("project_dir"))
     monkeypatch.setattr(setup_wizard, "_configure_autostart", lambda: order.append("autostart"))
@@ -806,7 +955,7 @@ def test_wizard_walks_imessage_before_dedicated_number(tmp_path, monkeypatch):
         "imessage",
         "dedicated_number",
         "summary",
-        "realtime",
+        "voice_stack",
         "signing_key",
         "project_dir",
         "autostart",

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -657,14 +657,123 @@ def _voice_setup_kwargs():
 
 def test_phone_voice_stack_configures_tts_stt(tmp_path, monkeypatch):
     monkeypatch.setenv("INKBOX_CLAUDE_ENV_FILE", str(tmp_path / ".env"))
+    questions = []
+    monkeypatch.setattr(
+        setup_wizard,
+        "prompt",
+        lambda question, *a, **k: questions.append(question) or "",
+    )
     monkeypatch.setattr(setup_wizard, "prompt_choice", lambda *a, **k: 2)
     identity = _VoiceIdentity()
 
     setup_wizard._configure_phone_call_voice_stack(identity, **_voice_setup_kwargs())
 
     assert setup_wizard._env("INKBOX_VOICE_STACK") == "inkbox_tts_stt"
+    assert questions == ["  Press Enter to continue and set up phone call handling"]
     assert setup_wizard._env("INKBOX_REALTIME_ENABLED") == "false"
     assert identity.incoming_updates[-1]["incoming_call_action"] == "auto_accept"
+
+
+def test_local_voice_stack_rebuilds_canonical_tunnel_url_after_hosted_mode(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("INKBOX_CLAUDE_ENV_FILE", str(tmp_path / ".env"))
+    monkeypatch.setattr(setup_wizard, "prompt", lambda *a, **k: "")
+    monkeypatch.setattr(setup_wizard, "prompt_choice", lambda *a, **k: 2)
+    identity = _VoiceIdentity()
+    identity.phone_number.client_websocket_url = None
+
+    setup_wizard._configure_phone_call_voice_stack(
+        identity,
+        **_voice_setup_kwargs(),
+    )
+
+    assert identity.incoming_updates[-1] == {
+        "incoming_call_action": "auto_accept",
+        "client_websocket_url": "wss://agent.inkboxwire.com/phone/media/ws",
+        "incoming_call_webhook_url": None,
+    }
+
+
+@pytest.mark.parametrize(
+    ("saved_stack", "expected_index"),
+    [
+        ("inkbox_voice_ai", 0),
+        ("openai_realtime", 1),
+        ("inkbox_tts_stt", 2),
+    ],
+)
+def test_voice_stack_rerun_defaults_to_saved_selection(
+    saved_stack, expected_index, monkeypatch,
+):
+    monkeypatch.setattr(
+        setup_wizard,
+        "_env",
+        lambda name: saved_stack if name == "INKBOX_VOICE_STACK" else "",
+    )
+    assert setup_wizard._voice_stack_default_index("") == expected_index
+
+
+def test_prompt_choice_reprompts_invalid_input_and_honors_default(monkeypatch):
+    answers = iter(["not-a-number", "9", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+    assert setup_wizard.prompt_choice("choose", ["one", "two", "three"], 1) == 1
+
+
+def test_prompt_choice_cancellation_exits(monkeypatch):
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+    with pytest.raises(SystemExit):
+        setup_wizard.prompt_choice("choose", ["one", "two"], 0)
+
+
+def test_phone_voice_stack_configures_valid_realtime(tmp_path, monkeypatch):
+    monkeypatch.setenv("INKBOX_CLAUDE_ENV_FILE", str(tmp_path / ".env"))
+    monkeypatch.setenv("INKBOX_REALTIME_API_KEY", "sk-valid")
+    monkeypatch.setattr(setup_wizard, "prompt", lambda *a, **k: "")
+    monkeypatch.setattr(setup_wizard, "prompt_choice", lambda *a, **k: 1)
+    monkeypatch.setattr(
+        setup_wizard,
+        "_test_openai_realtime_api_key",
+        lambda *a, **k: (True, "ok"),
+    )
+    identity = _VoiceIdentity()
+
+    setup_wizard._configure_phone_call_voice_stack(
+        identity,
+        **_voice_setup_kwargs(),
+    )
+
+    assert setup_wizard._env("INKBOX_VOICE_STACK") == "openai_realtime"
+    assert setup_wizard._env("INKBOX_REALTIME_API_KEY") == "sk-valid"
+    assert identity.incoming_updates[-1]["incoming_call_action"] == "auto_accept"
+
+
+def test_voice_ai_contact_scope_does_not_prompt_for_admin(tmp_path, monkeypatch):
+    monkeypatch.setenv("INKBOX_CLAUDE_ENV_FILE", str(tmp_path / ".env"))
+    choices = iter([0, 0])
+    monkeypatch.setattr(setup_wizard, "prompt_choice", lambda *a, **k: next(choices))
+    monkeypatch.setattr(
+        setup_wizard,
+        "prompt",
+        lambda question, *a, **k: (
+            ""
+            if "Press Enter" in question
+            else (_ for _ in ()).throw(AssertionError("admin prompted"))
+        ),
+    )
+    identity = _VoiceIdentity(authority="contact_scoped")
+
+    setup_wizard._configure_phone_call_voice_stack(
+        identity,
+        **_voice_setup_kwargs(),
+    )
+
+    assert identity.authority_updates == []
+    assert setup_wizard._env("INKBOX_VOICE_AI_AUTHORITY_MODE") == "contact_scoped"
+    assert setup_wizard._env("INKBOX_VOICE_STACK") == "inkbox_voice_ai"
 
 
 def test_realtime_validation_failure_loops_back_to_all_choices(tmp_path, monkeypatch):
@@ -693,7 +802,11 @@ def test_voice_ai_reuses_admin_identity_without_persisting_admin_key(tmp_path, m
     monkeypatch.setattr(
         setup_wizard,
         "prompt",
-        lambda *a, **k: (_ for _ in ()).throw(AssertionError("admin key must be reused")),
+        lambda question, *a, **k: (
+            ""
+            if "Press Enter" in question
+            else (_ for _ in ()).throw(AssertionError("admin key must be reused"))
+        ),
     )
     identity = _VoiceIdentity(authority="contact_scoped")
     admin_identity = _VoiceIdentity(authority="contact_scoped")
@@ -720,6 +833,7 @@ def test_voice_ai_failure_restores_all_prior_config(tmp_path, monkeypatch):
     monkeypatch.setenv("INKBOX_CLAUDE_ENV_FILE", str(tmp_path / ".env"))
     choices = iter([0, 1, 2])
     monkeypatch.setattr(setup_wizard, "prompt_choice", lambda *a, **k: next(choices))
+    monkeypatch.setattr(setup_wizard, "prompt", lambda *a, **k: "")
     identity = _VoiceIdentity(authority="contact_scoped")
     identity.get_hosted_agent_config = lambda: types.SimpleNamespace(
         authority_mode="contact_scoped",
@@ -747,7 +861,7 @@ def test_voice_ai_failure_restores_all_prior_config(tmp_path, monkeypatch):
 
     assert admin_identity.authority_updates == ["yolo", "contact_scoped"]
     assert identity.hosted_updates == [
-        {"voice": None, "model": None, "instructions": None},
+        {"voice": "old-voice", "model": "old-model", "instructions": "old instructions"},
         {"voice": "old-voice", "model": "old-model", "instructions": "old instructions"},
     ]
     assert identity.incoming_updates[1] == {

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -829,6 +829,50 @@ def test_voice_ai_reuses_admin_identity_without_persisting_admin_key(tmp_path, m
     assert "admin" not in env_file.read_text().lower()
 
 
+def test_voice_ai_rejects_non_admin_key_and_returns_to_stack_choices(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    env_file = tmp_path / ".env"
+    monkeypatch.setenv("INKBOX_CLAUDE_ENV_FILE", str(env_file))
+    choices = iter([0, 1, 2])
+    monkeypatch.setattr(setup_wizard, "prompt_choice", lambda *a, **k: next(choices))
+    monkeypatch.setattr(
+        setup_wizard,
+        "prompt",
+        lambda question, *a, **k: (
+            "" if "Press Enter" in question else "ApiKey_not_admin"
+        ),
+    )
+
+    class Whoami:
+        auth_subtype = "agent_scoped"
+
+    class FakeInkbox:
+        def __init__(self, **_kwargs):
+            pass
+
+        def whoami(self):
+            return Whoami()
+
+        def get_identity(self, _handle):
+            raise AssertionError("non-admin credential must not configure authority")
+
+    kwargs = _voice_setup_kwargs()
+    kwargs.update({"Inkbox": FakeInkbox, "WhoamiApiKeyResponse": Whoami})
+    identity = _VoiceIdentity(authority="contact_scoped")
+
+    setup_wizard._configure_phone_call_voice_stack(identity, **kwargs)
+
+    assert identity.authority_updates == []
+    assert identity.hosted_updates == []
+    assert setup_wizard._env("INKBOX_VOICE_STACK") == "inkbox_tts_stt"
+    assert setup_wizard._env("INKBOX_REALTIME_ENABLED") == "false"
+    assert "ApiKey_not_admin" not in env_file.read_text()
+    assert "requires an admin-scoped API key" in capsys.readouterr().out
+
+
 def test_voice_ai_failure_restores_all_prior_config(tmp_path, monkeypatch):
     monkeypatch.setenv("INKBOX_CLAUDE_ENV_FILE", str(tmp_path / ".env"))
     choices = iter([0, 1, 2])

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 
 from inkbox_claude import tools as tools_mod
+from inkbox_claude.config import BridgeConfig, VoiceStack
 
 
 @pytest.fixture(autouse=True)
@@ -171,14 +172,20 @@ class _FakeClient:
         return self.identity
 
 
-def _tool_map(client):
-    server, tool_names = tools_mod.build_inkbox_mcp_server(client, "claude-agent")
+def _tool_map(client, cfg=None):
+    server, tool_names = tools_mod.build_inkbox_mcp_server(client, "claude-agent", cfg)
     return {tool._inkbox_tool_name: tool for tool in server["tools"]}, tool_names
 
 
 def _call(client, name, arguments):
     tools, _tool_names = _tool_map(client)
     result = asyncio.run(tools[name](arguments))
+    return json.loads(result["content"][0]["text"])
+
+
+def _call_with_config(client, cfg, name, arguments):
+    registered, _ = _tool_map(client, cfg)
+    result = asyncio.run(registered[name](arguments))
     return json.loads(result["content"][0]["text"])
 
 
@@ -191,6 +198,38 @@ def test_call_tools_are_registered():
     assert "mcp__inkbox__inkbox_place_call" in tool_names
     assert "mcp__inkbox__inkbox_list_calls" in tool_names
     assert "mcp__inkbox__inkbox_get_call_transcript" in tool_names
+
+
+def test_hosted_place_call_uses_reason_and_saved_authority_default():
+    client = _FakeClient()
+    result = _call_with_config(
+        client,
+        BridgeConfig(
+            voice_stack=VoiceStack.INKBOX_VOICE_AI,
+            voicemail_detection="disabled",
+        ),
+        "inkbox_place_call",
+        {
+            "to_number": "+15551112222",
+            "purpose": "Confirm the release window",
+            "opening_message": "Introduce yourself first",
+            "context": "The release is currently green",
+        },
+    )
+
+    assert result["mode"] == "hosted_agent"
+    assert client.identity.place_call_kwargs == {
+        "to_number": "+15551112222",
+        "origination": "dedicated_number",
+        "mode": "hosted_agent",
+        "reason": (
+            "Confirm the release window\n\n"
+            "Opening guidance: Introduce yourself first\n\n"
+            "Additional context: The release is currently green"
+        ),
+        "voicemail_detection": "disabled",
+    }
+    assert "hosted_agent_authority_mode" not in client.identity.place_call_kwargs
 
 
 def test_coding_agent_tool_tier_is_registered():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -634,6 +634,68 @@ def test_successful_message_tool_notifies_current_session():
     assert deliveries == [("email", "ada@example.com")]
 
 
+def test_sms_tool_marks_success_only_after_sdk_send_returns():
+    client = _FakeClient()
+    events = []
+
+    class _Session:
+        def mark_tool_delivery(self, mode, target):
+            events.append(("delivered", mode, target, len(client.identity.sent_texts)))
+
+        def mark_tool_failure(self, mode, target, error):
+            events.append(("failed", mode, target, str(error)))
+
+    token = tools_mod.CURRENT_SESSION.set(_Session())
+    try:
+        data = _call(
+            client,
+            "inkbox_send_sms",
+            {"to": "+15551112222", "text": "release update"},
+        )
+    finally:
+        tools_mod.CURRENT_SESSION.reset(token)
+
+    assert data["sent"] is True
+    assert events == [("delivered", "sms", "+15551112222", 1)]
+
+
+def test_sms_tool_marks_sdk_failure_without_success():
+    client = _FakeClient()
+    events = []
+
+    class Rejected(Exception):
+        def __init__(self, message):
+            super().__init__(message)
+            self.detail = {"message": "recipient opted out"}
+
+    def reject(**_kwargs):
+        raise Rejected("provider rejected send")
+
+    client.identity.send_text = reject
+
+    class _Session:
+        def mark_tool_delivery(self, mode, target):
+            events.append(("delivered", mode, target))
+
+        def mark_tool_failure(self, mode, target, error):
+            events.append(("failed", mode, target, error))
+
+    token = tools_mod.CURRENT_SESSION.set(_Session())
+    try:
+        data = _call(
+            client,
+            "inkbox_send_sms",
+            {"to": "+15551112222", "text": "release update"},
+        )
+    finally:
+        tools_mod.CURRENT_SESSION.reset(token)
+
+    assert "error" in data
+    assert len(events) == 1
+    assert events[0][:3] == ("failed", "sms", "+15551112222")
+    assert isinstance(events[0][3], Rejected)
+
+
 def test_send_imessage_group_requires_dedicated_outbound_line():
     client = _FakeClient()
     data = _call(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -659,6 +659,82 @@ def test_sms_tool_marks_success_only_after_sdk_send_returns():
     assert events == [("delivered", "sms", "+15551112222", 1)]
 
 
+def test_sms_tool_preflight_blocks_duplicate_before_second_sdk_send():
+    client = _FakeClient()
+    reservations = 0
+    deliveries = []
+
+    class _Session:
+        def preflight_hosted_sms(self, target):
+            nonlocal reservations
+            assert target == "+15551112222"
+            reservations += 1
+            if reservations > 1:
+                return {
+                    "kind": "duplicate",
+                    "message": "duplicate send blocked",
+                }
+            return None
+
+        def mark_tool_delivery(self, mode, target):
+            deliveries.append((mode, target))
+
+    token = tools_mod.CURRENT_SESSION.set(_Session())
+    try:
+        first = _call(
+            client,
+            "inkbox_send_sms",
+            {"to": "+15551112222", "text": "release update"},
+        )
+        second = _call(
+            client,
+            "inkbox_send_sms",
+            {"to": "+15551112222", "text": "release update"},
+        )
+    finally:
+        tools_mod.CURRENT_SESSION.reset(token)
+
+    assert first["sent"] is True
+    assert second["error_code"] == "hosted_sms_send_blocked"
+    assert len(client.identity.sent_texts) == 1
+    assert deliveries == [("sms", "+15551112222")]
+
+
+def test_sms_tool_preflight_terminal_block_records_failure_without_sdk_send():
+    client = _FakeClient()
+    failures = []
+
+    class _Session:
+        def preflight_hosted_sms(self, target):
+            assert target == "+15559990000"
+            return {
+                "kind": "terminal",
+                "message": "hosted-call target mismatch",
+            }
+
+        def mark_tool_failure(self, mode, target, error):
+            failures.append((mode, target, error.error_code, str(error)))
+
+    token = tools_mod.CURRENT_SESSION.set(_Session())
+    try:
+        result = _call(
+            client,
+            "inkbox_send_sms",
+            {"to": "+15559990000", "text": "release update"},
+        )
+    finally:
+        tools_mod.CURRENT_SESSION.reset(token)
+
+    assert result["error_code"] == "hosted_sms_send_blocked"
+    assert client.identity.sent_texts == []
+    assert failures == [(
+        "sms",
+        "+15559990000",
+        "forbidden",
+        "hosted-call target mismatch",
+    )]
+
+
 def test_sms_tool_marks_sdk_failure_without_success():
     client = _FakeClient()
     events = []


### PR DESCRIPTION
## Executive Summary

- Adds a three-option **Phone call voice stack** wizard: Inkbox Voice AI, OpenAI Realtime API, and Inkbox TTS/STT.
- Routes inbound and outbound calls through the selected stack, inherits saved Voice AI authority by default, and passes the configured voicemail policy explicitly.
- Adds signed, restart-safe hosted `call.ended` reconciliation with exact-recipient, exact-once post-call SMS settlement.

## Description

- Pauses before the phone-call section, preserves rerun defaults, validates Realtime access before saving, and returns failed validation to all three choices.
- Configures Contact-scoped or YOLO Voice AI authority with transient admin credentials; runtime keeps the agent-scoped key and the canonical local mirror is `INKBOX_VOICE_AI_AUTHORITY_MODE`.
- Reconciles remote incoming-call routing during setup and gateway startup, and reports local/remote routing and authority drift in `doctor`.
- Uses stack-specific outbound call schemas: Voice AI sends `mode=hosted_agent` with a required bounded reason and no authority override; Realtime and Inkbox TTS/STT send `mode=client_websocket` with the current media URL.
- Preserves server-owned Voice AI voice/model/instructions while changing routing or authority.
- Registers signed identity `call.ended` delivery without replacing mail, text, iMessage, A2A, or external-event subscriptions.
- Grounds hosted completion in the authoritative call, transcript, caller number, and open action items. Current-call recipient data overrides generated memory or similarly named contacts.
- Journals the exact SMS target and tool attempt before provider I/O, correlates the real Claude tool result, permits one correction only for deterministic known-no-send failures, and never blindly retries ambiguous writes.
- Stores bounded private receipts atomically without SMS bodies, transcripts, contact memory, credentials, provider payloads, or completed replay material.
- Bumps the plugin from 0.2.7 to 0.2.8 and requires Inkbox SDK `>=0.5.9,<1.0.0` everywhere.

## Reason

Operators need one explicit setup surface for who owns phone audio and one saved Voice AI authority default for inbound and outbound hosted calls. Hosted calls also need to complete promised work after hangup without allowing model memory, duplicate delivery, restart, or an ambiguous provider outcome to redirect or replay an external write.

## Decisions

- Product copy says **Inkbox Voice AI** while the compatible API wire mode remains `hosted_agent`.
- Claude Code uses its supported Agent SDK session/resume surface, per-contact sessions, narrow Inkbox tool auto-allow rules, and pre/post tool hooks around the real side-effect boundary.
- Realtime exposes one `consult_agent` bridge into Claude Code. Hermes' direct realtime contact-tool scenario is not applicable because Claude does not expose that host-specific surface.
- Product calls retain the configured/default voicemail policy; call-capable CI explicitly sets and verifies `disabled`.
- The container is manual local-test support only and is not published or used as a CI/release gate.

## Testing

### Live-test inventory

- **Updated — `test_inbound_call_inkbox_tts_stt`:** proves a direct inbound client-WebSocket call has two-way audio, uses Inkbox STT/TTS, and persists `voicemail_detection=disabled`. This closes the prompt/audio-only false positive where the actual call record could retain the product default.
- **Updated — `test_outbound_call_realtime`:** correlates the driver's fresh inbound media leg with the AUT's fresh outbound request, proves two-way audio through OpenAI Realtime, and verifies disabled voicemail detection on the exact AUT-owned record. This closes both the uninspected-policy gap and the wrong-owner false failure where the driver's independent inbound default was asserted instead.
- **New — `test_outbound_call_hosted_and_post_call_wakeup`:** pairs fresh driver and AUT legs, requires hosted mode, non-empty reason, saved effective authority, disabled voicemail detection, current caller transcript plus matching open action before hangup, call-ID-scoped reconciliation, one exact-target sender row with the current speech-safe marker, and a full duplicate grace window. This removes acknowledgement/arbitrary-delay false positives, stale-call and wrong-leg races, recipient-inbox ambiguity, and duplicate-send false negatives.
- **Updated — `test_email_request_gets_call`:** correlates exactly one fresh driver inbound leg with exactly one fresh AUT outbound leg, observes the full duplicate grace window, and verifies disabled voicemail detection on the AUT-owned request. This closes stale-call, wrong-owner, prompt-only, and duplicate-call gaps.
- **Updated — `test_sms_request_gets_call`:** applies the same two-owner correlation, duplicate rejection, and exact AUT policy assertion to the SMS-triggered path. This closes the same stale/wrong-leg race without treating the driver's independent inbound default as the agent's request policy.
- **Updated — `test_reports_sender_details`:** explicitly asks for the full known email and phone while keeping exact contact-card assertions. This closes a live false negative where the model correctly reported the name and phone but referred to the email generically because the prompt only explicitly required the phone.
- **Updated — setup and hosted-proof contracts:** rejects an agent-scoped credential entered for YOLO, returns to all three stack choices, and proves the rejected key and remote authority were never persisted. Hosted timeout diagnostics inspect at most ten action items and emit only counts, booleans, and exception class names—never transcript, action, credential, or provider content.
- **Updated — hosted action request contract:** repeated cross-host live runs showed that a generic “SMS containing these words” request could reach the caller transcript while the hosted action summarizer omitted or reinterpreted the marker. The driver now requires Voice AI to create the post-call action immediately with the exact SMS body and read back all five words only after the action is saved. A deterministic workflow contract locks that wording; transcript, durable action, exact recipient, exact body, and duplicate gates remain strict.

### Validation

- Full local suite: **438 passed, 23 skipped**.
- Focused call-owner correlation contracts: **10 passed**.
- Focused wizard/doctor/startup/tools/hosted/live-contract suite: **139 passed**.
- Fatal Ruff rules, Python compilation, workflow YAML parsing, wheel contents, and `git diff --check`: passed.
- [Exact-head unit and contract CI](https://github.com/inkbox-ai/claude-code-plugin/actions/runs/30698682430): passed on `23d406fe73960aec9a26f6da2115692735535b29`.
- [Exact-head full-stack CI](https://github.com/inkbox-ai/claude-code-plugin/actions/runs/30698682415): passed on the same head, including real/mock channels, all four A2A variants, inbound TTS/STT, outbound Realtime, hosted Voice AI, external events, and the aggregate gate.

## Related PRs

- [Hermes plugin #83](https://github.com/inkbox-ai/hermes-agent-plugin/pull/83)
- [Codex plugin #35](https://github.com/inkbox-ai/codex-plugin/pull/35)
- [OpenClaw plugin #52](https://github.com/inkbox-ai/openclaw-plugin/pull/52)
- [OpenCode plugin #16](https://github.com/inkbox-ai/opencode-plugin/pull/16)
