### PR TITLE
Bump plugin version to 0.2.9

### DIFF
--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -105,7 +105,7 @@ jobs:
             echo "INKBOX_VOICE_STACK=inkbox_voice_ai" >> "$GITHUB_ENV"
             echo "INKBOX_REALTIME_ENABLED=false" >> "$GITHUB_ENV"
             echo "HOSTED_POST_CALL_MARKER=$marker" >> "$GITHUB_ENV"
-            echo "VOICE_DRIVER_LINE=After we hang up, send me one SMS. Create one post-call action now with the title Send SMS and put this exact five-word SMS body in the action details: $marker. Wait for the action tool to succeed, then read all five words back to me. Do not paraphrase, omit a word, or send the SMS during the call." >> "$GITHUB_ENV"
+            echo "VOICE_DRIVER_LINE=After we hang up, send me one SMS containing these exact five words: $marker. Create one post-call action now. Set both the action title and the action details to this exact seven-word phrase: Send SMS $marker. Wait for the action tool to succeed, then read the exact five-word SMS body back to me. Do not paraphrase, omit a word, or send the SMS during the call." >> "$GITHUB_ENV"
             # Keep the media peer alive while the test waits for Voice AI to
             # persist the open post-call action, then let the test hang up.
             echo "VOICE_DRIVER_LISTEN=180" >> "$GITHUB_ENV"

--- a/inkbox_claude/__init__.py
+++ b/inkbox_claude/__init__.py
@@ -1,3 +1,3 @@
 """Inkbox bridge for Claude Code — email, SMS, iMessage, and voice."""
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"

--- a/inkbox_claude/tools.py
+++ b/inkbox_claude/tools.py
@@ -1185,7 +1185,7 @@ def build_inkbox_mcp_server(
         inkbox_a2a_ask_caller,
         inkbox_a2a_fail,
     ]
-    server = create_sdk_mcp_server(name="inkbox", version="0.2.8", tools=tools)
+    server = create_sdk_mcp_server(name="inkbox", version="0.2.9", tools=tools)
     tool_names = [
         "mcp__inkbox__inkbox_whoami",
         "mcp__inkbox__inkbox_send_email",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-code-plugin"
-version = "0.2.8"
+version = "0.2.9"
 description = "Inkbox bridge for Claude Code — talk to your coding agent over email, SMS, iMessage, and voice"
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/test_live_voice_contract_helpers.py
+++ b/tests/test_live_voice_contract_helpers.py
@@ -26,10 +26,11 @@ def test_workflow_requires_action_first_exact_body_and_readback():
     workflow = (Path(__file__).parent.parent / ".github/workflows/live-voice.yml").read_text()
 
     assert (
-        "After we hang up, send me one SMS. Create one post-call action now with the "
-        "title Send SMS and put this exact five-word SMS body in the action details: "
-        "$marker. Wait for the action tool to succeed, then read all five words back "
-        "to me. Do not paraphrase, omit a word, or send the SMS during the call."
+        "After we hang up, send me one SMS containing these exact five words: $marker. "
+        "Create one post-call action now. Set both the action title and the action details "
+        "to this exact seven-word phrase: Send SMS $marker. Wait for the action tool to "
+        "succeed, then read the exact five-word SMS body back to me. Do not paraphrase, "
+        "omit a word, or send the SMS during the call."
         in workflow
     )
 


### PR DESCRIPTION
## Executive Summary

Bumps the Claude Code integration from 0.2.8 to 0.2.9 for the next patch release and makes the hosted-voice live request explicit about both durable action fields.

## Description

Updates package metadata, the exported runtime version, and MCP server identification so every Claude Code version surface reports 0.2.9. The hosted-voice live instruction now requires the unique SMS marker in both the action title and details, while retaining the strict persisted-action and delivered-SMS assertions.

## Reason

The recently merged non-interactive bootstrap capability needs a new patch version for distribution and runtime identification. Explicit action-field values remove model ambiguity observed in the live hosted-voice gate.

## Decisions

- **Patch release:** Version surfaces increment by exactly 0.0.1.
- **Version consistency:** Package and runtime-reported versions remain synchronized.
- **Test integrity:** The live test still requires one open SMS action with the current marker and verifies the resulting post-call SMS; only its spoken input is more explicit.

## Testing

- `pytest -q --ignore=tests/contract`: 436 passed and 23 live-only tests skipped.
- `pytest -q tests/test_live_voice_contract_helpers.py`: 10 passed.