### PR TITLE
Document safe agent self-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,34 @@ Flags: `--start` (launch the background gateway when done), `--no-setup` (instal
 
 ### Bootstrap an existing identity without prompts
 
-For unattended agent setup, install without opening the wizard and pass the API key through the environment (or standard input), never a command-line argument:
+For unattended agent setup, keep the identity handle, base URL, and API key supplied by the human who assigned the identity. Do not create a replacement identity. First download the installer once, inspect the exact file that will run, execute that same file with setup disabled, and remove it even if a step fails:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/inkbox-ai/claude-code-plugin/main/install.sh | bash -s -- --no-setup
-export INKBOX_API_KEY="ApiKey_..."
-inkbox-claude bootstrap --identity my-agent --project-dir "$PWD" \
+(
+  set -euo pipefail
+  installer="$(mktemp)"
+  trap 'rm -f "$installer"' EXIT
+  curl -fsSL https://raw.githubusercontent.com/inkbox-ai/claude-code-plugin/main/install.sh -o "$installer"
+  cat "$installer"
+  bash "$installer" --no-setup
+)
+```
+
+Stop if the downloaded script contains anything unexpected. Once the human-provided credential is available as the transient `INKBOX_API_KEY` environment variable, run the non-interactive bootstrap:
+
+```bash
+inkbox-claude bootstrap --identity '<handle>' --base-url '<url>' --project-dir "$PWD" \
   --voice-ai --rotate-signing-key --start-gateway
 unset INKBOX_API_KEY
 ```
 
-`bootstrap` validates that the key can access exactly the requested identity, scopes down an admin key before saving it, preserves existing Voice AI settings, and starts or restarts the detached gateway. Signing-key replacement is opt-in because it transfers verified webhook delivery away from any gateway using the previous key. The command prints a secret-redacted JSON result and is safe to resume.
+Keep the API key out of command-line arguments, source control, project instructions, and other persistent text. Supply it through a private channel, expose it only to the bootstrap process, and unset the transient environment variable afterward. Bootstrap stores the resulting agent-scoped configuration in the bridge's private local configuration.
+
+`bootstrap` validates that the key can access the requested existing identity, scopes down an admin key before saving it, preserves existing Voice AI settings, and starts or restarts the detached gateway. Signing-key replacement is explicit because it transfers verified webhook delivery away from any gateway using the previous key. The command prints a secret-redacted JSON result and is safe to resume.
+
+- `configured`: continue to verification.
+- `requires_human`: show the human every entry in `human_actions`, wait for them to complete the requested action, then rerun the exact same bootstrap command. Keep using the assigned handle; do not create another identity.
+- `error`: use the JSON `error` and `inkbox-claude doctor` output to diagnose the failed prerequisite or configuration, correct it, then rerun the exact same bootstrap command. Partial progress is preserved across retries.
 
 Check it any time:
 


### PR DESCRIPTION
## Executive Summary

Documents a safe, complete self-setup flow for agents connecting an assigned Inkbox identity to Claude Code.

- Inspects and executes the same downloaded installer artifact with interactive setup disabled.
- Preserves the assigned identity and private credential handling across resumable bootstrap attempts.
- Explains human-action handoff, error recovery, and doctor verification.

## Description

Expands the README's unattended bootstrap guidance into an agent-executable sequence. The installation example downloads the repository installer once, displays that exact artifact, executes it with `--no-setup`, and removes the temporary file on success or failure.

The guide supplies the complete host-specific bootstrap command with shell-safe placeholders, documents each JSON result state, and explains how to resume the same command after a requested human action or corrected error before verifying setup with `inkbox-claude doctor`.

## Reason

Agents given an existing identity and credential need standalone guidance to install and configure the integration safely without switching identities or exposing reusable secrets.

## Decisions

- **Installer inspection:** Display and execute one downloaded artifact so the reviewed script is the script that runs.
- **Recovery behavior:** Resume the identical bootstrap command after human action or error correction so partial progress and the assigned identity are preserved.
- **Credential handling:** Keep the credential out of command arguments, source control, project instructions, and persistent text.

## Testing

- README self-setup behavior: the documented flow should inspect and execute the same installer artifact, preserve the assigned identity through resumable bootstrap, and finish with `inkbox-claude doctor` reporting the configured integration.
- `python3 -m pytest -q tests/test_bootstrap.py tests/test_doctor.py`: 5 passed.
- `bash -n install.sh` and `bash install.sh --help`: passed; the installer exposes `--no-setup`.
- `python3 -m inkbox_claude.cli bootstrap --help` and `python3 -m inkbox_claude.cli doctor --help`: passed; the documented commands and bootstrap flags are registered.
- All README `bash` blocks parsed successfully with `bash -n`.
- `git diff --check`: passed before and after rebasing onto `origin/main`.
