### PR TITLE
Catch tool names bordered by . : - in the A2A progress leak-guard

### DIFF
--- a/inkbox_claude/a2a_progress.py
+++ b/inkbox_claude/a2a_progress.py
@@ -107,7 +107,7 @@ def _clean_update(value: Any, tool_names: list[str]) -> str:
         return _fallback_update()
     normalized_text = _normalize_identifier_text(text)
     if any(
-        re.search(rf"(?:^|_){re.escape(tool_name)}(?:_|$)", normalized_text)
+        re.search(rf"(?<![a-z0-9]){re.escape(tool_name)}(?![a-z0-9])", normalized_text)
         for tool_name in tool_names
         if tool_name
     ):

--- a/tests/test_a2a_gateway.py
+++ b/tests/test_a2a_gateway.py
@@ -646,6 +646,22 @@ def test_a2a_progress_summary_rejects_echoed_tool_identifier():
         )
 
 
+def test_a2a_progress_summary_rejects_tool_identifier_across_separators():
+    # The leak guard must suppress an echoed tool name regardless of the
+    # surrounding punctuation, not only underscores. The remote agent controls
+    # the task text (an untrusted prompt-injection surface), and the update is
+    # sent on to that untrusted agent, so a tool name bordered by '-', '.', or
+    # ':' must not slip through to them.
+    for update in (
+        "Running bash-based checks now",
+        "Inspecting the bash.exe helper",
+        "Using bash:mode for this step",
+    ):
+        assert progress_mod._clean_update(update, ["bash"]) == (
+            "I'm continuing the requested work."
+        )
+
+
 def test_a2a_progress_tool_names_are_bounded_and_do_not_retain_inputs():
     progress_mod.start_a2a_progress("task-1")
 


### PR DESCRIPTION
Fixes #66.

`_clean_update` only treated `_` as a word boundary when checking for echoed tool names, but the normaliser keeps `.`, `:` and `-`. So a tool name next to one of those (`"bash-based"`, `"edit.py"`) got past the guard and sent to the untrusted remote agent via `a2a_reply`.

- match echoed tool names across any non-alphanumeric boundary, not just `_`

**Tests:** names bordered by `-`, `.` and `:` now hit the fallback; existing underscore/space cases unchanged.

Before: `"Running bash-based checks now"` leaked `"bash"`. After: suppressed. Full suite green (550).