### PR TITLE
ci: pin realtime voice to gpt-realtime-2

### DIFF
--- a/.github/workflows/live-voice.yml
+++ b/.github/workflows/live-voice.yml
@@ -79,10 +79,10 @@ jobs:
 
       - name: Configure speech mode (${{ matrix.scenario }})
         run: |
+          echo "INKBOX_REALTIME_MODEL=gpt-realtime-2" >> "$GITHUB_ENV"
           if [ "${{ matrix.scenario }}" = "outbound_realtime" ]; then
             echo "INKBOX_VOICE_STACK=openai_realtime" >> "$GITHUB_ENV"
             echo "INKBOX_REALTIME_ENABLED=true" >> "$GITHUB_ENV"
-            echo "INKBOX_REALTIME_MODEL=gpt-realtime-2" >> "$GITHUB_ENV"
             echo "INKBOX_REALTIME_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> "$GITHUB_ENV"
           elif [ "${{ matrix.scenario }}" = "outbound_hosted" ]; then
             RUN_TOKEN="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"


### PR DESCRIPTION
## Executive Summary

This PR pins realtime voice CI to `gpt-realtime-2` for every voice scenario.

- Keeps the native host model for text turns.
- Makes the voice-model invariant explicit before scenario selection.

## Description

The voice workflow now exports `INKBOX_REALTIME_MODEL=gpt-realtime-2` for the entire scenario matrix instead of only the realtime branch. Hosted and transcript-based scenarios continue using their existing speech stacks.

## Reason

The scheduled voice suite should carry one explicit realtime model pin without changing the host-native text execution that this integration is meant to validate.

## Decisions

- **Text model scope:** Kept text turns on the native host because substituting a different host protocol would stop validating this integration.

## Testing

- Workflow configuration: Parsed every workflow YAML file successfully.
- Voice model configuration: Verified the live voice workflow contains the `gpt-realtime-2` pin.
- Patch hygiene: `git diff --check` passed.